### PR TITLE
Change wrccdc link

### DIFF
--- a/docs/Remote-zqd.md
+++ b/docs/Remote-zqd.md
@@ -206,7 +206,7 @@ However we can use the `zapi` command line tool on our VM to access this `zqd`
 directly via `localhost`.
 
 As sample packet data, we'll import a
-[wrccdc pcap](https://archive.wrccdc.org/pcaps/2018/) from a separate shell on
+[wrccdc pcap](https://wrccdc.org/) from a separate shell on
 our Linux VM:
 
 ```


### PR DESCRIPTION
The site for the pcap archive at [https://archive.wrccdc.org](https://archive.wrccdc.org/) has been unreachable for several days, which sets off failures in the nightly markdown link checker. I've emailed two different wrccdc email addresses to ask if the outage is temporary but neither has responded, so I feel like I should just change to a "live" link for now.