### PR TITLE
zealot: handle empty stats response

### DIFF
--- a/zealot/zealot.ts
+++ b/zealot/zealot.ts
@@ -63,6 +63,9 @@ export function createZealot(
       },
       stats: async (id: string): Promise<PoolStats> => {
         const res = await promise(pools.stats(id))
+        if (!res) {
+            return null
+        }
         const rec = new Context().decodeRecord(res)
         const stats: PoolStats = {
           size: rec.get<Int64>("size").toInt(),


### PR DESCRIPTION
On a stats request to an empty pool, the response is 204 No Content.  
Ensure this response is appropriately handled.

Fixes #1697