### PR TITLE
fix <Link /> typeError

### DIFF
--- a/src/js/components/common/Link.tsx
+++ b/src/js/components/common/Link.tsx
@@ -6,7 +6,7 @@ type Props = {href?: string; children: JSX.Element | string; onClick?: Function}
 
 export default function Link({href, onClick, children}: Props) {
   // Anchors can be passed through
-  if (href.startsWith("#")) return <a href={href}>{children}</a>
+  if (href?.startsWith("#")) return <a href={href}>{children}</a>
 
   const click = (e) => {
     e.preventDefault()


### PR DESCRIPTION
fixes #1703 

I'm a little surprised typescript didn't help enforce this, but we needed to check if a value was null before attempting to access a property from it inside the `<Link />` component. This also created a more global error if attempting to logout of a non-default workspace. Both cases should be fixed now.

Signed-off-by: Mason Fish <mason@looky.cloud>