### PR TITLE
Add initial doc regarding Space migration

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -14,6 +14,7 @@ effective use of the Brim desktop application and related tools.
 
 - [[Zeek Customization]]
 - [[Geolocation]]
+- [[Migration of Spaces]]
 
 ## Cookbooks
 

--- a/docs/Migration-of-Spaces.md
+++ b/docs/Migration-of-Spaces.md
@@ -5,17 +5,17 @@ now be stored in "Data Pools" in a "Zed Lake" rather than "Spaces" as they were
 previously.
 
 A [design document](https://github.com/brimdata/zed/blob/main/docs/lake/design.md)
-provides a thorough overview of pools and how they work. In brief, the use of
-pools ultimately enables new functionality that was not previously possible in
+provides a thorough overview of Pools and how they work. In brief, the use of
+Pools ultimately enables new functionality that was not previously possible in
 Brim, including:
 
-* Data may be incrementally added to, or deleted from, a pool.
-* Zed queries/analytics can make use of data stored across multiple pools.
+* Data may be incrementally added to, or deleted from, a Pool.
+* Zed queries/analytics can make use of data stored across multiple Pools.
 * Search indexes can be created to accelerate query performance.
 * Pre-computed derived analytics can be leveraged to accelerate computations on stored data.
 
 When upgrading to GA Brim release `v0.25.0` or newer, any data you had stored
 in Spaces that you wish to continue accessing will need to be migrated to
-pools. The tooling to perform this migration is still under development. This
+Pools. The tooling to perform this migration is still under development. This
 article serves as a resource we'll link to from the migration interface. It
 will be updated further as the release `v0.25.0` is being prepared.

--- a/docs/Migration-of-Spaces.md
+++ b/docs/Migration-of-Spaces.md
@@ -1,0 +1,21 @@
+# Migration of Spaces
+
+Starting with the planned future GA Brim release `v0.25.0`, imported data will
+now be stored in "Data Pools" in a "Zed Lake" rather than "Spaces" as they were
+previously.
+
+A [design document](https://github.com/brimdata/zed/blob/main/docs/lake/design.md)
+provides a thorough overview of pools and how they work. In brief, the use of
+pools ultimately enables new functionality that was not previously possible in
+Brim, including:
+
+* Data may be incrementally added to, or deleted from, a pool.
+* Zed queries/analytics can make use of data stored across multiple pools.
+* Search indexes can be created to accelerate query performance.
+* Pre-computed derived analytics can be leveraged to accelerate computations on stored data.
+
+When upgrading to GA Brim release `v0.25.0` or newer, any data you had stored
+in Spaces that you wish to continue accessing will need to be migrated to
+pools. The tooling to perform this migration is still under development. This
+article serves as a resource we'll link to from the migration interface. It
+will be updated further as the release `v0.25.0` is being prepared.

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -9,6 +9,7 @@
 
 - [[Zeek Customization]]
 - [[Geolocation]]
+- [[Migration of Spaces]]
 
 **Cookbooks**
 


### PR DESCRIPTION
Part of the plan for #1567 includes an article we can link to from our Space migration UX. While we're hopeful the migration tools should be seamless enough that users shouldn't need to read any supplemental materials to use it, some things I hope to accomplish by having an article:

1.  Educate the curious users on Zed Lakes & Data Pools to provide more detail (and links to even more detail) on why we've switched to this approach, how it benefits them, etc.
2.  We can continue change and/or add to the article if we notice user confusion or bugs as users start to upgrade & migrate

There's a bit of a chicken/egg snag where the article needs to exist before we can link to it from the tools, so here I've started a placeholder article with a stab at some minimal content. As the migration tooling comes together, I'll plan to expand it with screenshots and such.

While I took a crack at summarizing some of the goodness of Lakes/Pools, please don't mistaken this for official marketing copy. I fully expect we're going to to have many more words to say on these topics in the web site, blog posts, etc., and as that wording comes together I fully expect the summary can be revised accordingly. That said, if you think I badly misrepresented something or left out something essential, I'm all ears.