### PR TITLE
Always populate location in tab history

### DIFF
--- a/app/core/models/histories.test.ts
+++ b/app/core/models/histories.test.ts
@@ -19,6 +19,14 @@ test("tab histories get ", () => {
   expect(tabHistory.entries.map((e) => e.pathname)).toEqual(["/", "/home"])
 })
 
+test("create with empty entries defaults to root path", () => {
+  const histories = new Histories()
+  histories.create("tab-id-1", [], -1)
+
+  const tabHistory = histories.get("tab-id-1")
+  expect(tabHistory.location.pathname).toEqual("/")
+})
+
 test("serialize", () => {
   const histories = new Histories()
   histories.create("tab-id-1")

--- a/app/core/models/histories.ts
+++ b/app/core/models/histories.ts
@@ -4,6 +4,7 @@ import {
   MemoryHistory,
   UnregisterCallback
 } from "history"
+import {isEmpty} from "lodash"
 import {SerializedHistory} from "src/js/state/TabHistories/types"
 
 /**
@@ -25,6 +26,7 @@ export default class Histories {
   }
 
   create(id: string, initialEntries?, initialIndex?) {
+    if (isEmpty(initialEntries)) initialEntries = undefined
     const history = createMemoryHistory({initialEntries, initialIndex})
     this.histories.set(id, history)
     this.listenTo(id, history)


### PR DESCRIPTION
Fixes #1648 

The app state may contain history with an empty entries array.
If this happens, the location property will be undefined on the
history object. This will crash the app.

The fix is to never create a history with an empty initial entries.
If there are no entries, pass in undefined.

If you pass initial entries as undefined, the library will push a
"/" entry on the stack. Thus the location property will always be
populated.

For example:
```
> var history = h.createMemoryHistory({initialEntries: []})
> history.location.pathname
Uncaught TypeError: Cannot read property 'pathname' of undefined
```
But this works,
```
> var history = h.createMemoryHistory({initialEntries: undefined})
> history.location.pathname
'/'
```