### PR TITLE
Advance Brimcap dependency to tag v0.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7920,8 +7920,8 @@
       }
     },
     "brimcap": {
-      "version": "github:brimdata/brimcap#a011e281d3a48e0d6b20ccd2be6b3e250d70c59a",
-      "from": "github:brimdata/brimcap#a011e281d3a48e0d6b20ccd2be6b3e250d70c59a",
+      "version": "github:brimdata/brimcap#ce152ad10a7fcfcb903039ee706d7ce58afd4185",
+      "from": "github:brimdata/brimcap#v0.0.3",
       "dev": true
     },
     "browser-process-hrtime": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "babel-plugin-inline-react-svg": "^1.1.1",
     "babel-plugin-module-resolver": "^4.0.0",
     "babel-plugin-source-map-support": "^2.1.2",
-    "brimcap": "brimdata/brimcap#a011e281d3a48e0d6b20ccd2be6b3e250d70c59a",
+    "brimcap": "brimdata/brimcap#v0.0.3",
     "chalk": "^4.1.0",
     "commander": "^2.20.3",
     "cpx": "^1.5.0",


### PR DESCRIPTION
Brimcap now includes the `brimcap migrate` command for turning legacy Spaces into Pools, so let's use it.