### PR TITLE
Fix links to zapi description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,7 +133,7 @@ as usual.
 
 * Update zq to [v0.23.0](https://github.com/brimdata/zed/releases/tag/v0.23.0)
 * Update Zeek to [v3.2.1-brim4](https://github.com/brimdata/zeek/releases/tag/v3.2.1-brim4) which provides [Community ID](https://github.com/corelight/community-id-spec) generation and the latest [geolocation](https://github.com/brimdata/brim/wiki/Geolocation) data (#1202)
-* Binaries for [`pcap`](https://github.com/brimdata/zed/blob/main/cmd/pcap/README.md), [`zapi`](https://github.com/brimdata/zed/blob/main/cmd/zapi/README.md), and `zar` are now bundled with Brim (#1098)
+* Binaries for [`pcap`](https://github.com/brimdata/zed/blob/main/cmd/pcap/README.md), [`zapi`](https://github.com/brimdata/zed/blob/main/cmd/zed/README.md#zapi), and `zar` are now bundled with Brim (#1098)
 * Fix an issue where Brim presented a blank white screen when it failed to initialize (#1035)
 * Improve how Brim handles ZJSON responses from `zqd` (#1108)
 * Upgrade to Electron v10.1.4 and WebdriverIO v6.6.7 (#1106, #1159)

--- a/docs/Remote-zqd.md
+++ b/docs/Remote-zqd.md
@@ -71,7 +71,7 @@ a server-style process that manages the storage and querying of imported
 log/packet data.  Operations in `zqd` are invoked via a
 [REST API](https://en.wikipedia.org/wiki/Representational_state_transfer)
 that's utilized by a "client", such as the Brim app. The
-[`zapi`](https://github.com/brimdata/zed/tree/main/cmd/zapi) command is also available
+[`zapi`](https://github.com/brimdata/zed/blob/main/cmd/zed/README.md#zapi) command is also available
 as a command line client that can perform many of the same operations as the
 Brim app, and therefore may be useful in scripting and automation.
 


### PR DESCRIPTION
The changes in brimdata/zed#2563 caused the nightly Markdown link checker to see a breakage in the Brim changelog, so I've addressed that here by pointing to the new anchored section for `zapi` in the updated Zed README. While I was at it, I found a zapi reference in the wiki docs that wasn't broken, but I've updated to the same new link destination since it's now the home of the meaningful zapi content.