### PR TITLE
Don't expect a ts

### DIFF
--- a/ppl/detail/models/BrimEvent.ts
+++ b/ppl/detail/models/BrimEvent.ts
@@ -12,9 +12,9 @@ export interface BrimEventInterface {
 
 export class BrimEvent {
   static build(r: zed.Record) {
-    if (r.has("_path")) {
+    if (r.has("_path") && r.has("ts")) {
       return new ZeekEvent(r)
-    } else if (r.has("event_type")) {
+    } else if (r.has("event_type") && r.has("ts")) {
       return new SuricataEvent(r)
     } else {
       return new UnknownEvent(r)


### PR DESCRIPTION
Closes #1577

The original issue seems to have been solved with the zjson PR. However, I discovered that the detail pane did not render because some code expected a ts field to always be present.