### PR TITLE
Visualize a type value as a string

### DIFF
--- a/zealot/zed/types/base-primitive.ts
+++ b/zealot/zed/types/base-primitive.ts
@@ -1,0 +1,15 @@
+import {PrimitiveType, Value} from "zealot/zjson"
+
+export abstract class BasePrimitive<T> {
+  kind = "primitive"
+  abstract name: string
+  abstract create(value: Value, typedefs?: object): T
+
+  serialize(): PrimitiveType {
+    return {kind: "primitive", name: this.name}
+  }
+
+  toString() {
+    return this.name
+  }
+}

--- a/zealot/zed/types/type-alias.ts
+++ b/zealot/zed/types/type-alias.ts
@@ -39,4 +39,8 @@ export class TypeAlias implements ContainerTypeInterface {
   walkTypeValues(ctx: ZedContext, value: Value, visit) {
     ctx.walkTypeValues(this.type, value, visit)
   }
+
+  toString() {
+    return this.name + "=(" + this.type.toString() + ")"
+  }
 }

--- a/zealot/zed/types/type-array.ts
+++ b/zealot/zed/types/type-array.ts
@@ -42,4 +42,8 @@ export class TypeArray implements ContainerTypeInterface {
     if (isNull(value)) return
     value.map((v) => ctx.walkTypeValues(this.type, v, visit))
   }
+
+  toString() {
+    return "[" + this.type.toString() + "]"
+  }
 }

--- a/zealot/zed/types/type-bool.ts
+++ b/zealot/zed/types/type-bool.ts
@@ -1,14 +1,8 @@
 import {Bool} from "../values/bool"
-import {PrimitiveType} from "../../zjson"
-import {PrimitiveTypeInterface} from "./types"
+import {BasePrimitive} from "./base-primitive"
 
