### PR TITLE
Add more test steps to "advance Zed" workflow

### DIFF
--- a/.github/workflows/advance-zed.yml
+++ b/.github/workflows/advance-zed.yml
@@ -112,8 +112,12 @@ jobs:
         run: npm install https://github.com/brimdata/zed#${{ steps.zed_pr.outputs.sha }}
 
       - run: npm install --no-audit
+      - run: npm run format-check
       - run: npm run build
+      - run: npm run lint
+      - run: npm run tsc
       - run: npm test -- --maxWorkers=2 --ci
+      - run: npm run test:api
       - name: Integration Tests
         id: testIntegration
         run: xvfb-run --auto-servernum -s "-screen 0 1280x1024x24" npm run itest -- --ci --forceExit


### PR DESCRIPTION
We recently had an incident where a Zed change effectively broke Brim, but the workflow in `advance-zed.yml` passed ok because it was lacking the `npm run test:api` step that would have caught the failure. That step _is_ in `ci.yml`, so it eventually got caught, but only after Brim had advanced to a state where it was pointing to a Zed version that would fail CI every time.

Here I've copied over some of the steps in `ci.yml` that were previously missing from `advance-zed.yml`. @mattnibs correctly observed that the ideal solution would be to avoid any duplication of steps and instead have the Zed-advancing workflow call into the main CI workflow, similar to how the Brimcap CI is currently set up. However, in the interest of incremental improvement, for the moment I'm extending the duplication between the workflows just to reduce the likelihood of us hitting these breakages more in the short term.