### PR TITLE
Refresh with new span

### DIFF
--- a/src/js/components/CommitNotification.tsx
+++ b/src/js/components/CommitNotification.tsx
@@ -8,6 +8,7 @@ import Current from "../state/Current"
 import {useHistory} from "react-router"
 import {SpanArgs} from "../state/Search/types"
 import {decodeSearchParams} from "../../../app/search/utils/search-params"
+import {Span} from "../brim"
 
 export default function CommitNotification() {
   const dispatch = useDispatch()
@@ -34,7 +35,13 @@ export default function CommitNotification() {
         const [from, to] = currentSpan
         const [newFrom, newTo] = JSON.parse(fullSpan)
 
-        if (!from || !to || JSON.stringify(currentSpan) === prevFullSpan) {
+        // if user had not searched at all, searched using the empty pool span
+        // default, or had searched using the previous pool's full span, then
+        // we will load up the 'refresh' button's search with the new full span
+        if (
+          isEmptySpan(currentSpan) ||
+          JSON.stringify(currentSpan) === prevFullSpan
+        ) {
           setNewSpan([newFrom, newTo])
           return
         }
@@ -68,4 +75,11 @@ export default function CommitNotification() {
       <XButton onClick={() => onClick(1)} />
     </InfoNotice>
   )
+}
+
+const isEmptySpan = (span: Partial<SpanArgs>) => {
+  if (!span || span.length !== 2) return true
+  const [from, to] = span as Span
+  if (!from || !to) return true
+  return from.sec === 0 && from.ns === 0 && to.sec === 0 && to.ns === 1000000
 }


### PR DESCRIPTION
fixes #1728 

@jameskerr and I discussed this a bit and decided that an even better fix would be to add a new "empty pool" page which would not present any of the toolbar/searchbar/span-picker tools we currently show since those are not of any use on an empty pool anyway, and instead would assist users with how to ingest data into their empty pool. Much like github does for empty repositories.

In the meantime, however, here is a quick fix that simply checks if the last search's span is the empty span default that we set for empty pools (which is the first milisecond of unix time/1970), and if it is then we will use the fresh full span of the now-populated pool instead.   

Signed-off-by: Mason Fish <mason@brimsecurity.com>