### PR TITLE
Increase expected pool size due to Zed dcce5c22 change

### DIFF
--- a/test/api/ingest_test.ts
+++ b/test/api/ingest_test.ts
@@ -26,5 +26,5 @@ testApi("ingest ndjson log", async (zealot) => {
   await resp.array()
 
   const {size} = await zealot.pools.get(pool.id)
-  assertEquals(size, 4546)
+  assertEquals(size, 4467)
 })


### PR DESCRIPTION
The `npm run test:api` test in the Brim CI recently started failing because the pool size after importing `itest/testdata/custom-sample.ndjson` had increased from 4546 to 4467 as a result of changes in Zed commit `dcce5c22`  (brimdata/zed#2729). At a team discussion today it was agreed that this change is expected, so I've modified the expected value so the CI will start passing again.