### PR TITLE
Update link for integration test README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ npx jest Client.test.js -t "increment by one" # Run a single test by name
 npx jest --watch                              # Run all tests on every change
 ```
 
-For integration tests, see [itest/README.md](itest/README.md).
+For integration tests, see [test/integration/README.md](test/integration/README.md).
 
 **Snapshots**
 


### PR DESCRIPTION
The nightly markdown link checker informed me of this broken link after the changes in #1687. Based on those PR notes, this looks like the way to fix it.