### PR TITLE
Pool name bug

### DIFF
--- a/src/js/lib/MouseoverWatch.ts
+++ b/src/js/lib/MouseoverWatch.ts
@@ -28,6 +28,7 @@ export default class MouseoverWatch {
     document.removeEventListener("mousemove", this.listener)
     const bod = document.body
     bod && bod.removeEventListener("mouseleave", this.startExit)
+    clearTimeout(this.tid)
     return this
   }
 

--- a/src/js/state/migrations/202104291255_dropSpaces.test.ts
+++ b/src/js/state/migrations/202104291255_dropSpaces.test.ts
@@ -1,11 +1,16 @@
+import {getAllTabs} from "src/js/test/helpers/getTestState"
 import {migrate} from "src/js/test/helpers/migrate"
 
 test("migrating 202104291255_dropSpaces", async () => {
   const next = await migrate({state: "v0.24.0", to: "202104291255"})
-  expect.assertions(1)
+  expect.assertions(3)
 
   // @ts-ignore
   for (const {state} of Object.values(next.windows)) {
     expect(state.spaces).toBe(undefined)
+  }
+
+  for (let tab of getAllTabs(next)) {
+    expect(tab.layout.sidebarSections[0].id).toBe("pools")
   }
 })

--- a/src/js/state/migrations/202104291255_dropSpaces.ts
+++ b/src/js/state/migrations/202104291255_dropSpaces.ts
@@ -1,9 +1,14 @@
-import {getAllStates} from "../../test/helpers/getTestState"
+import {getAllStates, getAllTabs} from "../../test/helpers/getTestState"
 
 export default function dropSpaces(state: any) {
   // Default search records to "events"
   for (const s of getAllStates(state)) {
     delete s.spaces
+  }
+  for (const tab of getAllTabs(state)) {
+    tab.layout.sidebarSections.forEach((section) => {
+      if (section.id === "spaces") section.id = "pools"
+    })
   }
   return state
 }


### PR DESCRIPTION
Fixes #1638

The id of the sidebar section changed from "spaces" to "pools". But the persisted data from version 24 still has the id set to "spaces". This caused the sidebar to not render that section in version 25.

I've added to the migration that Matt wrote to include changing the section ids.

I wonder if there is a better way to save layout data like this. Seems odd to write migrations each time something small changes. I don't have an answer yet, but I will be thinking about it.

The screenshot below shows that the pools section is now visible.

<img width="938" alt="Screen Shot 2021-05-14 at 8 26 51 AM" src="https://user-images.githubusercontent.com/3460638/118293712-ca75b700-b48e-11eb-80d6-eb0b115c2623.png">

### Side fix

I fixed a bug in the RightPaneExpander component that would always display an error in the console. Those who look in the devtools will be familiar with it. It was the result of not clearing a timeout when the component unmounted.

<img width="561" alt="Screen Shot 2021-05-13 at 3 29 15 PM" src="https://user-images.githubusercontent.com/3460638/118294042-2b9d8a80-b48f-11eb-9602-5c8c30d3945d.png">
