### PR TITLE
Fix Notification Context Menu

### DIFF
--- a/app/legacy/space-migration/space-migration.tsx
+++ b/app/legacy/space-migration/space-migration.tsx
@@ -66,8 +66,8 @@ function Modal({onClose}) {
           }
         ],
         {
-          x: x - 50, // this will need to change as we add more items
-          y: y - 35 // this too
+          x: Math.round(x - 50), // this will need to change as we add more items
+          y: Math.round(y - 35) // this too
         }
       )
     }

--- a/src/js/lib/System.ts
+++ b/src/js/lib/System.ts
@@ -1,10 +1,10 @@
-import {MenuItemConstructorOptions, remote} from "electron"
+import {MenuItemConstructorOptions, remote, PopupOptions} from "electron"
 
 const isTest = process.env.BRIM_ITEST === "true"
 
 export function showContextMenu(
   template: MenuItemConstructorOptions[],
-  opts = {}
+  opts: PopupOptions = {}
 ) {
   if (isTest) {
     document.dispatchEvent(


### PR DESCRIPTION
Fixes #1639 

The electron context menu api failed to open when it got floats in the options instead of ints. The fix is to round the numbers before passing to the showContextMenu() function.