### PR TITLE
prepare for brimdata/zed#2632

### DIFF
--- a/scripts/download-zdeps/index.js
+++ b/scripts/download-zdeps/index.js
@@ -14,7 +14,6 @@ const platformDefs = {
   darwin: {
     zqdBin: "zqd",
     zqBin: "zq",
-    pcapBin: "pcap",
     zapiBin: "zapi",
     zedBin: "zed",
     osarch: "darwin-amd64"
@@ -22,7 +21,6 @@ const platformDefs = {
   linux: {
     zqdBin: "zqd",
     zqBin: "zq",
-    pcapBin: "pcap",
     zapiBin: "zapi",
     zedBin: "zed",
     osarch: "linux-amd64"
@@ -30,7 +28,6 @@ const platformDefs = {
   win32: {
     zqdBin: "zqd.exe",
     zqBin: "zq.exe",
-    pcapBin: "pcap.exe",
     zapiBin: "zapi.exe",
     zedBin: "zed.exe",
     osarch: "windows-amd64"
@@ -95,13 +92,7 @@ async function zedArtifactsDownload(version, destPath) {
 
     fs.mkdirpSync(destPath)
 
-    for (let f of [
-      plat.zqdBin,
-      plat.zqBin,
-      plat.pcapBin,
-      plat.zapiBin,
-      plat.zedBin
-    ]) {
+    for (let f of [plat.zqdBin, plat.zqBin, plat.zapiBin, plat.zedBin]) {
       fs.moveSync(
         path.join(tmpdir.name, paths.internalTopDir, f),
         path.join(destPath, f),
@@ -121,13 +112,7 @@ async function zedDevBuild(destPath) {
 
   const zedPackageDir = path.join(__dirname, "..", "..", "node_modules", "zed")
 
-  for (let f of [
-    plat.zqdBin,
-    plat.zqBin,
-    plat.pcapBin,
-    plat.zapiBin,
-    plat.zedBin
-  ]) {
+  for (let f of [plat.zqdBin, plat.zqBin, plat.zapiBin, plat.zedBin]) {
     fs.copyFileSync(path.join(zedPackageDir, "dist", f), path.join(destPath, f))
   }
 }

--- a/src/js/electron/brim-boot.test.ts
+++ b/src/js/electron/brim-boot.test.ts
@@ -10,9 +10,6 @@ test("boot starts zqd with defaults", async () => {
   // @ts-ignore
   const brim = await Brim.boot(file, createSession)
   expect(brim.zqd.root).toBe(path.normalize("/fake/path/data/spaces"))
-  expect(brim.zqd.suricataRunner).toBe("")
-  expect(brim.zqd.suricataUpdater).toBe("")
-  expect(brim.zqd.zeekRunner).toBe("")
 })
 
 test("gets global state from store", async () => {

--- a/src/js/electron/brim-reset-state.test.ts
+++ b/src/js/electron/brim-reset-state.test.ts
@@ -5,7 +5,7 @@ import tron from "./tron"
 import windowManager from "./tron/windowManager"
 
 function mockZqd() {
-  const zqd = new ZQD("test", "srun", "supdate", "zrun")
+  const zqd = new ZQD("test")
   jest.spyOn(zqd, "start").mockImplementation(() => {})
   jest.spyOn(zqd, "close").mockImplementation(() => Promise.resolve())
   return zqd

--- a/src/js/electron/brim-start.test.ts
+++ b/src/js/electron/brim-start.test.ts
@@ -7,7 +7,7 @@ jest.mock("./extensions", () => ({
 }))
 
 function mockZqd() {
-  const zqd = new ZQD("test", "srun", "supdate", "zrun")
+  const zqd = new ZQD("test")
   jest.spyOn(zqd, "start").mockImplementation(() => {})
   return zqd
 }

--- a/src/js/electron/brim.ts
+++ b/src/js/electron/brim.ts
@@ -12,7 +12,6 @@ import {
 } from "../auth0/utils"
 import createGlobalStore from "../state/createGlobalStore"
 import {getGlobalPersistable} from "../state/getPersistable"
-import Prefs from "../state/Prefs"
 import Workspaces from "../state/Workspaces"
 import {installExtensions} from "./extensions"
 import ipc from "./ipc"
@@ -49,12 +48,8 @@ export class Brim {
     const data = await session.load()
     const windows = windowManager(data)
     const store = createGlobalStore(data?.globalState)
-    const select = (fn) => fn(store.getState())
-    const suricataRunner = select(Prefs.getSuricataRunner)
-    const suricataUpdater = select(Prefs.getSuricataUpdater)
-    const zeekRunner = select(Prefs.getZeekRunner)
     const spaceDir = path.join(app.getPath("userData"), "data", "spaces")
-    const zqd = new ZQD(spaceDir, suricataRunner, suricataUpdater, zeekRunner)
+    const zqd = new ZQD(spaceDir)
     return new Brim({session, windows, store, zqd})
   }
 
@@ -62,7 +57,7 @@ export class Brim {
     this.windows = args.windows || windowManager()
     this.store = args.store || createGlobalStore(undefined)
     this.session = args.session || tron.session()
-    this.zqd = args.zqd || new ZQD(null, null, null, null)
+    this.zqd = args.zqd || new ZQD(null)
   }
 
   async start() {

--- a/test/api/helper/test_api.ts
+++ b/test/api/helper/test_api.ts
@@ -7,7 +7,6 @@ import {
 
 const DIR = dirname(fromFileUrl(import.meta.url))
 const ZQD_ROOT = join(DIR, "../zqd_root")
-const ZEEK_RUNNER = join(DIR, "../../../zdeps/zeek/zeekrunner")
 const ZQD_RUNNER = join(DIR, "../../../zdeps/zqd")
 
 function createDataDir() {
@@ -39,7 +38,7 @@ async function kill(zqd: Deno.Process, client: any) {
 
 async function start() {
   return Deno.run({
-    cmd: [ZQD_RUNNER, "listen", "-zeekrunner", ZEEK_RUNNER],
+    cmd: [ZQD_RUNNER, "listen"],
     cwd: ZQD_ROOT,
     stdout: "null",
     stderr: "null"


### PR DESCRIPTION
brimdata/zed#2632 removes the `pcap` command and `zqd listen`'s `-suricatarunner`, `-suricataupdater`, and `-zeekrunner` flags.