### PR TITLE
Show warning when old brim exists on the system

### DIFF
--- a/src/js/electron/main.ts
+++ b/src/js/electron/main.ts
@@ -17,11 +17,16 @@ import menu from "./menu"
 import {handleQuit} from "./quitter"
 
 import {handleSquirrelEvent} from "./squirrel"
+import {windowsPre25Exists} from "./windows-pre-25"
 
 console.time("init")
 
 async function main() {
   if (handleSquirrelEvent(app)) return
+  if (windowsPre25Exists()) {
+    app.quit()
+    return
+  }
   userTasks(app)
   const brim = await Brim.boot()
   menu.setMenu(brim)

--- a/src/js/electron/windows-pre-25.ts
+++ b/src/js/electron/windows-pre-25.ts
@@ -1,0 +1,20 @@
+import {app, dialog} from "electron"
+import {join} from "path"
+import fs from "fs-extra"
+
+function oldVersionPath() {
+  return join(app.getPath("appData"), "Local", "Brim")
+}
+
+export function windowsPre25Exists() {
+  const dir = oldVersionPath()
+
+  if (fs.existsSync(dir)) {
+    dialog.showErrorBox(
+      "Previous Brim Version Detected",
+      `Please uninstall it before before launching the new version.\n\n${dir}`
+    )
+    return true
+  }
+  return false
+}

--- a/src/js/electron/windows-pre-25.ts
+++ b/src/js/electron/windows-pre-25.ts
@@ -18,6 +18,16 @@ function getExe() {
   return join(getDir(), "Brim.exe")
 }
 
+/**
+ * Is there a duplicate, older version of Brim on the windows system?
+ * In version 25, we switched our installer. Previous versions placed
+ * the Brim.exe file in /%LocalAppData%/Brim/Brim.exe. It now places
+ * it in /%LocalAppData%/Programs/Brim/Brim.exe.
+ *
+ * If the old version exists, we inform the user to uninstall it first,
+ * then launch the new one.
+ * @returns boolean
+ */
 export function windowsPre25Exists() {
   if (os.platform() !== "win32") return false
 

--- a/src/js/electron/windows-pre-25.ts
+++ b/src/js/electron/windows-pre-25.ts
@@ -1,11 +1,11 @@
 import {app, dialog} from "electron"
-import {join} from "path"
 import fs from "fs-extra"
 import os from "os"
+import {join} from "path"
 
 const VAR = "LocalAppData"
 
-function oldVersionPath() {
+function getDir() {
   if (VAR in process.env) {
     const dir = process.env[VAR]
     return join(dir, "Brim")
@@ -14,11 +14,16 @@ function oldVersionPath() {
   }
 }
 
+function getExe() {
+  return join(getDir(), "Brim.exe")
+}
+
 export function windowsPre25Exists() {
   if (os.platform() !== "win32") return false
 
-  const dir = oldVersionPath()
-  if (!fs.existsSync(dir)) return false
+  const dir = getDir()
+  const exe = getExe()
+  if (!fs.existsSync(exe)) return false
 
   dialog.showErrorBox(
     "Previous Brim Version Detected",

--- a/src/js/electron/windows-pre-25.ts
+++ b/src/js/electron/windows-pre-25.ts
@@ -1,20 +1,28 @@
 import {app, dialog} from "electron"
 import {join} from "path"
 import fs from "fs-extra"
+import os from "os"
+
+const VAR = "LocalAppData"
 
 function oldVersionPath() {
-  return join(app.getPath("appData"), "Local", "Brim")
+  if (VAR in process.env) {
+    const dir = process.env[VAR]
+    return join(dir, "Brim")
+  } else {
+    return join(app.getPath("home"), "AppData", "Local", "Brim")
+  }
 }
 
 export function windowsPre25Exists() {
-  const dir = oldVersionPath()
+  if (os.platform() !== "win32") return false
 
-  if (fs.existsSync(dir)) {
-    dialog.showErrorBox(
-      "Previous Brim Version Detected",
-      `Please uninstall it before before launching the new version.\n\n${dir}`
-    )
-    return true
-  }
-  return false
+  const dir = oldVersionPath()
+  if (!fs.existsSync(dir)) return false
+
+  dialog.showErrorBox(
+    "Previous Brim Version Detected",
+    `Please uninstall it before before launching the new version.\n\n${dir}`
+  )
+  return true
 }


### PR DESCRIPTION
closes #1566

Here is the warning on Mac.

<img src="https://user-images.githubusercontent.com/3460638/117737189-29e17780-b1ae-11eb-951d-47300c06db0f.png" width="300"/>

To determine if the old brim is on the system, it asks the electron app for the "appData" path, which according to the docs:

```
appData 
Per-user application data directory, which by default points to:

%APPDATA% on Windows
$XDG_CONFIG_HOME or ~/.config on Linux
~/Library/Application Support on macOS
```

From there, it looks in `\Local\Brim`. This is where I saw brim on my windows 10 VM after installing it fresh from our website at version 0.24.

The next brim release was put at `\Local\Programs\Brim`. 

After the user clicks ok, the new app will immediately quit.