### PR TITLE
Histogram span fix

### DIFF
--- a/app/search/flows/histogram-search.ts
+++ b/app/search/flows/histogram-search.ts
@@ -15,9 +15,11 @@ const id = "Histogram"
 export function histogramSearch(): Thunk<Promise<void>> {
   return (dispatch, getState) => {
     const state = getState()
-    const {program, spanArgs, pins} = Url.getSearchParams(state)
+    const {program, pins} = Url.getSearchParams(state)
+    const span = Url.getSpanParamsWithDefaults(state)
+    const from = brim.time(span[0]).toDate()
+    const to = brim.time(span[1]).toDate()
     const brimProgram = brim.program(program, pins)
-    const [from, to] = brim.span(spanArgs).toDateTuple()
     const query = addEveryCountProc(brimProgram.string(), [from, to])
     const poolId = Current.mustGetPool(state).id
     const {response, promise} = dispatch(search({id, query, from, to, poolId}))

--- a/src/js/components/charts/MainHistogram/format.ts
+++ b/src/js/components/charts/MainHistogram/format.ts
@@ -19,24 +19,23 @@ export default function(data: ChartData, span: DateTuple): HistogramData {
   } = data.keys.reduce((obj, path) => ({...obj, [path]: 0}), {})
 
   const bins = []
-  Object.keys(data.table).map((ms) => {
-    // Some data might be out of range
-    const ts = new Date(parseInt(ms))
-    if (ts >= span[0] && ts < span[1]) {
-      bins.push({
-        ts,
-        paths: {
-          ...defaults,
-          ...data.table[ms]
-        },
-        count: Object.values(data.table[ms]).reduce((c, sum) => sum + c, 0)
-      })
-    }
+  const times = Object.keys(data.table).map((ms) => {
+    const epochTs = parseInt(ms)
+    const ts = new Date(epochTs)
+    bins.push({
+      ts,
+      paths: {
+        ...defaults,
+        ...data.table[ms]
+      },
+      count: Object.values(data.table[ms]).reduce((c, sum) => sum + c, 0)
+    })
+    return epochTs
   })
-
+  const spanStart = new Date(Math.min(...times, span[0].getTime()))
   return {
     interval,
-    span,
+    span: [spanStart, span[1]],
     points: bins,
     keys: data.keys
   }

--- a/src/js/components/charts/MainHistogram/useMainHistogram.tsx
+++ b/src/js/components/charts/MainHistogram/useMainHistogram.tsx
@@ -112,7 +112,7 @@ export default function(width: number, height: number): HistogramChart {
       xScale: d3
         .scaleUtc()
         .range([0, innerWidth(width, margins)])
-        .domain(span),
+        .domain(data.span),
       pens
     }
   }, [chartData, status, span, innerSpan, width, height])


### PR DESCRIPTION
fixes #1699 

When we issue the histogram search to collect time-grouped counts by path, the first group's timestamp can be rounded down from the included span's start time. When the histogram then renders each group as a bar, it will be skipped because it will fall just outside of the span. This behavior is more obvious in the case when logs are concentrated into two dense groups which are then separated by a relatively large amount of time (in this case the first bar will not be rendered). The fix proposed here is to use the smallest value between the specified span start and the oldest histogram chart timestamp so that the histogram's representation adjusts for the rounding that occurs.

There was also a bug with the way span's were used as you clicked forward and back in the history where a stale span was being used instead of the most current one.
