### PR TITLE
Advance Brimcap dependency to tag v0.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8174,8 +8174,8 @@
       }
     },
     "brimcap": {
-      "version": "github:brimdata/brimcap#4c5f46485f063e815717f23d32dffba1673c0d12",
-      "from": "github:brimdata/brimcap#4c5f46485f063e815717f23d32dffba1673c0d12",
+      "version": "github:brimdata/brimcap#11a4b1b090bdee910dd345127c50b27f4d41a18a",
+      "from": "github:brimdata/brimcap#v0.0.5",
       "dev": true
     },
     "browser-process-hrtime": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "babel-plugin-inline-react-svg": "^1.1.1",
     "babel-plugin-module-resolver": "^4.0.0",
     "babel-plugin-source-map-support": "^2.1.2",
-    "brimcap": "brimdata/brimcap#4c5f46485f063e815717f23d32dffba1673c0d12",
+    "brimcap": "brimdata/brimcap#v0.0.5",
     "chalk": "^4.1.0",
     "commander": "^2.20.3",
     "cpx": "^1.5.0",


### PR DESCRIPTION
The ultimate motivation is to get the benefit of the fix in brimdata/brimcap#18.