### PR TITLE
Fix brimcap zombies

### DIFF
--- a/plugins/brimcap/brimcap-cli.ts
+++ b/plugins/brimcap/brimcap-cli.ts
@@ -53,7 +53,7 @@ export default class BrimcapCLI {
   public load(pcapPath: string, opts: loadOptions): ChildProcess {
     const subCommandWithArgs = ["load", ...toCliOpts(opts), pcapPath]
 
-    return spawn(this.binPath, subCommandWithArgs)
+    return spawn(this.binPath, subCommandWithArgs, {detached: true})
   }
 
   public search(opts: searchOptions) {

--- a/plugins/brimcap/brimcap-cli.ts
+++ b/plugins/brimcap/brimcap-cli.ts
@@ -53,7 +53,7 @@ export default class BrimcapCLI {
   public load(pcapPath: string, opts: loadOptions): ChildProcess {
     const subCommandWithArgs = ["load", ...toCliOpts(opts), pcapPath]
 
-    return spawn(this.binPath, subCommandWithArgs, {detached: true})
+    return spawn(this.binPath, subCommandWithArgs)
   }
 
   public search(opts: searchOptions) {

--- a/plugins/brimcap/brimcap-plugin.ts
+++ b/plugins/brimcap/brimcap-plugin.ts
@@ -289,6 +289,7 @@ export default class BrimcapPlugin {
       Object.values(this.loadingProcesses).map((lp: ChildProcess) => {
         return new Promise((res) => {
           if (lp.killed) {
+            delete this.loadingProcesses[lp.pid]
             res()
             return
           }

--- a/plugins/brimcap/index.ts
+++ b/plugins/brimcap/index.ts
@@ -8,6 +8,6 @@ export const activate = (api: BrimApi) => {
   brimcap.init()
 }
 
-export const deactivate = () => {
-  brimcap && brimcap.cleanup()
+export const deactivate = async () => {
+  brimcap && (await brimcap.cleanup())
 }

--- a/src/js/detail.tsx
+++ b/src/js/detail.tsx
@@ -14,7 +14,10 @@ import lib from "./lib"
 import theme from "./style-theme"
 
 initDetail()
-  .then((store) => {
+  .then(({store, pluginManager}) => {
+    window.onbeforeunload = () => {
+      pluginManager.deactivate()
+    }
     ReactDOM.render(
       <Router history={global.windowHistory}>
         <AppErrorBoundary>

--- a/src/js/detail.tsx
+++ b/src/js/detail.tsx
@@ -15,8 +15,8 @@ import theme from "./style-theme"
 
 initDetail()
   .then(({store, pluginManager}) => {
-    window.onbeforeunload = () => {
-      pluginManager.deactivate()
+    window.onbeforeunload = async () => {
+      await pluginManager.deactivate()
     }
     ReactDOM.render(
       <Router history={global.windowHistory}>

--- a/src/js/initializers/initDetail.ts
+++ b/src/js/initializers/initDetail.ts
@@ -6,7 +6,7 @@ import brim from "../brim"
 import initialize from "./initialize"
 
 export default async () => {
-  const store = await initialize()
+  const {store, pluginManager} = await initialize()
   // Set the span to everything
   const pool = Current.mustGetPool(store.getState())
   pool && store.dispatch(Search.setSpan(brim.pool(pool).everythingSpan()))
@@ -16,5 +16,5 @@ export default async () => {
   store.dispatch(LogDetails.clear())
   log && store.dispatch(viewLogDetail(log))
 
-  return store
+  return {store, pluginManager}
 }

--- a/src/js/initializers/initIpcListeners.ts
+++ b/src/js/initializers/initIpcListeners.ts
@@ -23,9 +23,9 @@ export default (store: Store, pluginManager: PluginManager) => {
   })
 
   ipcRenderer.on("prepareClose", async (e, replyChannel) => {
-    store.dispatch(TabHistories.save(global.tabHistories.serialize()))
+    await pluginManager.deactivate()
     await dispatch(deletePartialPools())
-    pluginManager.deactivate()
+    store.dispatch(TabHistories.save(global.tabHistories.serialize()))
     ipcRenderer.send(replyChannel)
   })
 

--- a/src/js/initializers/initPlugins.ts
+++ b/src/js/initializers/initPlugins.ts
@@ -1,7 +1,6 @@
 import path from "path"
 import PluginManager from "./pluginManager"
 import BrimApi from "../api"
-import log from "electron-log"
 
 const initPlugins = async (api: BrimApi) => {
   const pluginManager = new PluginManager(api)

--- a/src/js/initializers/initPlugins.ts
+++ b/src/js/initializers/initPlugins.ts
@@ -1,6 +1,7 @@
 import path from "path"
 import PluginManager from "./pluginManager"
 import BrimApi from "../api"
+import log from "electron-log"
 
 const initPlugins = async (api: BrimApi) => {
   const pluginManager = new PluginManager(api)
@@ -9,7 +10,6 @@ const initPlugins = async (api: BrimApi) => {
   await pluginManager.load(path.join(__dirname, "../../../plugins"))
   // load native brim plugins
   // await pluginManager.load("native brim plugins")
-
   pluginManager.activate()
 
   return pluginManager

--- a/src/js/initializers/initialize.ts
+++ b/src/js/initializers/initialize.ts
@@ -19,5 +19,5 @@ export default async function initialize() {
   initIpcListeners(store, pluginManager)
   initMenuActionListeners(store)
   initWorkspaceParams(store)
-  return store
+  return {store, pluginManager}
 }

--- a/src/js/search.tsx
+++ b/src/js/search.tsx
@@ -15,12 +15,13 @@ import deletePartialPools from "./flows/deletePartialPools"
 import TabHistories from "./state/TabHistories"
 
 initialize()
-  .then((store) => {
-    window.onbeforeunload = () => {
+  .then(({store, pluginManager}) => {
+    window.onbeforeunload = async () => {
       // This runs during reload
       // Visit initIpcListeners.ts#prepareClose for closing window
+      await pluginManager.deactivate()
+      await store.dispatch(deletePartialPools())
       store.dispatch(TabHistories.save(global.tabHistories.serialize()))
-      store.dispatch(deletePartialPools())
     }
     ReactDOM.render(
       <AppErrorBoundary>


### PR DESCRIPTION
fixes #1612 

Refreshing the app would close the stdio streams to/from any launched `brimcap` processes which caused the process to terminate, however the app/parent process would loose sight of the spawned process and not always be around to wait for the child exit, causing zombie processes. Now we explicitly kill and await the exit of all spawned processes on reload and quit. 