### PR TITLE
notify on failures

### DIFF
--- a/plugins/brimcap/brimcap-plugin.ts
+++ b/plugins/brimcap/brimcap-plugin.ts
@@ -202,7 +202,9 @@ export default class BrimcapPlugin {
       searchOpts = this.logToSearchOpts(log)
     } catch (e) {
       console.error(e)
-      this.api.toast.error("Missing 5-tuple from log")
+      this.api.toast.error(
+        "Flow's 5-tuple and/or time span was not found in the connection record"
+      )
       return
     }
 
@@ -221,11 +223,11 @@ export default class BrimcapPlugin {
     this.api.toast.promise(
       searchAndOpen(),
       {
-        loading: "Preparing PCAP...",
-        success: "Preparation Complete",
+        loading: "Preparing pcap...",
+        success: "Preparation complete",
         error: (err) => {
           console.error(err)
-          return "Error Preparing PCAP: " + err.message
+          return "Error preparing pcap: " + err.message
         }
       },
       this.toastConfig

--- a/plugins/brimcap/brimcap-plugin.ts
+++ b/plugins/brimcap/brimcap-plugin.ts
@@ -186,7 +186,7 @@ export default class BrimcapPlugin {
     return {
       dstIp: log.get("id.resp_h").toString(),
       dstPort: log.get("id.resp_p").toString(),
-      duration: dur.isSet() ? dur.toString() : "0s",
+      duration: dur?.isSet() ? dur.toString() : "0s",
       proto: log.get("proto").toString(),
       root: this.brimcapDataRoot,
       srcIp: log.get("id.orig_h").toString(),


### PR DESCRIPTION
fixes #1616 

Provides more information to users for two error cases:

**Attempting to launch wireshark on an any `conn` record that has no 5-tuple information**
<img width="1250" alt="image" src="https://user-images.githubusercontent.com/14865533/117349630-74868b00-ae60-11eb-8e4e-014fe9f10ee7.png">


**Attempting to launch wireshark when no pcaps are found in the search**
<img width="1251" alt="image" src="https://user-images.githubusercontent.com/14865533/117349669-849e6a80-ae60-11eb-9487-acae725d0038.png">



Signed-off-by: Mason Fish <mason@looky.cloud>