### PR TITLE
handle adapter bug for global dispatch

### DIFF
--- a/src/js/api/ui-apis.ts
+++ b/src/js/api/ui-apis.ts
@@ -23,6 +23,6 @@ export class ConfigsApi {
   }
 
   add(config: Config) {
-    this.dispatch(Configs.create(config))
+    this.dispatch(Configs.set(config))
   }
 }

--- a/src/js/state/Configs/index.ts
+++ b/src/js/state/Configs/index.ts
@@ -27,8 +27,12 @@ const slice = createSlice({
   name: "$configs",
   initialState: adapter.getInitialState(),
   reducers: {
-    create: adapter.addOne,
-    delete: adapter.removeOne
+    set(state, action) {
+      adapter.upsertOne(state, action.payload)
+    },
+    delete(state, action) {
+      adapter.removeOne(state, action.payload)
+    }
   }
 })
 

--- a/src/js/state/Configs/test.ts
+++ b/src/js/state/Configs/test.ts
@@ -41,18 +41,18 @@ beforeEach(() => {
 
 test("Create", () => {
   // add one
-  dispatch(Configs.create(testConfig1))
+  dispatch(Configs.set(testConfig1))
   expect(select(Configs.all)).toHaveLength(1)
   expect(select(Configs.get(testConfig1.name))).toEqual(testConfig1)
 
   // add second
-  dispatch(Configs.create(testConfig2))
+  dispatch(Configs.set(testConfig2))
   expect(select(Configs.all)).toHaveLength(2)
   expect(select(Configs.get(testConfig2.name))).toEqual(testConfig2)
 })
 
 test("Delete", () => {
-  dispatch(Configs.create(testConfig1))
+  dispatch(Configs.set(testConfig1))
 
   dispatch(Configs.delete(testConfig1.name))
   expect(select(Configs.all)).toHaveLength(0)

--- a/src/js/state/PluginStorage/index.ts
+++ b/src/js/state/PluginStorage/index.ts
@@ -13,8 +13,12 @@ const slice = createSlice({
   name: "$pluginStorage",
   initialState,
   reducers: {
-    set: adapter.upsertOne,
-    delete: adapter.removeOne
+    set(state, action) {
+      adapter.upsertOne(state, action.payload)
+    },
+    delete(state, action) {
+      adapter.removeOne(state, action.payload)
+    }
   }
 })
 


### PR DESCRIPTION
fixes #1653 

This is an issue we hadn't seen before because until recently we hadn't combined the redux toolkit entity adapters we've begun to use with our existing globally dispatched actions. It has a simple fix though.

Actions may have a `remote` key set if dispatched from another window. In such a case the `adapter.addOne()` and similar CRUD methods will not recognize the passed in action param to be of type `PayloadAction` and will instead interpret the value as an Entity (i.e. a Config type in this case). So instead, we will always pass in the entity/action.payload when using adapters for global reducers.

I also changed the method from `create` to `set` and used upsertOne, since it was already overwriting the existing value (semantically speaking, "set" indicates that overwriting behavior to me more than "create" does) and now matches the same `set`/`delete` api as the `ConfigPropValues`, and `PluginStorage` reducers so that we are more consistent

Signed-off-by: Mason Fish <mason@looky.cloud>