### PR TITLE
brimcap yaml config docs link

### DIFF
--- a/plugins/brimcap/brimcap-plugin.ts
+++ b/plugins/brimcap/brimcap-plugin.ts
@@ -358,7 +358,12 @@ export default class BrimcapPlugin {
           name: this.yamlConfigPropName,
           type: "file",
           label: "Brimcap YAML Config File",
-          defaultValue: ""
+          defaultValue: "",
+          helpLink: {
+            label: "docs",
+            url:
+              "https://github.com/brimdata/brimcap/wiki/Custom-Brimcap-Config"
+          }
         }
       }
     }

--- a/src/js/brim/form.ts
+++ b/src/js/brim/form.ts
@@ -8,6 +8,10 @@ export type FormFieldConfig = {
   label: string
   check?: (arg0: string) => FormCheckResult
   submit?: (arg0: string) => void
+  helpLink?: {
+    label: string
+    url: string
+  }
 }
 
 export type FormConfig = {

--- a/src/js/components/Preferences/Preferences.tsx
+++ b/src/js/components/Preferences/Preferences.tsx
@@ -17,6 +17,7 @@ import TextInput from "../common/forms/TextInput"
 import ConfigPropValues from "src/js/state/ConfigPropValues"
 import {useSelector} from "react-redux"
 import get from "lodash/get"
+import Link from "../common/Link"
 
 function ConfigFormItems(props: {configs: FormConfig}) {
   const {configs} = props
@@ -25,13 +26,32 @@ function ConfigFormItems(props: {configs: FormConfig}) {
   const configVals = useSelector(ConfigPropValues.all)
 
   const formInputs = Object.values(configs).map((c) => {
-    const {label, defaultValue, name} = c
+    const {label, defaultValue, name, helpLink} = c
     if (!c.type) return
+
+    const maybeHelpLinkLabel = () => {
+      if (!helpLink) return null
+      const {url, label} = helpLink
+      return (
+        <>
+          {" "}
+          <Link href={url}>{label}</Link>
+        </>
+      )
+    }
+
+    const itemLabel = (
+      <InputLabel>
+        {label}
+        {maybeHelpLinkLabel()}
+      </InputLabel>
+    )
+
     switch (c.type) {
       case "file":
         return (
           <div key={name} className="setting-panel">
-            <InputLabel>{label}</InputLabel>
+            {itemLabel}
             <FileInput
               name={name}
               defaultValue={
@@ -46,9 +66,7 @@ function ConfigFormItems(props: {configs: FormConfig}) {
       case "string":
         return (
           <div key={name} className="setting-panel">
-            <div>
-              <InputLabel>{label}</InputLabel>
-            </div>
+            {itemLabel}
             <TextInput
               name={name}
               type="text"

--- a/src/js/components/Preferences/usePreferencesForm.ts
+++ b/src/js/components/Preferences/usePreferencesForm.ts
@@ -24,7 +24,7 @@ export const useConfigsForm = (): FormConfig => {
   const formConfig: FormConfig = {}
   configs.forEach((config) => {
     Object.values(config.properties).forEach((prop) => {
-      const {name, label, defaultValue, type, command} = prop
+      const {name, label, defaultValue, type, command, helpLink} = prop
 
       const submit = (value) => {
         if (command) dispatch(executeCommand(command, value))
@@ -56,7 +56,8 @@ export const useConfigsForm = (): FormConfig => {
         label,
         defaultValue,
         submit,
-        check
+        check,
+        helpLink
       }
     })
   })

--- a/src/js/state/Configs/index.ts
+++ b/src/js/state/Configs/index.ts
@@ -7,6 +7,10 @@ export type ConfigItem = {
   name: string
   type: ConfigItemType
   label: string
+  helpLink?: {
+    label: string
+    url: string
+  }
   command?: string
   defaultValue?: string
 }


### PR DESCRIPTION
fixes #1704 

Extends the configs api exposed to plugins with ability to add a help link which the app styles to appear right after the label. Brimcap then uses this to add a "docs" link to accompany the yaml configuration's label in the preferences panel.

<img width="1250" alt="image" src="https://user-images.githubusercontent.com/14865533/121439963-cb89ef00-c93b-11eb-9f17-521a76f5ef7c.png">


Signed-off-by: Mason Fish <mason@looky.cloud>