### PR TITLE
Advance Brimcap to a1f4486

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7920,8 +7920,8 @@
       }
     },
     "brimcap": {
-      "version": "github:brimdata/brimcap#82f0140a7c623846f07a9003af3090b9f0452694",
-      "from": "github:brimdata/brimcap#82f0140a7c623846f07a9003af3090b9f0452694",
+      "version": "github:brimdata/brimcap#a1f44861206e807e458f9d16627fb1a2fdaa9ae2",
+      "from": "github:brimdata/brimcap#a1f44861206e807e458f9d16627fb1a2fdaa9ae2",
       "dev": true
     },
     "browser-process-hrtime": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "babel-plugin-inline-react-svg": "^1.1.1",
     "babel-plugin-module-resolver": "^4.0.0",
     "babel-plugin-source-map-support": "^2.1.2",
-    "brimcap": "brimdata/brimcap#82f0140a7c623846f07a9003af3090b9f0452694",
+    "brimcap": "brimdata/brimcap#a1f44861206e807e458f9d16627fb1a2fdaa9ae2",
     "chalk": "^4.1.0",
     "commander": "^2.20.3",
     "cpx": "^1.5.0",


### PR DESCRIPTION
Looking to make things current so I can do more end-to-end testing with the last wave of Zed language updates now in all systems.