### PR TITLE
Zed Lang Change

### DIFF
--- a/itest/tests/__snapshots__/query.test.ts.snap
+++ b/itest/tests/__snapshots__/query.test.ts.snap
@@ -30,14 +30,14 @@ Array [
 ]
 `;
 
-exports[`Query tests query002: "_path=conn | count()" 1`] = `
+exports[`Query tests query002: "_path=="conn" | count()" 1`] = `
 Array [
   "count",
   "19",
 ]
 `;
 
-exports[`Query tests query003: "_path=conn | cut ts, id.orig_h, id.orig_p, id.resp_h, id.resp_p, proto | sort ts" 1`] = `
+exports[`Query tests query003: "_path=="conn" | cut ts, id.orig_h, id.orig_p, id.resp_h, id.resp_p, proto | sort ts" 1`] = `
 Array [
   "ts",
   "id.orig_h",
@@ -233,7 +233,7 @@ Array [
 ]
 `;
 
-exports[`Query tests query006: "_path=x509 or _path=ssl | sort _path" 1`] = `
+exports[`Query tests query006: "_path=="x509" or _path=="ssl" | sort _path" 1`] = `
 Array [
   "2020-02-25T16:03:14.021",
   "ssl",

--- a/itest/tests/contextMenu.test.ts
+++ b/itest/tests/contextMenu.test.ts
@@ -23,7 +23,7 @@ describe("context menu tests", () => {
     function scalarString(value: string): () => Promise<void> {
       const path = "string"
       const fieldName = "scalar"
-      const query = `_path=${path} ${fieldName}!=null | cut id, ${fieldName} | sort id`
+      const query = `_path=="${path}" ${fieldName}!=null | cut id, ${fieldName} | sort id`
       const cell = cellContaining(value)
       return () => runTest(query, cell, "Filter = value")
     }
@@ -49,7 +49,7 @@ describe("context menu tests", () => {
     function scalarAddr(value) {
       const path = "addr"
       const fieldName = "scalar"
-      const query = `_path=${path} ${fieldName}!=null | cut id, ${fieldName} | sort id`
+      const query = `_path=="${path}" ${fieldName}!=null | cut id, ${fieldName} | sort id`
       const cell = cellContaining(value)
       return () => runTest(query, cell, "Filter = value")
     }
@@ -61,7 +61,7 @@ describe("context menu tests", () => {
   describe("rightclick scalar unset", () => {
     const UNSET = "⦻"
     function scalarUnset(value) {
-      const query = `_path=string | cut id, scalar | sort -r id | head 10`
+      const query = `_path=="string" | cut id, scalar | sort -r id | head 10`
       const cell = cellContaining(value)
       return () => runTest(query, cell, "Filter = value")
     }

--- a/itest/tests/ingest.test.ts
+++ b/itest/tests/ingest.test.ts
@@ -19,7 +19,7 @@ describe("Ingest tests", () => {
   })
 
   const searchZql =
-    "_path=conn proto=tcp | cut ts, id.orig_h, id.orig_p, id.resp_h, id.resp_p, proto | sort ts"
+    '_path=="conn" proto=="tcp" | cut ts, id.orig_h, id.orig_p, id.resp_h, id.resp_p, proto | sort ts'
   const sampleFiles = [
     "sample.pcap",
     "sample.pcapng",

--- a/itest/tests/lake.test.ts
+++ b/itest/tests/lake.test.ts
@@ -1,66 +1,67 @@
 // This is needed to use zealot outside a browser.
-global.fetch = require("node-fetch")
+// global.fetch = require("node-fetch")
 
-import {execSync} from "child_process"
-import path from "path"
+// import {execSync} from "child_process"
+// import path from "path"
 
-import {createZealot} from "zealot"
+// import {createZealot} from "zealot"
 
-import {testDataDir} from "../lib/env"
-import {retryUntil} from "../lib/control"
-import {nodeZedDistDir} from "../lib/env"
-import {handleError} from "../lib/jest"
-import appStep from "../lib/appStep/api"
-import newAppInstance from "../lib/newAppInstance"
+// import {testDataDir} from "../lib/env"
+// import {retryUntil} from "../lib/control"
+// import {nodeZedDistDir} from "../lib/env"
+// import {handleError} from "../lib/jest"
+// import appStep from "../lib/appStep/api"
+// import newAppInstance from "../lib/newAppInstance"
 
 describe("Lake tests", () => {
-  let app
-  let testIdx = 0
-  const ZED = path.join(nodeZedDistDir(), "zed")
-  const LAKE_POOL_NAME = "sample.zar"
-  beforeAll(() => {
-    app = newAppInstance(path.basename(__filename), ++testIdx)
-    return appStep.startApp(app)
-  })
+  test("skipping lake tests", () => {})
+  // let app
+  // let testIdx = 0
+  // const ZED = path.join(nodeZedDistDir(), "zed")
+  // const LAKE_POOL_NAME = "sample.zar"
+  // beforeAll(() => {
+  //   app = newAppInstance(path.basename(__filename), ++testIdx)
+  //   return appStep.startApp(app)
+  // })
 
-  afterAll(async () => {
-    if (app && app.isRunning()) {
-      await app.stop()
-    }
-  })
+  // afterAll(async () => {
+  //   if (app && app.isRunning()) {
+  //     await app.stop()
+  //   }
+  // })
 
-  // XXX (nibs) - skip until https://github.com/brimdata/zed/issues/2547
-  test.skip(`Brim starts when a lake pool is present`, (done) => {
-    appStep
-      .ingestFile(app, "sample.tsv")
-      .then(async () => {
-        // Use zealot to
-        // 1. Create a new pool
-        // 2. Find the path to sample.tsv.brim's all.zng
-        const client = createZealot("localhost:9867")
-        const userDataDir = await app.electron.remote.app.getPath("userData")
-        const lakeRoot = path.join(userDataDir, "data", "lake")
-        const tsvFile = path.normalize(path.join(testDataDir(), "sample.tsv"))
+  // // XXX (nibs) - skip until https://github.com/brimdata/zed/issues/2547
+  // test.skip(`Brim starts when a lake pool is present`, (done) => {
+  //   appStep
+  //     .ingestFile(app, "sample.tsv")
+  //     .then(async () => {
+  //       // Use zealot to
+  //       // 1. Create a new pool
+  //       // 2. Find the path to sample.tsv.brim's all.zng
+  //       const client = createZealot("localhost:9867")
+  //       const userDataDir = await app.electron.remote.app.getPath("userData")
+  //       const lakeRoot = path.join(userDataDir, "data", "lake")
+  //       const tsvFile = path.normalize(path.join(testDataDir(), "sample.tsv"))
 
-        // Create a pool inside the lake.
-        const options = {env: {...process.env, ZED_LAKE_ROOT: lakeRoot}}
-        execSync(`"${ZED}" lake create -p default -S 1024B`, options)
-        execSync(`"${ZED}" lake load -p default "${tsvFile}"`, options)
+  //       // Create a pool inside the lake.
+  //       const options = {env: {...process.env, ZED_LAKE_ROOT: lakeRoot}}
+  //       execSync(`"${ZED}" lake create -p default -S 1024B`, options)
+  //       execSync(`"${ZED}" lake load -p default "${tsvFile}"`, options)
 
-        // Make sure zed lake identifies both pools.
-        retryUntil(
-          () => client.pools.list(),
-          (pools) => pools.length === 2
-        )
+  //       // Make sure zed lake identifies both pools.
+  //       retryUntil(
+  //         () => client.pools.list(),
+  //         (pools) => pools.length === 2
+  //       )
 
-        // Reload the app so that it reads the new pool.
-        await appStep.reload(app)
-        await appStep.click(app, ".add-tab")
-        await (await app.client.$(`=${LAKE_POOL_NAME}`)).waitForDisplayed()
-        done()
-      })
-      .catch((err) => {
-        handleError(app, err, done)
-      })
-  })
+  //       // Reload the app so that it reads the new pool.
+  //       await appStep.reload(app)
+  //       await appStep.click(app, ".add-tab")
+  //       await (await app.client.$(`=${LAKE_POOL_NAME}`)).waitForDisplayed()
+  //       done()
+  //     })
+  //     .catch((err) => {
+  //       handleError(app, err, done)
+  //     })
+  // })
 })

--- a/itest/tests/pcaps.test.ts
+++ b/itest/tests/pcaps.test.ts
@@ -42,7 +42,7 @@ describe("Test PCAPs", () => {
   test("pcap button downloads deterministically-formed pcap file", (done) => {
     runSearch(
       app,
-      "_path=ssl id.orig_h=192.168.1.110 id.resp_h=209.216.230.240 id.resp_p=443"
+      '_path=="ssl" id.orig_h==192.168.1.110 id.resp_h==209.216.230.240 id.resp_p==443'
     )
       .then(async () => {
         await appStep.click(app, selectors.viewer.resultCellContaining("ssl"))
@@ -60,7 +60,7 @@ describe("Test PCAPs", () => {
   })
 
   test("pcap download works for null duration", (done) => {
-    runSearch(app, "duration=null id.orig_p=47783")
+    runSearch(app, "duration==null id.orig_p==47783")
       .then(async () => {
         await appStep.click(app, selectors.viewer.resultCellContaining("conn"))
         await appStep.savePcap(app)

--- a/itest/tests/query.test.ts
+++ b/itest/tests/query.test.ts
@@ -9,11 +9,11 @@ import {handleError} from "../lib/jest"
 const simpleQueries = [
   "* | count()",
   "* | count() by _path | sort _path",
-  "_path=conn | count()",
-  "_path=conn | cut ts, id.orig_h, id.orig_p, id.resp_h, id.resp_p, proto | sort ts",
+  '_path=="conn" | count()',
+  '_path=="conn" | cut ts, id.orig_h, id.orig_p, id.resp_h, id.resp_p, proto | sort ts',
   "* | every 2s count() | sort ts",
   "* | every 2s count() by _path | sort ts, _path",
-  "_path=x509 or _path=ssl | sort _path"
+  '_path=="x509" or _path=="ssl" | sort _path'
 ]
 
 describe("Query tests", () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25429,8 +25429,8 @@
       }
     },
     "zed": {
-      "version": "git+https://github.com/brimdata/zed.git#e51dadd66dcfd71364152e99abe9d6cd6e461265",
-      "from": "git+https://github.com/brimdata/zed.git#e51dadd66dcfd71364152e99abe9d6cd6e461265"
+      "version": "git+https://github.com/brimdata/zed.git#63520bd0479d9c712909afefdfd63e337584f619",
+      "from": "git+https://github.com/brimdata/zed.git#63520bd0479d9c712909afefdfd63e337584f619"
     },
     "zip-stream": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "styled-components": "^5.1.1",
     "tree-model": "^1.0.7",
     "valid-url": "^1.0.9",
-    "zed": "git+https://github.com/brimdata/zed.git#e51dadd66dcfd71364152e99abe9d6cd6e461265"
+    "zed": "git+https://github.com/brimdata/zed.git#63520bd0479d9c712909afefdfd63e337584f619"
   },
   "optionalDependencies": {
     "electron-installer-debian": "^3.0.0",

--- a/plugins/brimcap/brimcap-plugin.ts
+++ b/plugins/brimcap/brimcap-plugin.ts
@@ -279,7 +279,7 @@ export default class BrimcapPlugin {
       })
 
       // wait for process to end
-      await new Promise((res, rej) => {
+      await new Promise<void>((res, rej) => {
         p.on("close", (code) => {
           delete this.loadingProcesses[p.pid]
           if (code === 0) res()
@@ -303,7 +303,7 @@ export default class BrimcapPlugin {
   public async cleanup() {
     await Promise.all(
       Object.values(this.loadingProcesses).map((lp: ChildProcess) => {
-        return new Promise((res) => {
+        return new Promise<void>((res) => {
           if (lp.killed) {
             delete this.loadingProcesses[lp.pid]
             res()

--- a/ppl/detail/flows/fetch.test.ts
+++ b/ppl/detail/flows/fetch.test.ts
@@ -16,14 +16,6 @@ const suricata = createRecord({
   community_id: "1:N7YGmWjwTmMKNhsZHBR618n3ReA="
 })
 
-const uidOrCommunityIdZql =
-  'uid="CbOjYpkXn9LfqV51c" or "CbOjYpkXn9LfqV51c" in conn_uids or "CbOjYpkXn9LfqV51c" in uids or referenced_file.uid="CbOjYpkXn9LfqV51c" or (community_id = "1:N7YGmWjwTmMKNhsZHBR618n3ReA=" and ts >= 1582646593.978 and ts < 1582646683.994) | head 100'
-
-const uidZql =
-  'uid="CbOjYpkXn9LfqV51c" or "CbOjYpkXn9LfqV51c" in conn_uids or "CbOjYpkXn9LfqV51c" in uids or referenced_file.uid="CbOjYpkXn9LfqV51c" | head 100'
-
-const cidZql = 'community_id="1:N7YGmWjwTmMKNhsZHBR618n3ReA=" | head 100'
-
 const stubs = {
   uidResult: useResponse("correlationUid"),
   uidAndCommunityResult: useResponse("correlationUidCommunityId"),
@@ -51,8 +43,12 @@ describe("zeek log when community_id is found", () => {
     await store.dispatch(fetchCorrelation(zeek))
     const searches = zealot.calls("search")
     const len = searches.length
-    expect(searches[len - 2].args).toBe(uidZql)
-    expect(searches[len - 1].args).toBe(uidOrCommunityIdZql)
+    expect(searches[len - 2].args).toMatchInlineSnapshot(
+      `"uid==\\"CbOjYpkXn9LfqV51c\\" or \\"CbOjYpkXn9LfqV51c\\" in conn_uids or \\"CbOjYpkXn9LfqV51c\\" in uids or referenced_file.uid==\\"CbOjYpkXn9LfqV51c\\" | head 100"`
+    )
+    expect(searches[len - 1].args).toMatchInlineSnapshot(
+      `"uid==\\"CbOjYpkXn9LfqV51c\\" or \\"CbOjYpkXn9LfqV51c\\" in conn_uids or \\"CbOjYpkXn9LfqV51c\\" in uids or referenced_file.uid==\\"CbOjYpkXn9LfqV51c\\" or (community_id == \\"1:N7YGmWjwTmMKNhsZHBR618n3ReA=\\" and ts >= 1582646593.978 and ts < 1582646683.994) | head 100"`
+    )
   })
 
   test("returns the records", async () => {
@@ -79,7 +75,9 @@ describe("zeek log when community_id is not found", () => {
   test("runs the uid search", async () => {
     const {zealot, store} = setup
     await store.dispatch(fetchCorrelation(zeek))
-    expect(last<any>(zealot.calls("search")).args).toBe(uidZql)
+    expect(last<any>(zealot.calls("search")).args).toMatchInlineSnapshot(
+      `"uid==\\"CbOjYpkXn9LfqV51c\\" or \\"CbOjYpkXn9LfqV51c\\" in conn_uids or \\"CbOjYpkXn9LfqV51c\\" in uids or referenced_file.uid==\\"CbOjYpkXn9LfqV51c\\" | head 100"`
+    )
   })
 
   test("returns the records", async () => {
@@ -107,7 +105,9 @@ describe("suricata alert when community_id found", () => {
   test("issues the community id query", async () => {
     const {zealot, store} = setup
     await store.dispatch(fetchCorrelation(suricata))
-    expect(last<any>(zealot.calls("search")).args).toBe(cidZql)
+    expect(last<any>(zealot.calls("search")).args).toMatchInlineSnapshot(
+      `"community_id==\\"1:N7YGmWjwTmMKNhsZHBR618n3ReA=\\" | head 100"`
+    )
   })
 
   test("returns the records", async () => {

--- a/ppl/queries/initial.test.ts
+++ b/ppl/queries/initial.test.ts
@@ -1,0 +1,15 @@
+import {parse} from "zealot"
+import init from "./initial"
+
+test("they all parse", () => {
+  const queries = init()
+  queries.items.forEach((item) => {
+    if (!("value" in item)) return
+
+    try {
+      parse(item.value)
+    } catch (e) {
+      throw new Error(item.value + "\n" + e.toString())
+    }
+  })
+})

--- a/ppl/queries/initial.ts
+++ b/ppl/queries/initial.ts
@@ -15,7 +15,7 @@ const init = (): QueriesState => ({
     {
       id: "2",
       name: "Unique DNS Queries",
-      value: "_path=dns | count() by query | sort -r",
+      value: '_path=="dns" | count() by query | sort -r',
       description:
         "Shows all unique DNS queries contained in the data set with count",
       tags: ["dns", "initial exploration"]
@@ -23,7 +23,7 @@ const init = (): QueriesState => ({
     {
       id: "3",
       name: "Windows Networking Activity",
-      value: "_path=smb* OR _path=dce_rpc",
+      value: '_path matches smb* OR _path=="dce_rpc"',
       description:
         "Filters and displays smb_files, smb_mapping and DCE_RPC activity",
       tags: ["windows", "smb", "malware"]
@@ -32,7 +32,7 @@ const init = (): QueriesState => ({
       id: "4",
       name: "HTTP Requests",
       value:
-        "_path=http | cut id.orig_h, id.resp_h, id.resp_p, method,host, uri | uniq -c",
+        '_path=="http" | cut id.orig_h, id.resp_h, id.resp_p, method,host, uri | uniq -c',
       description:
         "Displays a list of the count unique HTTP requests including source and destination",
       tags: ["http", "initial exploration", "malware"]
@@ -40,7 +40,8 @@ const init = (): QueriesState => ({
     {
       id: "5",
       name: "Unique Network Connections",
-      value: "_path=conn | cut id.orig_h, id.resp_p, id.resp_h | sort | uniq",
+      value:
+        '_path=="conn" | cut id.orig_h, id.resp_p, id.resp_h | sort | uniq',
       description:
         "Displays a table showing all unique source:port:destination connections pairings",
       tags: ["network", "initial exploration"]
@@ -49,7 +50,7 @@ const init = (): QueriesState => ({
       id: "6",
       name: "Connection Received Data",
       value:
-        "_path=conn | put total_bytes = orig_bytes + resp_bytes | sort -r total_bytes | cut uid, id, orig_bytes, resp_bytes, total_bytes",
+        '_path=="conn" | put total_bytes := orig_bytes + resp_bytes | sort -r total_bytes | cut uid, id, orig_bytes, resp_bytes, total_bytes',
       description:
         "Shows the connections between hosts, sorted by data received",
       tags: ["network"]
@@ -66,7 +67,7 @@ const init = (): QueriesState => ({
     {
       id: "8",
       name: "HTTP Post Requests",
-      value: "method=POST | cut ts, uid, id, method, uri, status_code",
+      value: 'method=="POST" | cut ts, uid, id, method, uri, status_code',
       description:
         "Displays all HTTP Post requests including the URI and HTTP status code",
       tags: ["http", "malware"]
@@ -75,7 +76,7 @@ const init = (): QueriesState => ({
       id: "9",
       name: "Show IP Subnets",
       value:
-        "_path=conn | put classnet=network_of(id.resp_h) | cut classnet | count() by classnet | sort -r",
+        '_path=="conn" | put classnet := network_of(id.resp_h) | cut classnet | count() by classnet | sort -r',
       description:
         "Enumerates the associated IP subclasses for all destination IP-addresses including count of connections",
       tags: ["network"]
@@ -84,7 +85,7 @@ const init = (): QueriesState => ({
       id: "10",
       name: "Suricata Alerts by Category",
       value:
-        "event_type=alert | count() by alert.severity,alert.category | sort count",
+        'event_type=="alert" | count() by alert.severity,alert.category | sort count',
       description: "Shows all suricata alert counts by category and severity",
       tags: ["suricata", "malware"]
     },
@@ -92,7 +93,7 @@ const init = (): QueriesState => ({
       id: "11",
       name: "Suricata Alerts by Source and Destination",
       value:
-        "event_type=alert | alerts=union(alert.category) by src_ip, dest_ip",
+        'event_type=="alert" | alerts := union(alert.category) by src_ip, dest_ip',
       description:
         "Shows all suricata alerts in a list by unique source and destination IP addresses",
       tags: ["suricata", "malware"]
@@ -101,7 +102,7 @@ const init = (): QueriesState => ({
       id: "12",
       name: "Suricata Alerts by Subnet",
       value:
-        "event_type=alert | alerts=union(alert.category) by network_of(dest_ip)",
+        'event_type=="alert" | alerts := union(alert.category) by network_of(dest_ip)',
       description: "Displays a list of Suricata Alerts by CIDR IP Subnets",
       tags: ["suricata", "malware"]
     }

--- a/src/js/brim/ast.test.ts
+++ b/src/js/brim/ast.test.ts
@@ -54,17 +54,17 @@ describe("#groupByKeys", () => {
       .groupByKeys()
 
   test("no group by", () => {
-    expect(getGroupByKeys("_path=conn")).toEqual([])
+    expect(getGroupByKeys("_path==conn")).toEqual([])
   })
 
   test("one key", () => {
-    expect(getGroupByKeys("_path=conn | count() by duration")).toEqual([
+    expect(getGroupByKeys("_path==conn | count() by duration")).toEqual([
       "duration"
     ])
   })
 
   test("several keys", () => {
-    expect(getGroupByKeys("_path=conn | count() by duration, uid")).toEqual([
+    expect(getGroupByKeys("_path==conn | count() by duration, uid")).toEqual([
       "duration",
       "uid"
     ])

--- a/src/js/brim/program.test.ts
+++ b/src/js/brim/program.test.ts
@@ -14,11 +14,11 @@ describe("excluding and including", () => {
 
   test("excluding a field", () => {
     const program = brim
-      .program("_path=weird")
+      .program('_path=="weird"')
       .exclude(field)
       .string()
 
-    expect(program).toEqual('_path=weird uid!="123"')
+    expect(program).toEqual('_path=="weird" uid!="123"')
   })
 
   test("excluding a field with a pipe", () => {
@@ -36,20 +36,20 @@ describe("excluding and including", () => {
 
   test("excluding a field with two pipes", () => {
     const program = brim
-      .program("_path=weird | sort | filter 1")
+      .program('_path=="weird" | sort | filter 1')
       .exclude(field)
       .string()
 
-    expect(program).toEqual('_path=weird uid!="123" | sort | filter 1')
+    expect(program).toEqual('_path=="weird" uid!="123" | sort | filter 1')
   })
 
   test("including a field with two pipes", () => {
     const program = brim
-      .program("_path=weird | sort | filter 1")
+      .program('_path=="weird" | sort | filter 1')
       .include(field)
       .string()
 
-    expect(program).toEqual('_path=weird uid="123" | sort | filter 1')
+    expect(program).toEqual('_path=="weird" uid=="123" | sort | filter 1')
   })
 })
 
@@ -67,17 +67,17 @@ describe("drill down", () => {
       .drillDown(result)
       .string()
 
-    expect(program).toBe("id.orig_h=192.168.0.54")
+    expect(program).toBe("id.orig_h==192.168.0.54")
   })
 
   test("combines keys in the group by proc", () => {
     const program = brim
-      .program("_path=dns | count() by id.orig_h, proto, query | sort -r")
+      .program('_path=="dns" | count() by id.orig_h, proto, query | sort -r')
       .drillDown(result)
       .string()
 
     expect(program).toBe(
-      '_path=dns id.orig_h=192.168.0.54 proto="udp" query="WPAD"'
+      '_path=="dns" id.orig_h==192.168.0.54 proto=="udp" query=="WPAD"'
     )
   })
 
@@ -87,7 +87,7 @@ describe("drill down", () => {
       .drillDown(result)
       .string()
 
-    expect(program).toBe("id.orig_h=192.168.0.54")
+    expect(program).toBe("id.orig_h==192.168.0.54")
   })
 
   test("easy peasy", () => {
@@ -96,18 +96,18 @@ describe("drill down", () => {
       .drillDown(result)
       .string()
 
-    expect(program).toBe('names james proto="udp"')
+    expect(program).toBe('names james proto=="udp"')
   })
 
   test("count by and filter the same", () => {
     const result = createRecord({md5: "123", count: 1})
 
     const program = brim
-      .program("md5=123 | count() by md5 | sort -r | head 5")
+      .program('md5=="123" | count() by md5 | sort -r | head 5')
       .drillDown(result)
       .string()
 
-    expect(program).toEqual('md5=123 md5="123"')
+    expect(program).toEqual('md5=="123"')
   })
 
   test("filter query", () => {
@@ -118,13 +118,13 @@ describe("drill down", () => {
 
     const program = brim
       .program(
-        '_path=files filename!="-" | count() by md5,filename | count() by md5 | sort -r | filter count > 1'
+        '_path=="files" filename!="-" | count() by md5,filename | count() by md5 | sort -r | filter count > 1'
       )
       .drillDown(result)
       .string()
 
     expect(program).toEqual(
-      '_path=files filename!="-" md5="9f51ef98c42df4430a978e4157c43dd5"'
+      '_path=="files" filename!="-" md5=="9f51ef98c42df4430a978e4157c43dd5"'
     )
   })
 })
@@ -237,28 +237,30 @@ describe("#hasAnalytics()", () => {
   })
 
   test("for filter proc", () => {
-    expect(brim.program("* | filter _path=conn").hasAnalytics()).toBe(false)
+    expect(brim.program('* | filter _path=="conn"').hasAnalytics()).toBe(false)
   })
 })
 
 describe("#addHeadProc", () => {
   test("when no head exists", () => {
-    expect(addHeadProc("_path=dns", 300)).toBe("_path=dns | head 300")
+    expect(addHeadProc('_path=="dns"', 300)).toBe('_path=="dns" | head 300')
   })
 
   test("when head exists", () => {
-    expect(addHeadProc("_path=dns | head 45", 300)).toBe("_path=dns | head 45")
+    expect(addHeadProc('_path=="dns" | head 45', 300)).toBe(
+      '_path=="dns" | head 45'
+    )
   })
 
   test("when sort exists", () => {
-    expect(addHeadProc("_path=dns | sort ts", 300)).toBe(
-      "_path=dns | sort ts | head 300"
+    expect(addHeadProc('_path=="dns" | sort ts', 300)).toBe(
+      '_path=="dns" | sort ts | head 300'
     )
   })
 
   test("when sort and head exists", () => {
-    expect(addHeadProc("_path=dns | head 23 | sort ts", 300)).toBe(
-      "_path=dns | head 23 | sort ts"
+    expect(addHeadProc('_path=="dns" | head 23 | sort ts', 300)).toBe(
+      '_path=="dns" | head 23 | sort ts'
     )
   })
 })
@@ -288,10 +290,11 @@ describe("#hasHeadCount", () => {
 })
 
 describe("Get Parts of Program", () => {
-  const program = "md5=123 _path=files | count() by md5 | sort -r | head 1"
+  const program =
+    'md5=="123" _path=="files" | count() by md5 | sort -r | head 1'
 
   test("get filter part", () => {
-    expect(splitParts(program)[0]).toBe("md5=123 _path=files")
+    expect(splitParts(program)[0]).toBe('md5=="123" _path=="files"')
   })
 
   test("get filter part when none", () => {
@@ -303,16 +306,16 @@ describe("Get Parts of Program", () => {
   })
 
   test("get proc part when none", () => {
-    expect(splitParts("_path=files")[1]).toEqual("")
+    expect(splitParts('_path=="files"')[1]).toEqual("")
   })
 })
 
 describe("Join Parts of Program", () => {
-  const filter = "md5=123"
+  const filter = 'md5=="123"'
   const proc = "count() by _path"
 
   test("#joinParts", () => {
-    expect(joinParts(filter, proc)).toBe("md5=123 | count() by _path")
+    expect(joinParts(filter, proc)).toBe('md5=="123" | count() by _path')
   })
 
   test("#joinParts when empty filter", () => {
@@ -321,21 +324,21 @@ describe("Join Parts of Program", () => {
 })
 
 describe("Parallelizing multiple programs", () => {
-  const a = "md5=123 | count()"
-  const b = "md5=123 | head 5"
-  const c = "md5=123 | count() by _path"
+  const a = 'md5=="123" | count()'
+  const b = 'md5=="123" | head 5'
+  const c = 'md5=="123" | count() by _path'
 
   test("#parallelizeProcs when programs have same filter", () => {
     expect(parallelizeProcs([a, b, c])).toEqual(
-      "md5=123 | split ( => count() => head 5 => count() by _path)"
+      'md5=="123" | split ( => count() => head 5 => count() by _path)'
     )
   })
 
-  test("#parallelizeProcs when programs do no have same filter", () => {
+  test("#parallelizeProcs when programs do not have same filter", () => {
     expect(() => {
-      parallelizeProcs([a, b, c, "_path=conn"])
+      parallelizeProcs([a, b, c, '_path=="conn"'])
     }).toThrow(
-      "Filters must be the same in all programs: md5=123, md5=123, md5=123, _path=conn"
+      'Filters must be the same in all programs: md5=="123", md5=="123", md5=="123", _path=="conn"'
     )
   })
 })
@@ -345,20 +348,22 @@ describe("extracting the first filter", () => {
     expect(brim.program("*").filter()).toEqual("*")
   })
 
-  test("_path=conn", () => {
-    expect(brim.program("_path=conn").filter()).toEqual("_path=conn")
+  test('_path=="conn"', () => {
+    expect(brim.program('_path=="conn"').filter()).toEqual('_path=="conn"')
   })
 
-  test("_path=conn | sum(duration)", () => {
-    expect(brim.program("_path=conn | sum(duration)").filter()).toEqual(
-      "_path=conn"
+  test('_path=="conn" | sum(duration)', () => {
+    expect(brim.program('_path=="conn" | sum(duration)').filter()).toEqual(
+      '_path=="conn"'
     )
   })
 
-  test("_path=conn | filter a", () => {
+  test('_path=="conn" | filter a', () => {
     // This is questionable. We'd need another way to extract the filter if we
-    // want the result of this to be _path=conn | filter a
-    expect(brim.program("_path=conn | filter a").filter()).toEqual("_path=conn")
+    // want the result of this to be _path==\"conn\" | filter a
+    expect(brim.program('_path=="conn" | filter a').filter()).toEqual(
+      '_path=="conn"'
+    )
   })
 
   test("count()", () => {

--- a/src/js/brim/syntax.ts
+++ b/src/js/brim/syntax.ts
@@ -6,7 +6,7 @@ export default {
     return `${field.name}!=${toZql(field.value)}`
   },
   include(field: zed.Field) {
-    return `${field.name}=${toZql(field.value)}`
+    return `${field.name}==${toZql(field.value)}`
   },
   in(field: zed.Field) {
     return `${toZql(field.value)} in ${field.name}`

--- a/src/js/flows/submitSearch/__tests__/validate.test.ts
+++ b/src/js/flows/submitSearch/__tests__/validate.test.ts
@@ -33,7 +33,7 @@ test("Validates the zql", () => {
   store.dispatch(tabHistory.push(`/workspaces/1/lakes/${pool.id}/search`))
   expect(select(SearchBar.getSearchBarError)).toEqual(null)
 
-  dispatch(SearchBar.changeSearchBarInput("_ath="))
+  dispatch(SearchBar.changeSearchBarInput("_ath=="))
   submit().catch((e) => e)
 
   expect(select(SearchBar.getSearchBarError)).toMatch(

--- a/src/js/flows/submitSearch/__tests__/validate.test.ts
+++ b/src/js/flows/submitSearch/__tests__/validate.test.ts
@@ -37,7 +37,7 @@ test("Validates the zql", () => {
   submit().catch((e) => e)
 
   expect(select(SearchBar.getSearchBarError)).toMatch(
-    /Expected [\s\S]* but end of input found\./
+    /Expected [\s\S]* found\./
   )
 })
 

--- a/src/js/searches/programs.test.ts
+++ b/src/js/searches/programs.test.ts
@@ -16,7 +16,7 @@ test("conn correlation", () => {
       record.get("ts") as zed.Time,
       record.get("duration") as zed.Duration
     )
-  ).toBe(
-    'uid="CbOjYpkXn9LfqV51c" or "CbOjYpkXn9LfqV51c" in conn_uids or "CbOjYpkXn9LfqV51c" in uids or referenced_file.uid="CbOjYpkXn9LfqV51c" or (community_id = "1:h09VUfAoDYfBA0xGKuKCQ7nOxqU=" and ts >= 1425568032.998 and ts < 1425568123.707) | head 100'
+  ).toMatchInlineSnapshot(
+    `"uid==\\"CbOjYpkXn9LfqV51c\\" or \\"CbOjYpkXn9LfqV51c\\" in conn_uids or \\"CbOjYpkXn9LfqV51c\\" in uids or referenced_file.uid==\\"CbOjYpkXn9LfqV51c\\" or (community_id == \\"1:h09VUfAoDYfBA0xGKuKCQ7nOxqU=\\" and ts >= 1425568032.998 and ts < 1425568123.707) | head 100"`
   )
 })

--- a/src/js/searches/programs.ts
+++ b/src/js/searches/programs.ts
@@ -2,27 +2,27 @@ import {zed} from "zealot"
 import zql from "../zql"
 
 export function md5Correlation(md5: string) {
-  return `md5=${md5} | count() by md5 | sort -r | head 5`
+  return `md5==${md5} | count() by md5 | sort -r | head 5`
 }
 
 export function txHostsCorrelation(md5: string) {
-  return `md5=${md5} | count() by tx_hosts | sort -r | head 5`
+  return `md5==${md5} | count() by tx_hosts | sort -r | head 5`
 }
 
 export function rxHostsCorrelation(md5: string) {
-  return `md5=${md5} | count() by rx_hosts | sort -r | head 5`
+  return `md5==${md5} | count() by rx_hosts | sort -r | head 5`
 }
 
 export function filenameCorrelation(md5: string) {
-  return `md5=${md5} | count() by filename, mime_type | sort -r | head 5`
+  return `md5==${md5} | count() by filename, mime_type | sort -r | head 5`
 }
 
 export function uidFilter(uid: string | zed.Primitive) {
-  return zql`uid=${uid} or ${uid} in conn_uids or ${uid} in uids or referenced_file.uid=${uid}`
+  return zql`uid==${uid} or ${uid} in conn_uids or ${uid} in uids or referenced_file.uid==${uid}`
 }
 
 export function cidFilter(cid: string | zed.Primitive) {
-  return zql`community_id=${cid}`
+  return zql`community_id==${cid}`
 }
 
 export const UID_CORRELATION_LIMIT = 100
@@ -59,6 +59,6 @@ export function connCorrelation(
   const tsDate = ts.toDate()
   const dur = duration.asSeconds() + 90 // Add a 1.5 minute buffer for events that get logged late
   const endTsDate = new Date(new Date(tsDate).getTime() + dur * 1000)
-  const cidFilter = zql`community_id = ${cid} and ts >= ${tsDate} and ts < ${endTsDate}`
+  const cidFilter = zql`community_id == ${cid} and ts >= ${tsDate} and ts < ${endTsDate}`
   return `${uidFilter(uid)} or (${cidFilter}) | ${correlationLimit()}`
 }

--- a/src/js/state/SearchBar/test.ts
+++ b/src/js/state/SearchBar/test.ts
@@ -131,7 +131,7 @@ test("append an include field", () => {
   const field = createField("_path", "conn")
   const state = store.dispatchAll([appendQueryInclude(field)])
 
-  expect(SearchBar.getSearchBarInputValue(state)).toBe('_path="conn"')
+  expect(SearchBar.getSearchBarInputValue(state)).toBe('_path=="conn"')
 })
 
 test("append an include field when some text already exists", () => {
@@ -140,7 +140,7 @@ test("append an include field when some text already exists", () => {
     SearchBar.changeSearchBarInput("text"),
     appendQueryInclude(field)
   ])
-  expect(SearchBar.getSearchBarInputValue(state)).toBe('text _path="conn"')
+  expect(SearchBar.getSearchBarInputValue(state)).toBe('text _path=="conn"')
 })
 
 test("append an exclude field", () => {

--- a/src/js/state/migrations/202105141312_zedKeywordSearchUpdate.test.ts
+++ b/src/js/state/migrations/202105141312_zedKeywordSearchUpdate.test.ts
@@ -1,0 +1,19 @@
+import {getAllStates} from "src/js/test/helpers/getTestState"
+import {migrate} from "src/js/test/helpers/migrate"
+import {parse} from "zealot"
+import {UPDATED_V25_DEFAULT_QUERIES} from "./202105141312_zedKeywordSearchUpdate"
+
+test("migrating 202105141312_zedKeywordSearchUpdate", async () => {
+  const next = await migrate({state: "v0.24.0", to: "202105141312"})
+  expect.assertions(24)
+
+  for (const state of getAllStates(next)) {
+    state.queries.items.forEach((i) => {
+      const newQuery = UPDATED_V25_DEFAULT_QUERIES.find((q) => q.id === i.id)
+      if (newQuery) {
+        expect(i.value).toBe(newQuery.value)
+        parse(i.value) // this will throw if it doesn't work
+      }
+    })
+  }
+})

--- a/src/js/state/migrations/202105141312_zedKeywordSearchUpdate.ts
+++ b/src/js/state/migrations/202105141312_zedKeywordSearchUpdate.ts
@@ -1,4 +1,3 @@
-import {parse} from "path"
 import {getAllStates} from "src/js/test/helpers/getTestState"
 
 export const UPDATED_V25_DEFAULT_QUERIES = [

--- a/src/js/state/migrations/202105141312_zedKeywordSearchUpdate.ts
+++ b/src/js/state/migrations/202105141312_zedKeywordSearchUpdate.ts
@@ -51,6 +51,7 @@ export const UPDATED_V25_DEFAULT_QUERIES = [
 
 export default function zedKeywordSearchUpdate(state: any) {
   for (const s of getAllStates(state)) {
+    if (!s.queries || !s.queries.items) continue
     s.queries.items.forEach((i) => {
       const newQuery = UPDATED_V25_DEFAULT_QUERIES.find((q) => q.id === i.id)
       if (newQuery) {

--- a/src/js/state/migrations/202105141312_zedKeywordSearchUpdate.ts
+++ b/src/js/state/migrations/202105141312_zedKeywordSearchUpdate.ts
@@ -1,0 +1,64 @@
+import {parse} from "path"
+import {getAllStates} from "src/js/test/helpers/getTestState"
+
+export const UPDATED_V25_DEFAULT_QUERIES = [
+  {id: "1", value: "count() by _path | sort -r"},
+  {id: "2", value: '_path=="dns" | count() by query | sort -r'},
+  {id: "3", value: '_path matches smb* OR _path=="dce_rpc"'},
+  {
+    id: "4",
+    value:
+      '_path=="http" | cut id.orig_h, id.resp_h, id.resp_p, method,host, uri | uniq -c'
+  },
+  {
+    id: "5",
+    value: '_path=="conn" | cut id.orig_h, id.resp_p, id.resp_h | sort | uniq'
+  },
+  {
+    id: "6",
+    value:
+      '_path=="conn" | put total_bytes := orig_bytes + resp_bytes | sort -r total_bytes | cut uid, id, orig_bytes, resp_bytes, total_bytes'
+  },
+  {
+    id: "7",
+    value:
+      "filename!=null | cut _path, tx_hosts, rx_hosts, conn_uids, mime_type, filename, md5, sha1"
+  },
+  {
+    id: "8",
+    value: 'method=="POST" | cut ts, uid, id, method, uri, status_code'
+  },
+  {
+    id: "9",
+    value:
+      '_path=="conn" | put classnet := network_of(id.resp_h) | cut classnet | count() by classnet | sort -r'
+  },
+  {
+    id: "10",
+    value:
+      'event_type=="alert" | count() by alert.severity,alert.category | sort count'
+  },
+  {
+    id: "11",
+    value:
+      'event_type=="alert" | alerts := union(alert.category) by src_ip, dest_ip'
+  },
+  {
+    id: "12",
+    value:
+      'event_type=="alert" | alerts := union(alert.category) by network_of(dest_ip)'
+  }
+]
+
+export default function zedKeywordSearchUpdate(state: any) {
+  for (const s of getAllStates(state)) {
+    s.queries.items.forEach((i) => {
+      const newQuery = UPDATED_V25_DEFAULT_QUERIES.find((q) => q.id === i.id)
+      if (newQuery) {
+        i.value = newQuery.value
+      }
+    })
+  }
+
+  return state
+}

--- a/test/api/search_test.ts
+++ b/test/api/search_test.ts
@@ -70,9 +70,8 @@ testApi("search#callbacks start and end", async (zealot: any) => {
 
 testApi("search#callbacks record", async (zealot: any) => {
   await setup(zealot)
-  const resp = await zealot.search("_path=conn | sort ts | head 1")
+  const resp = await zealot.search('_path=="conn" | sort ts | head 1')
   const records = spy()
-
   await new Promise((resolve, reject) => {
     resp
       .callbacks()

--- a/zealot/zealot.ts
+++ b/zealot/zealot.ts
@@ -37,6 +37,7 @@ export function createZealot(
       return promise({method: "GET", path: "/auth/identity"})
     },
     search: (zql: string, args?: Partial<SearchArgs>) => {
+      console.log("zql", zql)
       return stream(search(zql, {...searchArgs, ...args}))
     },
     archive: {

--- a/zealot/zealot.ts
+++ b/zealot/zealot.ts
@@ -37,7 +37,6 @@ export function createZealot(
       return promise({method: "GET", path: "/auth/identity"})
     },
     search: (zql: string, args?: Partial<SearchArgs>) => {
-      console.log("zql", zql)
       return stream(search(zql, {...searchArgs, ...args}))
     },
     archive: {


### PR DESCRIPTION
Fixes #1644 

Update the app with the new equality, assignment, and matches syntax. Based off the zed branch : 
https://github.com/brimdata/zed/pull/2692

|before | after|
|---| ---|
|`_path=conn` | `_path=="conn"`|
|`query=google*` | `query matches google*`|
|`put sum = a + b` | `put sum := a + b`|


* Updates all app queries
* Updates queries in the itest suite
* Migrates the query library
* Adds parse tests for the default queries in the query library

**Note:** It is likely that user's history entries will contain queries with wrong syntax now. This will be addressed prominently in the release notes, but that's it. No attempt to migrate old history queries will be made. The tooling to do so is not present and not easily built.