### PR TITLE
Advance Brimcap dependency to tag v0.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8174,8 +8174,8 @@
       }
     },
     "brimcap": {
-      "version": "github:brimdata/brimcap#6c529304b3a2c5d044be4defb5c01502f8d000e3",
-      "from": "github:brimdata/brimcap#6c529304b3a2c5d044be4defb5c01502f8d000e3",
+      "version": "github:brimdata/brimcap#30aaa45feb3bb477a984b091dc8391e876e21b5a",
+      "from": "github:brimdata/brimcap#v0.0.6",
       "dev": true
     },
     "browser-process-hrtime": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "babel-plugin-inline-react-svg": "^1.1.1",
     "babel-plugin-module-resolver": "^4.0.0",
     "babel-plugin-source-map-support": "^2.1.2",
-    "brimcap": "brimdata/brimcap#6c529304b3a2c5d044be4defb5c01502f8d000e3",
+    "brimcap": "brimdata/brimcap#v0.0.6",
     "chalk": "^4.1.0",
     "commander": "^2.20.3",
     "cpx": "^1.5.0",


### PR DESCRIPTION
The last step before cutting a new Brim beta release.