### PR TITLE
Bigint serialize fix

### DIFF
--- a/src/js/brim/interop.ts
+++ b/src/js/brim/interop.ts
@@ -1,13 +1,18 @@
 import brim from "./"
+import {PoolStats} from "../../../zealot/types"
+import {Pool} from "../state/Pools/types"
 
 export default {
-  poolPayloadToPool(pool: any) {
-    if (pool.span) {
-      const span = pool.span
+  poolStatsPayloadToPool(poolPayload: PoolStats): Partial<Pool> {
+    if (!poolPayload) return null
+    const {span, ...payload} = poolPayload
+    const pool: Partial<Pool> = {...payload}
+    if (span) {
+      const span = poolPayload.span
       const start = brim.time(span.ts)
       const end = start.addTs(brim.time(span.dur).toTs())
-      pool = {...pool, min_time: start.toTs(), max_time: end.toTs()}
-      delete pool.span
+      pool.min_time = start.toTs()
+      pool.max_time = end.toTs()
     }
     return pool
   }

--- a/src/js/flows/ingestFiles.test.ts
+++ b/src/js/flows/ingestFiles.test.ts
@@ -78,8 +78,7 @@ describe("success case", () => {
         max_time: {ns: 1, sec: 1},
         ingest: {
           progress: null,
-          warnings: [],
-          snapshot: 0
+          warnings: []
         }
       })
     )

--- a/src/js/flows/ingestFiles.ts
+++ b/src/js/flows/ingestFiles.ts
@@ -15,6 +15,7 @@ import {Dispatch, Thunk} from "../state/types"
 import {getZealot} from "./getZealot"
 import BrimApi from "../api"
 import {Zealot} from "../../../zealot"
+import interop from "../brim/interop"
 
 export default (files: File[]): Thunk<Promise<void>> => (
   dispatch,
@@ -71,7 +72,7 @@ const createDir = () => ({
   }
 })
 
-const createPool = (client, gDispatch, workspaceId) => ({
+const createPool = (client: Zealot, gDispatch, workspaceId) => ({
   async do(params: IngestParams) {
     let createParams
     if (params.dataDir) {
@@ -83,7 +84,7 @@ const createPool = (client, gDispatch, workspaceId) => ({
     gDispatch(
       Pools.setDetail(workspaceId, {
         ...pool,
-        ingest: {progress: 0, snapshot: 0, warnings: []}
+        ingest: {progress: 0, warnings: []}
       })
     )
 
@@ -126,8 +127,10 @@ const executeLoader = (
       dispatch(space.setIngestProgress(value))
     }
     const onDetailUpdate = async (): Promise<void> => {
-      const details = await client.pools.stats(poolId)
-      dispatch(Pools.setDetail(workspaceId, {id: poolId, ...details}))
+      const stats = interop.poolStatsPayloadToPool(
+        await client.pools.stats(poolId)
+      )
+      dispatch(Pools.setDetail(workspaceId, {id: poolId, ...stats}))
     }
     const onWarning = (warning: string): void => {
       dispatch(space.appendIngestWarning(warning))

--- a/src/js/flows/initPool.ts
+++ b/src/js/flows/initPool.ts
@@ -1,4 +1,3 @@
-import brim from "../brim"
 import Current from "../state/Current"
 import Pools from "../state/Pools"
 import {Thunk} from "../state/types"
@@ -13,7 +12,6 @@ export const initPool = (poolId: string): Thunk<Promise<void>> => (
   const zealot = dispatch(getZealot())
   return zealot.pools
     .get(poolId)
-    .then(brim.interop.poolPayloadToPool)
     .then((data) => {
       dispatch(Pools.setDetail(workspaceId, data))
     })

--- a/src/js/flows/refreshPoolInfo.ts
+++ b/src/js/flows/refreshPoolInfo.ts
@@ -2,25 +2,33 @@ import {Thunk} from "../state/types"
 import Current from "../state/Current"
 import Pools from "../state/Pools"
 import {getZealot} from "./getZealot"
+import {Zealot} from "../../../zealot"
+import {PoolConfig, PoolStats} from "../../../zealot/types"
+import interop from "../brim/interop"
 
 export default function refreshPoolInfo(): Thunk {
   return () => (dispatch, getState) => {
-    const zealot = dispatch(getZealot())
+    const zealot: Zealot = dispatch(getZealot())
     const id = Current.getPoolId(getState())
 
-    let config = {}
-    let stats = {}
+    let config: PoolConfig
+    let stats: PoolStats
     Promise.all([
-      zealot.pools.get(id).then((data: any) => {
+      zealot.pools.get(id).then((data: PoolConfig) => {
         config = data
       }),
-      zealot.pools.stats(id).then((data: any) => {
+      zealot.pools.stats(id).then((data: PoolStats) => {
         stats = data
       })
     ]).then(() => {
       const id = Current.getWorkspaceId(getState())
       if (!id) return
-      dispatch(Pools.setDetail(id, {...config, ...stats}))
+      dispatch(
+        Pools.setDetail(id, {
+          ...config,
+          ...interop.poolStatsPayloadToPool(stats)
+        })
+      )
     })
   }
 }

--- a/src/js/flows/refreshPoolNames.ts
+++ b/src/js/flows/refreshPoolNames.ts
@@ -3,6 +3,7 @@ import Current from "../state/Current"
 import Pools from "../state/Pools"
 import {getZealot} from "./getZealot"
 import {BrimWorkspace} from "../brim"
+import interop from "../brim/interop"
 
 export default function refreshPoolNames(
   ws?: BrimWorkspace
@@ -17,7 +18,9 @@ export default function refreshPoolNames(
         pools = data || []
         return Promise.all(
           pools.map(async (pool, i) => {
-            let stats = await zealot.pools.stats(pool.id)
+            const stats = interop.poolStatsPayloadToPool(
+              await zealot.pools.stats(pool.id)
+            )
             pools[i] = {...pool, ...stats}
           })
         )

--- a/src/js/lib/is.ts
+++ b/src/js/lib/is.ts
@@ -23,7 +23,7 @@ export function isNumber(value: unknown): value is number {
   return typeof value === "number" && isFinite(value)
 }
 
-export function isBigInt(value: unknown): value is BigInt {
+export function isBigInt(value: unknown): value is bigint {
   return typeof value === "bigint"
 }
 

--- a/src/js/state/Pools/actions.ts
+++ b/src/js/state/Pools/actions.ts
@@ -17,7 +17,7 @@ export default {
     pools: pools || []
   }),
 
-  setDetail: (workspaceId: string, pool: any): POOLS_DETAIL => ({
+  setDetail: (workspaceId: string, pool: Partial<Pool>): POOLS_DETAIL => ({
     type: "$POOLS_DETAIL",
     workspaceId,
     pool

--- a/src/js/state/Pools/actionsFor.ts
+++ b/src/js/state/Pools/actionsFor.ts
@@ -1,4 +1,4 @@
-import {POOLS_DETAIL, POOLS_REMOVE} from "./types"
+import {POOLS_REMOVE} from "./types"
 import actions from "./actions"
 
 export default function actionsFor(workspaceId: string, poolId: string) {
@@ -16,11 +16,6 @@ export default function actionsFor(workspaceId: string, poolId: string) {
       type: "$POOLS_REMOVE",
       workspaceId,
       poolId
-    }),
-    create: (): POOLS_DETAIL => ({
-      type: "$POOLS_DETAIL",
-      workspaceId,
-      pool: {id: poolId}
     })
   }
 }

--- a/src/js/state/Pools/reducer.ts
+++ b/src/js/state/Pools/reducer.ts
@@ -1,7 +1,6 @@
 import produce from "immer"
 
 import {Pool, PoolsAction, PoolsState} from "./types"
-import brim from "../../brim"
 
 const init: PoolsState = {}
 
@@ -20,8 +19,7 @@ const poolsReducer = produce((draft, action: PoolsAction): {
       // time. In the future brim.Span type should mimic the formatted
       // transmitted over the wire.
 
-      var pool = brim.interop.poolPayloadToPool(action.pool)
-      draft[id] = defaults(pool, draft[id])
+      draft[id] = defaults(action.pool, draft[id])
       break
 
     case "$POOLS_RENAME":
@@ -69,18 +67,17 @@ export default function reducer(
 function defaults(next: Partial<Pool>, prev: Pool): Pool {
   // It would be nice to not need to keep this ingest state in the pool
   // object. An separate ingest reducer would be good.
-  const pool = brim.interop.poolPayloadToPool(next)
   const defaults = {min_time: {sec: 0, ns: 0}, max_time: {sec: 0, ns: 0}}
   const defaultIngest = {progress: null, warnings: []}
   const prevIngest = prev && prev.ingest
   return {
     ...defaults,
     ...prev,
-    ...pool,
+    ...next,
     ingest: {
       ...defaultIngest,
       ...prevIngest,
-      ...pool.ingest
+      ...next.ingest
     }
   }
 }

--- a/zealot/types.ts
+++ b/zealot/types.ts
@@ -69,8 +69,8 @@ export interface Ts {
 }
 
 export interface Span {
-  ts: BigInt
-  dur: BigInt
+  ts: bigint
+  dur: bigint
 }
 
 export interface PoolConfig {

--- a/zealot/zed/values/int64.ts
+++ b/zealot/zed/values/int64.ts
@@ -10,7 +10,7 @@ export class Int64 extends Primitive {
     return parseInt(this.value)
   }
 
-  toBigInt(): BigInt {
+  toBigInt(): bigint {
     return BigInt(this.value)
   }
 }


### PR DESCRIPTION
The `span` received from zealot contains `bigint`s. This seems like an appropriate way to type the data and also for Zealot as a generic js client to zed lake serve. However, Brim struggles with this data type since it does not readily de/serialize to JSON which the app requires whenever sending data over ipc. Since our global dispatch is backed by ipc calls, we must always send plain js in our actions, so this PR converts the bigints from the `/stats` call right after receiving the data, instead of right before saving it in redux. I also added some more explicit typing here to help protect the logic and readability.

Signed-off-by: Mason Fish <mason@brimsecurity.com>