### PR TITLE
Change "ZQD" ref to "Zed"

### DIFF
--- a/src/js/components/WorkspaceModals/ViewWorkspaceModal.tsx
+++ b/src/js/components/WorkspaceModals/ViewWorkspaceModal.tsx
@@ -160,7 +160,7 @@ const ViewWorkspace = ({onClose, onEdit}) => {
         </Status>
         <WorkspaceFields>
           <Field label="Host" value={[host, port].join(":")} />
-          <Field label="ZQD Version" value={version} />
+          <Field label="Zed Version" value={version} />
           <Field label="Pools" value={`${poolCount}`} />
         </WorkspaceFields>
       </StyledWorkspaceDetail>


### PR DESCRIPTION
While updating Brim docs, I noticed that there was still this "ZQD" reference in the "Get Info" modal for Workspaces. When fixed as it is in this branch, now it looks like:

![](https://user-images.githubusercontent.com/5934157/123168089-5a166a00-d42c-11eb-8f80-b83a9a7efb07.png)