### PR TITLE
Remove/change links to Zeek JSON Import doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,7 +256,7 @@ as usual.
 * **NOTE**: Prior state such as Search History will be lost on upgrade to this version
 * Update zq to [v0.13.0](https://github.com/brimdata/zed/releases/tag/v0.13.0) (#750)
 * Start the [Brim wiki](https://github.com/brimdata/brim/wiki) for documentation (#660)
-* Import of Zeek logs in TSV, JSON, and ZNG formats (see the [wiki](https://github.com/brimdata/brim/wiki/Zeek-JSON-Import) for info on JSON). (#594, #720, #727, #625, #581, #643, #672, #716, #700, #717, #719, #735, #721, #729, #713)
+* Import of Zeek logs in TSV, JSON, and ZNG formats (see the [v0.24.0 docs](https://github.com/brimdata/brim/blob/v0.24.0/docs/Zeek-JSON-Import.md) for info on JSON). (#594, #720, #727, #625, #581, #643, #672, #716, #700, #717, #719, #735, #721, #729, #713)
 * Support for Brim on Linux: `.deb` (#631) and `.rpm` (#636) installer packages
 * Fix an issue where holding down arrow keys could freeze Brim (#670, #692)
 * Allow Log Details to be popped out to a separate window by double-clicking an event or via a control at the top of Log Details panel (#651)

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -12,7 +12,6 @@ effective use of the Brim desktop application and related tools.
 
 ## User Documentation
 
-- [[Zeek JSON Import]]
 - [[Zeek Customization]]
 - [[Geolocation]]
 

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -7,7 +7,6 @@
 
 **User Documentation**
 
-- [[Zeek JSON Import]]
 - [[Zeek Customization]]
 - [[Geolocation]]
 


### PR DESCRIPTION
The changes in #1580 removed the "Zeek JSON Import" doc, which is fine since this functionality is gone. However, I realize now that in its absence, the links left behind in the wiki Home/Sidebar are still active but initiate the creation of a new doc, which is not what we'd want.

While I was at it I saw a link to it in the CHANGELOG that I went ahead and updated to point to the doc as it existing in the last  tagged release, just in case archaeologists ever go looking through old histories.