### PR TITLE
space migrate: refresh pool on fail

### DIFF
--- a/app/legacy/space-migration/space-migration.tsx
+++ b/app/legacy/space-migration/space-migration.tsx
@@ -106,6 +106,7 @@ function Modal({onClose}) {
       })
       .catch((e) => {
         toast.dismiss(id)
+        dispatch(refreshPoolNames())
         // This is a bug in the toast library, these subsequent toasts
         // were not being displayed without the setTimeout()
         setTimeout(() => {

--- a/app/legacy/space-migration/space-migrator.ts
+++ b/app/legacy/space-migration/space-migrator.ts
@@ -2,6 +2,7 @@ import {pathsClient} from "app/ipc/paths"
 import {ChildProcess, spawn} from "child_process"
 import fs from "fs-extra"
 import readline from "readline"
+import tee from "tee-1"
 
 /**
  * Data in the app was stored in a file store in versions before 25.
@@ -36,8 +37,8 @@ export default class SpaceMigrator {
         `-zqd=${this.srcDir}`,
         `-root=${this.destDir}`
       ])
-
-      const linesErr = readline.createInterface({input: this.process.stderr})
+      let stderr = this.process.stderr.pipe(tee(process.stderr))
+      const linesErr = readline.createInterface({input: stderr})
       let total = 0
       let count = 0
       let space = ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -23914,6 +23914,21 @@
         }
       }
     },
+    "tee-1": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/tee-1/-/tee-1-0.2.0.tgz",
+      "integrity": "sha1-csjgJjuRi2PYgyJjvE0V/ogiSRc=",
+      "requires": {
+        "through": "~1.1.1"
+      },
+      "dependencies": {
+        "through": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/through/-/through-1.1.2.tgz",
+          "integrity": "sha1-NEpUJaN3MxTKfg62US+6+vdsC/4="
+        }
+      }
+    },
     "temp-file": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.3.7.tgz",

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     "semver": "^7.3.2",
     "source-map-support": "^0.5.19",
     "styled-components": "^5.1.1",
+    "tee-1": "^0.2.0",
     "tree-model": "^1.0.7",
     "valid-url": "^1.0.9",
     "zed": "git+https://github.com/brimdata/zed.git#1d16c1b6ae24c20210683c533905598239d37d80"


### PR DESCRIPTION
If migrate fails because it was cancelled, the current pool it is
operating on will be deleted. As a result, refresh pools on failure so
things remain up to date.

Also:
- Use tee-1 package to tee migration logs into the brim process stderr.
  Better to have some visibility than none.