### PR TITLE
fix hidden window close

### DIFF
--- a/src/js/electron/tron/window.ts
+++ b/src/js/electron/tron/window.ts
@@ -42,7 +42,6 @@ function aboutWindow() {
 
 function hiddenWindow() {
   const win = new BrowserWindow({
-    closable: false,
     show: false,
     webPreferences: {
       nodeIntegration: true,


### PR DESCRIPTION
fixes #1707 

I had initially used the `closable: false` option for the "hidden" window as an extra safeguard to prevent users from closing the window (and also as an inferred description that this window should always be open), but it turns out this also prevents us from programmatically closing the window. Given that the window is hidden anyway, I don't think this is actually necessary and am removing.

Signed-off-by: Mason Fish <mason@looky.cloud>