### PR TITLE
ConfigValueProp defaults

### DIFF
--- a/src/js/api/ui-apis.ts
+++ b/src/js/api/ui-apis.ts
@@ -24,5 +24,19 @@ export class ConfigsApi {
 
   add(config: Config) {
     this.dispatch(Configs.set(config))
+    // Set the defaults values if there are any
+    for (let name in config.properties) {
+      const prop = config.properties[name]
+      const exists = this.get(config.name, name)
+      if (exists === undefined && "defaultValue" in prop) {
+        this.dispatch(
+          ConfigPropValues.set({
+            configName: config.name,
+            propName: name,
+            value: prop.defaultValue
+          })
+        )
+      }
+    }
   }
 }

--- a/src/js/api/ui-apis.ts
+++ b/src/js/api/ui-apis.ts
@@ -24,7 +24,7 @@ export class ConfigsApi {
 
   add(config: Config) {
     this.dispatch(Configs.set(config))
-    // Set the defaults values if there are any
+    // Set default values if there are any unset values
     for (let name in config.properties) {
       const prop = config.properties[name]
       const exists = this.get(config.name, name)

--- a/src/js/components/Preferences/Preferences.tsx
+++ b/src/js/components/Preferences/Preferences.tsx
@@ -22,7 +22,6 @@ import Link from "../common/Link"
 function ConfigFormItems(props: {configs: FormConfig}) {
   const {configs} = props
   if (!configs) return null
-
   const configVals = useSelector(ConfigPropValues.all)
 
   const formInputs = Object.values(configs).map((c) => {
@@ -47,6 +46,7 @@ function ConfigFormItems(props: {configs: FormConfig}) {
       </InputLabel>
     )
 
+    const val = get(configVals, [c.configName, c.name], undefined)
     switch (c.type) {
       case "file":
         return (
@@ -54,11 +54,7 @@ function ConfigFormItems(props: {configs: FormConfig}) {
             {itemLabel}
             <FileInput
               name={name}
-              defaultValue={
-                get(configVals, [c.configName, c.name], "") ||
-                defaultValue ||
-                ""
-              }
+              defaultValue={val === undefined ? defaultValue : val}
               placeholder="default"
             />
           </div>
@@ -70,8 +66,8 @@ function ConfigFormItems(props: {configs: FormConfig}) {
             <TextInput
               name={name}
               type="text"
-              placeholder="default"
-              defaultValue={defaultValue}
+              placeholder=""
+              defaultValue={val === undefined ? defaultValue : val}
             />
           </div>
         )

--- a/src/js/state/ConfigPropValues/index.ts
+++ b/src/js/state/ConfigPropValues/index.ts
@@ -32,8 +32,11 @@ const slice = createSlice({
 export default {
   reducer: slice.reducer,
   ...slice.actions,
-  get: (configName, propName) => ({configPropValues: state}) => {
-    if (!state[configName]) return null
+  get: (configName: string, propName?: string) => ({
+    configPropValues: state
+  }) => {
+    if (!state[configName]) return undefined
+    if (!propName) return state[configName]
     return state[configName][propName]
   },
   all: (state) => state.configPropValues

--- a/src/js/state/ConfigPropValues/test.ts
+++ b/src/js/state/ConfigPropValues/test.ts
@@ -106,5 +106,7 @@ test("Delete", () => {
 
   const all = select(ConfigPropValues.all)
   expect(Object.keys(all)).toHaveLength(0)
-  expect(select(ConfigPropValues.get(configName1, configProperty1))).toBeNull()
+  expect(select(ConfigPropValues.get(configName1, configProperty1))).toBe(
+    undefined
+  )
 })


### PR DESCRIPTION
I needed to adjust some of the way we get and set config values to implement #1724 .

1. When "getting" a config value, if the key is not set, return undefined instead of null. We were previously sometimes returning null, and other times undefined.

2. When adding config properties, loop through them at startup and set the value to the defaultValue, if there is no value already present.

