### PR TITLE
Restore wrccdc link

### DIFF
--- a/docs/Remote-zed-lake.md
+++ b/docs/Remote-zed-lake.md
@@ -208,7 +208,7 @@ However we can use the `zapi` command line tool on our VM to access this `zqd`
 directly via `localhost`.
 
 As sample packet data, we'll import a
-[wrccdc pcap](https://wrccdc.org/) from a separate shell on
+[wrccdc pcap](https://archive.wrccdc.org/pcaps/2018/) from a separate shell on
 our Linux VM:
 
 ```


### PR DESCRIPTION
I've been in contact with the wrccdc people during the long time their packet archive has been offline. It's confirmed to be back, hopefully for good, so I'm restoring this link that I'd taken out in #1586.