### PR TITLE
legacy space migrate: delete pool

### DIFF
--- a/app/legacy/space-migration/space-migration.tsx
+++ b/app/legacy/space-migration/space-migration.tsx
@@ -13,6 +13,7 @@ import {
   Title
 } from "src/js/components/ModalDialog/ModalDialog"
 import refreshPoolNames from "src/js/flows/refreshPoolNames"
+import deletePool from "src/js/flows/deletePool"
 import ThreeDotsIcon from "src/js/icons/ThreeDotsIcon"
 import {showContextMenu} from "src/js/lib/System"
 import {AppDispatch} from "src/js/state/types"
@@ -106,11 +107,13 @@ function Modal({onClose}) {
       })
       .catch((e) => {
         toast.dismiss(id)
-        dispatch(refreshPoolNames())
+        if ("currentPoolID" in e) {
+          dispatch(deletePool(e.currentPoolID))
+        }
         // This is a bug in the toast library, these subsequent toasts
         // were not being displayed without the setTimeout()
         setTimeout(() => {
-          toast.error(e.toString())
+          toast.error(e.message)
         })
       })
   }

--- a/app/legacy/space-migration/space-migrator.ts
+++ b/app/legacy/space-migration/space-migrator.ts
@@ -53,7 +53,7 @@ export default class SpaceMigrator {
         if ("space" in status && status.space !== space) {
           space = status.space
           count++
-          onUpdate({total, space: space, count})
+          onUpdate({total, space, count})
         }
         if ("pool_id" in status) {
           this.currentPoolID = status.pool_id

--- a/app/legacy/space-migration/space-migrator.ts
+++ b/app/legacy/space-migration/space-migrator.ts
@@ -11,6 +11,7 @@ import tee from "tee-1"
  */
 export default class SpaceMigrator {
   process: ChildProcess | null
+  currentPoolID: String | null
 
   constructor(readonly srcDir: string, readonly destDir: string) {}
 
@@ -39,24 +40,23 @@ export default class SpaceMigrator {
       ])
       let stderr = this.process.stderr.pipe(tee(process.stderr))
       const linesErr = readline.createInterface({input: stderr})
+      let space = ""
       let total = 0
       let count = 0
-      let space = ""
-      let totalRegexp = /^migrating (\d+) spaces$/
 
       linesErr.on("line", (line) => {
         console.log(line)
         const status = tryJson(line.toString())
-        if ("msg" in status) {
-          const match = status.msg.match(totalRegexp)
-          if (match) {
-            total = parseInt(match[1])
-          }
+        if (status.msg === "migrating spaces") {
+          total = status.count
         }
         if ("space" in status && status.space !== space) {
           space = status.space
           count++
-          onUpdate({total, space, count})
+          onUpdate({total, space: space, count})
+        }
+        if ("pool_id" in status) {
+          this.currentPoolID = status.pool_id
         }
       })
 
@@ -66,9 +66,15 @@ export default class SpaceMigrator {
 
       this.process.on("exit", (code) => {
         if (this.process.killed) {
-          reject("Migration was cancelled")
+          reject({
+            message: "Migration was cancelled",
+            currentPoolID: this.currentPoolID
+          })
         } else if (code !== 0) {
-          reject("Migration failed")
+          reject({
+            message: "Migration failed",
+            currentPoolID: this.currentPoolID
+          })
         } else resolve()
       })
     }).finally(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7926,8 +7926,8 @@
       }
     },
     "brimcap": {
-      "version": "github:brimdata/brimcap#692d288cc2fcc35fd0584f27be9933e545c5a160",
-      "from": "github:brimdata/brimcap#692d288cc2fcc35fd0584f27be9933e545c5a160",
+      "version": "github:brimdata/brimcap#5dae4c561709b176e616ff0c167db8f6d468eb91",
+      "from": "github:brimdata/brimcap#5dae4c561709b176e616ff0c167db8f6d468eb91",
       "dev": true
     },
     "browser-process-hrtime": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "babel-plugin-inline-react-svg": "^1.1.1",
     "babel-plugin-module-resolver": "^4.0.0",
     "babel-plugin-source-map-support": "^2.1.2",
-    "brimcap": "brimdata/brimcap#692d288cc2fcc35fd0584f27be9933e545c5a160",
+    "brimcap": "brimdata/brimcap#5dae4c561709b176e616ff0c167db8f6d468eb91",
     "chalk": "^4.1.0",
     "commander": "^2.20.3",
     "cpx": "^1.5.0",


### PR DESCRIPTION
Due to issues with not being able to send a SIGINT signal in windows, if
a migrate is aborted have the brim app delete the current pool.