### PR TITLE
Advance Brimcap to 82f0140

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7920,8 +7920,8 @@
       }
     },
     "brimcap": {
-      "version": "github:brimdata/brimcap#ce152ad10a7fcfcb903039ee706d7ce58afd4185",
-      "from": "github:brimdata/brimcap#v0.0.3",
+      "version": "github:brimdata/brimcap#82f0140a7c623846f07a9003af3090b9f0452694",
+      "from": "github:brimdata/brimcap#82f0140a7c623846f07a9003af3090b9f0452694",
       "dev": true
     },
     "browser-process-hrtime": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "babel-plugin-inline-react-svg": "^1.1.1",
     "babel-plugin-module-resolver": "^4.0.0",
     "babel-plugin-source-map-support": "^2.1.2",
-    "brimcap": "brimdata/brimcap#v0.0.3",
+    "brimcap": "brimdata/brimcap#82f0140a7c623846f07a9003af3090b9f0452694",
     "chalk": "^4.1.0",
     "commander": "^2.20.3",
     "cpx": "^1.5.0",


### PR DESCRIPTION
I'm looking to do some end-to-end testing of Space migration on all the platforms and hence am looking to have Brim pointing at the latest Brimcap before I make some scratch builds.