### PR TITLE
Improve brimcap load error handling

### DIFF
--- a/plugins/brimcap/brimcap-cli.ts
+++ b/plugins/brimcap/brimcap-cli.ts
@@ -1,5 +1,5 @@
 import {spawnSync, spawn, ChildProcess} from "child_process"
-import {compact} from "lodash"
+import {compact, isEmpty} from "lodash"
 import flatMap from "lodash/flatMap"
 
 interface packetOptions {
@@ -17,6 +17,7 @@ export interface loadOptions {
   n?: number
   root: string
   pool: string
+  json?: boolean
   suricata?: boolean
   suricataStderr?: string
   suricataStdout?: string
@@ -47,8 +48,13 @@ const toCliOpts = (opts: loadOptions | searchOptions): string[] =>
   compact(
     flatMap(
       Object.entries(opts).map(([k, v]) => {
-        if (!v) return
-        return [`-${OPTION_NAME_MAP[k] || k}`, v]
+        const optKey = `-${OPTION_NAME_MAP[k] || k}`
+        // booleans flags don't use values, if opting in just include the key
+        if (typeof v === "boolean" && v) return [optKey]
+        // otherwise, if no value provided, don't include this option
+        if (isEmpty(v)) return
+
+        return [optKey, v]
       })
     )
   )

--- a/src/js/flows/ingestFiles.ts
+++ b/src/js/flows/ingestFiles.ts
@@ -1,4 +1,4 @@
-import {lakePath, workspacesPath} from "app/router/utils/paths"
+import {lakePath, workspacePath} from "app/router/utils/paths"
 import fsExtra from "fs-extra"
 import brim from "../brim"
 import ingest from "../brim/ingest"
@@ -160,7 +160,7 @@ const setPool = (dispatch, tabId, workspaceId) => ({
     global.tabHistories.getOrCreate(tabId).push(url)
   },
   undo() {
-    const url = workspacesPath()
+    const url = workspacePath(workspaceId)
     global.tabHistories.getOrCreate(tabId).replace(url)
   }
 })


### PR DESCRIPTION
fixes #1652 

3 changes here:

* BrimcapCli handles boolean options better. With this, I'm including the `-json` option in load now, though the behavior did not change (stderr returns JSON with or without this option)
* On ingest failure, instead of redirecting users to the "Choose a workspace" page, we just redirect back the workspace they were on when they began ingest
* The main fix relating to the linked ticket: `brimcap` may send ndjson in it's stderr stream. In the error case described in the ticket, the stream was sending a status message AND an error message as json separated by a single new line but the prior parser was only expecting regular json. Now we always parse and process as ndjson.

Signed-off-by: Mason Fish <mason@looky.cloud>