### PR TITLE
Only publish wiki when docs/ directory changes

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'docs/**'
 
 jobs:
   build:


### PR DESCRIPTION
When setting up the Brimcap wiki in brimdata/brimcap#30, @mattnibs made the helpful suggestion that the Action only be triggered to run when the contents of the `docs/` directory changes. Having made the improvement there, I'm circling back to do the same here.