-class TypeOfBool implements PrimitiveTypeInterface<Bool> {
+class TypeOfBool extends BasePrimitive<Bool> {
   name = "bool"
-  kind = "primitive"
-
-  serialize(): PrimitiveType {
-    return {kind: "primitive", name: this.name}
-  }
 
   create(value: string) {
     return new Bool(value)

--- a/zealot/zed/types/type-bstring.ts
+++ b/zealot/zed/types/type-bstring.ts
@@ -1,14 +1,8 @@
 import {BString} from "../values/bstring"
-import {PrimitiveType} from "../../zjson"
-import {PrimitiveTypeInterface} from "./types"
+import {BasePrimitive} from "./base-primitive"
 
-class TypeOfBString implements PrimitiveTypeInterface<BString> {
+class TypeOfBString extends BasePrimitive<BString> {
   name = "bstring"
-  kind = "primitive"
-
-  serialize(): PrimitiveType {
-    return {kind: "primitive", name: this.name}
-  }
 
   create(value: string) {
     return new BString(value)

--- a/zealot/zed/types/type-bytes.ts
+++ b/zealot/zed/types/type-bytes.ts
@@ -1,14 +1,8 @@
 import {Bytes} from "../values/bytes"
-import {PrimitiveType} from "../../zjson"
-import {PrimitiveTypeInterface} from "./types"
+import {BasePrimitive} from "./base-primitive"
 
-class TypeOfBytes implements PrimitiveTypeInterface<Bytes> {
+class TypeOfBytes extends BasePrimitive<Bytes> {
   name = "bytes"
-  kind = "primitive"
-
-  serialize(): PrimitiveType {
-    return {kind: "primitive", name: this.name}
-  }
 
   create(value: string) {
     return new Bytes(value)

--- a/zealot/zed/types/type-duration.ts
+++ b/zealot/zed/types/type-duration.ts
@@ -1,14 +1,8 @@
 import {Duration} from "../values/duration"
-import {PrimitiveType} from "../../zjson"
-import {PrimitiveTypeInterface} from "./types"
+import {BasePrimitive} from "./base-primitive"
 
-class TypeOfDuration implements PrimitiveTypeInterface<Duration> {
+class TypeOfDuration extends BasePrimitive<Duration> {
   name = "duration"
-  kind = "primitive"
-
-  serialize(): PrimitiveType {
-    return {kind: "primitive", name: this.name}
-  }
 
   create(value: string) {
     return new Duration(value)

--- a/zealot/zed/types/type-error.ts
+++ b/zealot/zed/types/type-error.ts
@@ -1,14 +1,8 @@
-import {PrimitiveTypeInterface} from "./types"
 import {Error} from "../values/error"
-import {PrimitiveType} from "../../zjson"
+import {BasePrimitive} from "./base-primitive"
 
-class TypeOfError implements PrimitiveTypeInterface<Error> {
+class TypeOfError extends BasePrimitive<Error> {
   name = "error"
-  kind = "primitive"
-
-  serialize(): PrimitiveType {
-    return {kind: "primitive", name: this.name}
-  }
 
   create(value: string) {
     return new Error(value)

--- a/zealot/zed/types/type-float64.ts
+++ b/zealot/zed/types/type-float64.ts
@@ -1,14 +1,8 @@
 import {Float64} from "../values/float64"
-import {PrimitiveType} from "../../zjson"
-import {PrimitiveTypeInterface} from "./types"
+import {BasePrimitive} from "./base-primitive"
 
-class TypeOfFloat64 implements PrimitiveTypeInterface<Float64> {
+class TypeOfFloat64 extends BasePrimitive<Float64> {
   name = "float64"
-  kind = "primitive"
-
-  serialize(): PrimitiveType {
-    return {kind: "primitive", name: this.name}
-  }
 
   create(value) {
     return new Float64(value)

--- a/zealot/zed/types/type-int16.ts
+++ b/zealot/zed/types/type-int16.ts
@@ -1,14 +1,8 @@
 import {Int16} from "../values/int16"
-import {PrimitiveType} from "../../zjson"
-import {PrimitiveTypeInterface} from "./types"
+import {BasePrimitive} from "./base-primitive"
 
-class TypeOfInt16 implements PrimitiveTypeInterface<Int16> {
+class TypeOfInt16 extends BasePrimitive<Int16> {
   name = "int16"
-  kind = "primitive"
-
-  serialize(): PrimitiveType {
-    return {kind: "primitive", name: this.name}
-  }
 
   create(value) {
     return new Int16(value)

--- a/zealot/zed/types/type-int32.ts
+++ b/zealot/zed/types/type-int32.ts
@@ -1,14 +1,8 @@
 import {Int32} from "../values/int32"
-import {PrimitiveType} from "../../zjson"
-import {PrimitiveTypeInterface} from "./types"
+import {BasePrimitive} from "./base-primitive"
 
-class TypeOfInt32 implements PrimitiveTypeInterface<Int32> {
+class TypeOfInt32 extends BasePrimitive<Int32> {
   name = "int32"
-  kind = "primitive"
-
-  serialize(): PrimitiveType {
-    return {kind: "primitive", name: this.name}
-  }
 
   create(value) {
     return new Int32(value)

--- a/zealot/zed/types/type-int64.ts
+++ b/zealot/zed/types/type-int64.ts
@@ -1,14 +1,8 @@
 import {Int64} from "../values/int64"
-import {PrimitiveType} from "../../zjson"
-import {PrimitiveTypeInterface} from "./types"
+import {BasePrimitive} from "./base-primitive"
 
-class TypeOfInt64 implements PrimitiveTypeInterface<Int64> {
+class TypeOfInt64 extends BasePrimitive<Int64> {
   name = "int64"
-  kind = "primitive"
-
-  serialize(): PrimitiveType {
-    return {kind: "primitive", name: this.name}
-  }
 
   create(value) {
     return new Int64(value)

--- a/zealot/zed/types/type-int8.ts
+++ b/zealot/zed/types/type-int8.ts
@@ -1,14 +1,8 @@
 import {Int8} from "../values/int8"
-import {PrimitiveType} from "../../zjson"
-import {PrimitiveTypeInterface} from "./types"
+import {BasePrimitive} from "./base-primitive"
 
-class TypeOfInt8 implements PrimitiveTypeInterface<Int8> {
+class TypeOfInt8 extends BasePrimitive<Int8> {
   name = "int8"
-  kind = "primitive"
-
-  serialize(): PrimitiveType {
-    return {kind: "primitive", name: this.name}
-  }
 
   create(value) {
     return new Int8(value)

--- a/zealot/zed/types/type-ip.ts
+++ b/zealot/zed/types/type-ip.ts
@@ -1,14 +1,8 @@
 import {Ip} from "../values/ip"
-import {PrimitiveType} from "../../zjson"
-import {PrimitiveTypeInterface} from "./types"
+import {BasePrimitive} from "./base-primitive"
 
-class TypeOfIp implements PrimitiveTypeInterface<Ip> {
+class TypeOfIp extends BasePrimitive<Ip> {
   name = "ip"
-  kind = "primitive"
-
-  serialize(): PrimitiveType {
-    return {kind: "primitive", name: this.name}
-  }
 
   create(value: string) {
     return new Ip(value)

--- a/zealot/zed/types/type-map.ts
+++ b/zealot/zed/types/type-map.ts
@@ -43,4 +43,8 @@ export class TypeMap implements ContainerTypeInterface {
     ctx.walkTypeValues(this.keyType, key, visit)
     ctx.walkTypeValues(this.valType, val, visit)
   }
+
+  toString() {
+    return "|{" + this.keyType.toString() + "," + this.valType.toString() + "}|"
+  }
 }

--- a/zealot/zed/types/type-net.ts
+++ b/zealot/zed/types/type-net.ts
@@ -1,14 +1,8 @@
 import {Net} from "../values/net"
-import {PrimitiveType} from "../../zjson"
-import {PrimitiveTypeInterface} from "./types"
+import {BasePrimitive} from "./base-primitive"
 
-class TypeOfNet implements PrimitiveTypeInterface<Net> {
+class TypeOfNet extends BasePrimitive<Net> {
   name = "net"
-  kind = "primitive"
-
-  serialize(): PrimitiveType {
-    return {kind: "primitive", name: this.name}
-  }
 
   create(value: string) {
     return new Net(value)

--- a/zealot/zed/types/type-null.ts
+++ b/zealot/zed/types/type-null.ts
@@ -1,14 +1,8 @@
 import {Null} from "../values/null"
-import {PrimitiveType} from "../../zjson"
-import {PrimitiveTypeInterface} from "./types"
+import {BasePrimitive} from "./base-primitive"
 
-class TypeOfNull implements PrimitiveTypeInterface<Null> {
+class TypeOfNull extends BasePrimitive<Null> {
   name = "null"
-  kind = "primitive"
-
-  serialize(): PrimitiveType {
-    return {kind: "primitive", name: this.name}
-  }
 
   create(_value: any) {
     return new Null()

--- a/zealot/zed/types/type-record.ts
+++ b/zealot/zed/types/type-record.ts
@@ -1,5 +1,5 @@
 import {isNull} from "../utils"
-import {RecordType, Value} from "../../zjson"
+import {RecordFieldType, RecordType, Value} from "../../zjson"
 import {ZedContext} from "../context"
 import {typeId} from "../utils"
 import {Field} from "../values/field"
@@ -18,13 +18,25 @@ export class TypeRecord implements ContainerTypeInterface {
     this.fields = fields
   }
 
-  static stringify(fields) {
+  static stringify(fields: RecordFieldType[] | null) {
     if (isNull(fields)) return "null"
     let s = "{"
     let sep = ""
     fields.forEach((f) => {
       // XXX need to check if name has funny chars
       s += sep + f.name + ":" + typeId(f.type)
+      sep = ","
+    })
+    s += "}"
+    return s
+  }
+
+  toString() {
+    if (isNull(this.fields)) return "null"
+    let s = "{"
+    let sep = ""
+    this.fields.forEach((f) => {
+      s += sep + f.name + ":" + f.type.toString()
       sep = ","
     })
     s += "}"

--- a/zealot/zed/types/type-set.ts
+++ b/zealot/zed/types/type-set.ts
@@ -39,4 +39,8 @@ export class TypeSet implements ContainerTypeInterface {
     if (isNull(value)) return
     value.forEach((v) => ctx.walkTypeValues(this.type, v, visit))
   }
+
+  toString() {
+    return `|[` + this.type.toString() + `]|`
+  }
 }

--- a/zealot/zed/types/type-string.ts
+++ b/zealot/zed/types/type-string.ts
@@ -1,13 +1,8 @@
-import {PrimitiveTypeInterface} from "./types"
 import {String} from "../values/string"
-import {PrimitiveType} from "../../zjson"
-class TypeOfString implements PrimitiveTypeInterface<String> {
+import {BasePrimitive} from "./base-primitive"
+class TypeOfString extends BasePrimitive<String> {
   name = "string"
-  kind = "primitive"
 
-  serialize(): PrimitiveType {
-    return {kind: "primitive", name: this.name}
-  }
   create(value: string) {
     return new String(value)
   }

--- a/zealot/zed/types/type-time.ts
+++ b/zealot/zed/types/type-time.ts
@@ -1,14 +1,8 @@
 import {Time} from "../values/time"
-import {PrimitiveType} from "../../zjson"
-import {PrimitiveTypeInterface} from "./types"
+import {BasePrimitive} from "./base-primitive"
 
-class TypeOfTime implements PrimitiveTypeInterface<Time> {
+class TypeOfTime extends BasePrimitive<Time> {
   name = "time"
-  kind = "primitive"
-
-  serialize(): PrimitiveType {
-    return {kind: "primitive", name: this.name}
-  }
 
   create(value: string) {
     return new Time(value)

--- a/zealot/zed/types/type-type.ts
+++ b/zealot/zed/types/type-type.ts
@@ -1,15 +1,9 @@
 import {isNull} from "../utils"
 import {TypeValue} from "../values/type"
-import {PrimitiveType} from "../../zjson"
-import {PrimitiveTypeInterface} from "./types"
+import {BasePrimitive} from "./base-primitive"
 
-export class TypeOfType implements PrimitiveTypeInterface<TypeValue> {
+export class TypeOfType extends BasePrimitive<TypeValue> {
   name = "type"
-  kind = "primitive"
-
-  serialize(): PrimitiveType {
-    return {kind: "primitive", name: this.name}
-  }
 
   create(value: string | null, typedefs) {
     if (isNull(value)) {

--- a/zealot/zed/types/type-typename.ts
+++ b/zealot/zed/types/type-typename.ts
@@ -1,14 +1,8 @@
 import {Typename} from "../values/typename"
-import {PrimitiveType} from "../../zjson"
-import {PrimitiveTypeInterface} from "./types"
+import {BasePrimitive} from "./base-primitive"
 
-class TypeOfTypename implements PrimitiveTypeInterface<Typename> {
+class TypeOfTypename extends BasePrimitive<Typename> {
   name = "typename"
-  kind = "primitive"
-
-  serialize(): PrimitiveType {
-    return {kind: "primitive", name: this.name}
-  }
 
   create(value: string) {
     return new Typename(value)

--- a/zealot/zed/types/type-uint16.ts
+++ b/zealot/zed/types/type-uint16.ts
@@ -1,21 +1,11 @@
 import {Uint16} from "../values/uint16"
-import {PrimitiveType} from "../../zjson"
-import {PrimitiveTypeInterface} from "./types"
+import {BasePrimitive} from "./base-primitive"
 
-class TypeOfUint16 implements PrimitiveTypeInterface<Uint16> {
+class TypeOfUint16 extends BasePrimitive<Uint16> {
   name = "uint16"
-  kind = "primitive"
-
-  serialize(): PrimitiveType {
-    return {kind: "primitive", name: this.name}
-  }
 
   create(value) {
     return new Uint16(value)
-  }
-
-  stringify() {
-    return this.name
   }
 }
 

--- a/zealot/zed/types/type-uint32.ts
+++ b/zealot/zed/types/type-uint32.ts
@@ -1,14 +1,8 @@
 import {Uint32} from "../values/uint32"
-import {PrimitiveType} from "../../zjson"
-import {PrimitiveTypeInterface} from "./types"
+import {BasePrimitive} from "./base-primitive"
 
-class TypeOfUint32 implements PrimitiveTypeInterface<Uint32> {
+class TypeOfUint32 extends BasePrimitive<Uint32> {
   name = "uint32"
-  kind = "primitive"
-
-  serialize(): PrimitiveType {
-    return {kind: "primitive", name: this.name}
-  }
 
   create(value) {
     return new Uint32(value)

--- a/zealot/zed/types/type-uint64.ts
+++ b/zealot/zed/types/type-uint64.ts
@@ -1,14 +1,8 @@
 import {Uint64} from "../values/uint64"
-import {PrimitiveType} from "../../zjson"
-import {PrimitiveTypeInterface} from "./types"
+import {BasePrimitive} from "./base-primitive"
 
-class TypeOfUint64 implements PrimitiveTypeInterface<Uint64> {
+class TypeOfUint64 extends BasePrimitive<Uint64> {
   name = "uint64"
-  kind = "primitive"
-
-  serialize(): PrimitiveType {
-    return {kind: "primitive", name: this.name}
-  }
 
   create(value) {
     return new Uint64(value)

--- a/zealot/zed/types/type-uint8.ts
+++ b/zealot/zed/types/type-uint8.ts
@@ -1,14 +1,8 @@
 import {Uint8} from "../values/uint8"
-import {PrimitiveType} from "../../zjson"
-import {PrimitiveTypeInterface} from "./types"
+import {BasePrimitive} from "./base-primitive"
 
-class TypeOfUint8 implements PrimitiveTypeInterface<Uint8> {
+class TypeOfUint8 extends BasePrimitive<Uint8> {
   name = "uint8"
-  kind = "primitive"
-
-  serialize(): PrimitiveType {
-    return {kind: "primitive", name: this.name}
-  }
 
   create(value) {
     return new Uint8(value)

--- a/zealot/zed/types/type-union.ts
+++ b/zealot/zed/types/type-union.ts
@@ -46,4 +46,8 @@ export class TypeUnion implements ContainerTypeInterface {
 
     if (value === null) ctx.walkTypeValue(innerType, innerValue, visit)
   }
+
+  toString() {
+    return `(${this.types.map((t) => t.toString()).join(",")})`
+  }
 }

--- a/zealot/zed/types/types.ts
+++ b/zealot/zed/types/types.ts
@@ -1,6 +1,6 @@
+import {Type, Value} from "../../zjson"
 import {ZedContext} from "../context"
 import {ZedValue} from "../values/types"
-import {PrimitiveType, Type, Value} from "../../zjson"
 import {TypeAlias} from "./type-alias"
 import {TypeArray} from "./type-array"
 import {TypeMap} from "./type-map"
@@ -17,14 +17,6 @@ export type ZedType =
   | TypeUnion
   | TypeMap
   | TypeAlias
-
-export interface PrimitiveTypeInterface<T> {
-  name: string
-  kind: string
-  serialize(): PrimitiveType
-  create(value: Value, typedefs?: object): T
-  toString(): string
-}
 
 export interface ContainerTypeInterface {
   serialize(typedefs: object): Type

--- a/zealot/zed/values/type.ts
+++ b/zealot/zed/values/type.ts
@@ -14,7 +14,7 @@ export class TypeValue {
 
   toString() {
     if (isNull(this.value)) return "null"
-    return this.value.toString()
+    return "(" + this.value.toString() + ")"
   }
 
   serialize() {


### PR DESCRIPTION
This is a case where we are using a "type" as a "value". That means we need to visually represent a "type" in a cell in the viewer. I looked at what zq does for this and tried to copy.

```
{
    _path: "ssl",
    typeof: ({_path:string,ts:time,uid:bstring,id:{orig_h:ip,orig_p:port=(uint16),resp_h:ip,resp_p:port},version:bstring,cipher:bstring,curve:bstring,server_name:bstring,resumed:bool,last_alert:bstring,next_protocol:bstring,established:bool,cert_chain_fuids:[bstring],client_cert_chain_fuids:[bstring],subject:bstring,issuer:bstring,client_subject:bstring,client_issuer:bstring,validation_status:bstring,ja3:bstring,ja3s:bstring})
}
```

To implement this, I've added a `toString()` method to every zed type. I also created an abstract `BasePrimitive<T>` class to represent the expected interface of a primitive type, and to implement 2 methods that are the same for all primitives (`toString()` and `serialize()`).

![image](https://user-images.githubusercontent.com/3460638/124673103-20525400-de6d-11eb-8689-58b3178cb018.png)

fixes #1725 