### PR TITLE
Display Preferences

### DIFF
--- a/app/core/format.ts
+++ b/app/core/format.ts
@@ -2,21 +2,27 @@ import * as d3 from "d3"
 import brim from "src/js/brim"
 import {zed} from "zealot"
 
-export function formatPrimitive(data: zed.Primitive, config: object) {
+export type FormatConfig = {
+  thousands: string
+}
+
+export function formatPrimitive(
+  data: zed.Primitive,
+  config: Partial<FormatConfig> = {}
+) {
   if (data.isUnset()) return "⦻"
   if (zed.isNamed(data.type, "port")) return data.toString()
-  if (zed.isInt(data)) return formatInt(data.toString(), config)
+  if (zed.isInt(data)) return formatInt(data.toInt(), config)
   if (zed.isTime(data)) return brim.time(data.toDate()).format()
   return data.toString()
 }
 
-export function formatInt(string: string, config = {}) {
+export function formatInt(string: number, config: Partial<FormatConfig> = {}) {
   const locale = d3.formatLocale({
     decimal: ".",
-    thousands: config.thousandsSeparator || ",",
+    thousands: config.thousands || ",",
     grouping: [3],
     currency: ["", "$"],
-    minus: "\u2212",
     percent: "\u202f%"
   })
   return locale.format(",")(string)

--- a/app/core/formatters/format-zed.ts
+++ b/app/core/formatters/format-zed.ts
@@ -1,11 +1,23 @@
+import * as d3 from "d3"
 import brim from "src/js/brim"
-import {withCommas} from "src/js/lib/fmt"
 import {zed} from "zealot"
 
-export function formatPrimitive(data: zed.Primitive) {
+export function formatPrimitive(data: zed.Primitive, config: object) {
   if (data.isUnset()) return "⦻"
   if (zed.isNamed(data.type, "port")) return data.toString()
-  if (zed.isInt(data)) return withCommas(data.toString())
+  if (zed.isInt(data)) return formatInt(data.toString(), config)
   if (zed.isTime(data)) return brim.time(data.toDate()).format()
   return data.toString()
+}
+
+export function formatInt(string: string, config = {}) {
+  const locale = d3.formatLocale({
+    decimal: ".",
+    thousands: config.thousandsSeparator || ",",
+    grouping: [3],
+    currency: ["", "$"],
+    minus: "\u2212",
+    percent: "\u202f%"
+  })
+  return locale.format(",")(string)
 }

--- a/app/detail/Fields.tsx
+++ b/app/detail/Fields.tsx
@@ -1,5 +1,5 @@
 import {Data, Name, Value} from "app/core/Data"
-import {formatPrimitive} from "app/core/formatters/format-zed"
+import {formatPrimitive} from "app/core/format"
 import {typeClassNames} from "app/core/utils/type-class-names"
 import React, {memo, useCallback, useMemo, useState} from "react"
 import {useDispatch} from "react-redux"

--- a/app/detail/Fields.tsx
+++ b/app/detail/Fields.tsx
@@ -1,5 +1,5 @@
 import {Data, Name, Value} from "app/core/Data"
-import {formatPrimitive} from "app/core/format"
+import {useZedFormatter} from "app/core/format"
 import {typeClassNames} from "app/core/utils/type-class-names"
 import React, {memo, useCallback, useMemo, useState} from "react"
 import {useDispatch} from "react-redux"
@@ -18,12 +18,14 @@ type DTProps = {
   fields: zed.Field[]
   onRightClick: (f: zed.Field) => void
   onHover: (f: zed.Field) => void
+  format: (f: zed.Primitive) => string
 }
 
 const DataPanel = React.memo<DTProps>(function DataTable({
   fields,
   onRightClick,
-  onHover
+  onHover,
+  format
 }: DTProps) {
   return (
     <Panel>
@@ -36,7 +38,7 @@ const DataPanel = React.memo<DTProps>(function DataTable({
             className={typeClassNames(field.data)}
             onContextMenu={() => onRightClick(field)}
           >
-            {formatPrimitive(field.data as zed.Primitive)}
+            {format(field.data as zed.Primitive)}
           </Value>
         </Data>
       ))}
@@ -72,7 +74,7 @@ function Tooltip({field, record}) {
 export default memo(function Fields({record}: Props) {
   const dispatch = useDispatch()
   const [hovered, setHovered] = useState({name: "", type: ""})
-
+  const format = useZedFormatter()
   const onHover = useCallback((field) => {
     setHovered(field)
   }, [])
@@ -91,6 +93,7 @@ export default memo(function Fields({record}: Props) {
     <section>
       <PanelHeading>Fields</PanelHeading>
       <DataPanel
+        format={format}
         fields={fields}
         onRightClick={onRightClick}
         onHover={onHover}

--- a/app/viewer/measure.ts
+++ b/app/viewer/measure.ts
@@ -1,4 +1,4 @@
-import {formatPrimitive} from "app/core/format"
+import {FormatConfig, formatPrimitive} from "app/core/format"
 import {isEventType} from "ppl/suricata/suricata-plugin"
 import {isPath} from "ppl/zeek/zeek-plugin"
 import {zed} from "zealot"
@@ -16,10 +16,16 @@ export function estimateHeaderWidth(name: string) {
   return Math.min(MAX_WIDTH, width)
 }
 
-export function estimateCellWidth(value: zed.AnyValue, name: string) {
+export function estimateCellWidth(
+  value: zed.AnyValue,
+  name: string,
+  config: Partial<FormatConfig>
+) {
   let width = MIN_WIDTH
   if (value instanceof zed.Primitive) {
-    width = Math.ceil(formatPrimitive(value).length * ONE_CHAR + CELL_PAD)
+    width = Math.ceil(
+      formatPrimitive(value, config).length * ONE_CHAR + CELL_PAD
+    )
   } else {
     width = Math.ceil(value.toString().length * ONE_CHAR + CELL_PAD)
   }

--- a/app/viewer/measure.ts
+++ b/app/viewer/measure.ts
@@ -1,4 +1,4 @@
-import {formatPrimitive} from "app/core/formatters/format-zed"
+import {formatPrimitive} from "app/core/format"
 import {isEventType} from "ppl/suricata/suricata-plugin"
 import {isPath} from "ppl/zeek/zeek-plugin"
 import {zed} from "zealot"

--- a/app/viewer/value.tsx
+++ b/app/viewer/value.tsx
@@ -5,8 +5,9 @@ import searchFieldContextMenu from "ppl/menus/searchFieldContextMenu"
 import {isEventType, SuricataEventType} from "ppl/suricata/suricata-plugin"
 import {isPath, ZeekPath} from "ppl/zeek/zeek-plugin"
 import React, {Fragment} from "react"
-import {useDispatch} from "react-redux"
+import {useDispatch, useSelector} from "react-redux"
 import {cssVar} from "src/js/lib/cssVar"
+import ConfigPropValues from "src/js/state/ConfigPropValues"
 import styled from "styled-components"
 import {zed} from "zealot"
 
@@ -32,6 +33,7 @@ type ValueProps = {
   record: zed.Record
   padBefore?: boolean
   padAfter?: boolean
+  displayConfig: object
 }
 
 const Space = styled.span`
@@ -82,7 +84,7 @@ function renderValue(props) {
   } else if (isEventType(props.field)) {
     return <SuricataEventType {...props} />
   } else {
-    return formatPrimitive(props.value as zed.Primitive)
+    return formatPrimitive(props.value as zed.Primitive, props.displayConfig)
   }
 }
 

--- a/app/viewer/value.tsx
+++ b/app/viewer/value.tsx
@@ -1,13 +1,12 @@
-import {formatPrimitive} from "app/core/format"
+import {useZedFormatter} from "app/core/format"
 import {typeClassNames} from "app/core/utils/type-class-names"
 import {transparentize} from "polished"
 import searchFieldContextMenu from "ppl/menus/searchFieldContextMenu"
 import {isEventType, SuricataEventType} from "ppl/suricata/suricata-plugin"
 import {isPath, ZeekPath} from "ppl/zeek/zeek-plugin"
 import React, {Fragment} from "react"
-import {useDispatch, useSelector} from "react-redux"
+import {useDispatch} from "react-redux"
 import {cssVar} from "src/js/lib/cssVar"
-import ConfigPropValues from "src/js/state/ConfigPropValues"
 import styled from "styled-components"
 import {zed} from "zealot"
 
@@ -56,6 +55,7 @@ export default function Value(props: ValueProps) {
 
 export function PrimitiveValue(props: ValueProps) {
   const dispatch = useDispatch()
+  const format = useZedFormatter()
   const fillCell = props.field.value === props.value // This is the only value in the cell
   return (
     <BG
@@ -72,19 +72,19 @@ export function PrimitiveValue(props: ValueProps) {
       }
     >
       {pad(props.padBefore)}
-      {renderValue(props)}
+      {renderValue(props, format)}
       {pad(props.padAfter)}
     </BG>
   )
 }
 
-function renderValue(props) {
+function renderValue(props, format) {
   if (isPath(props.field)) {
     return <ZeekPath {...props} />
   } else if (isEventType(props.field)) {
     return <SuricataEventType {...props} />
   } else {
-    return formatPrimitive(props.value as zed.Primitive, props.displayConfig)
+    return format(props.value as zed.Primitive)
   }
 }
 

--- a/app/viewer/value.tsx
+++ b/app/viewer/value.tsx
@@ -1,4 +1,4 @@
-import {formatPrimitive} from "app/core/formatters/format-zed"
+import {formatPrimitive} from "app/core/format"
 import {typeClassNames} from "app/core/utils/type-class-names"
 import {transparentize} from "polished"
 import searchFieldContextMenu from "ppl/menus/searchFieldContextMenu"

--- a/plugins/core/index.ts
+++ b/plugins/core/index.ts
@@ -1,0 +1,18 @@
+import BrimApi from "src/js/api"
+
+export function activate(api: BrimApi) {
+  api.configs.add({
+    name: "display",
+    title: "Number Formats",
+    properties: {
+      thousandsSeparator: {
+        name: "thousandsSeparator",
+        label: "Thousands Separator",
+        type: "string",
+        defaultValue: ","
+      }
+    }
+  })
+}
+
+export function deactivate() {}

--- a/src/js/components/FieldCell.tsx
+++ b/src/js/components/FieldCell.tsx
@@ -1,4 +1,4 @@
-import {formatPrimitive} from "app/core/formatters/format-zed"
+import {formatPrimitive} from "app/core/format"
 import {typeClassNames} from "app/core/utils/type-class-names"
 import classNames from "classnames"
 import React from "react"

--- a/src/js/components/FieldCell.tsx
+++ b/src/js/components/FieldCell.tsx
@@ -1,4 +1,4 @@
-import {formatPrimitive} from "app/core/format"
+import {useZedFormatter} from "app/core/format"
 import {typeClassNames} from "app/core/utils/type-class-names"
 import classNames from "classnames"
 import React from "react"
@@ -17,6 +17,7 @@ function getBackground(field, record) {
 }
 
 export default function FieldCell({field, record}: Props) {
+  const format = useZedFormatter()
   return (
     <div
       className={classNames(
@@ -26,7 +27,7 @@ export default function FieldCell({field, record}: Props) {
         getBackground(field, record)
       )}
     >
-      {formatPrimitive(field.data as zed.Primitive)}
+      {format(field.data as zed.Primitive)}
     </div>
   )
 }

--- a/src/js/components/LogRow.tsx
+++ b/src/js/components/LogRow.tsx
@@ -9,6 +9,7 @@ import {ViewerDimens} from "../types"
 import * as Styler from "./Viewer/Styler"
 
 type Props = {
+  displayConfig: object
   dimens: ViewerDimens
   highlight: boolean
   index: number
@@ -31,6 +32,7 @@ const LogRow = (props: Props) => {
       return (
         <Cell width={width} key={key} name={field.name}>
           <Value
+            displayConfig={props.displayConfig}
             value={field.value}
             field={field}
             record={log}
@@ -63,6 +65,7 @@ export default memo<Props>(LogRow, (prevProps: Props, nextProps: Props) => {
     prevProps.highlight === nextProps.highlight &&
     prevProps.dimens.rowWidth === nextProps.dimens.rowWidth &&
     prevProps.timeZone === nextProps.timeZone &&
-    prevProps.timeFormat === nextProps.timeFormat
+    prevProps.timeFormat === nextProps.timeFormat &&
+    prevProps.displayConfig === nextProps.displayConfig
   )
 })

--- a/src/js/components/Preferences/Preferences.test.tsx
+++ b/src/js/components/Preferences/Preferences.test.tsx
@@ -1,0 +1,9 @@
+import {render} from "test/unit/helpers"
+import {setupBrim} from "test/unit/helpers/setup-brim"
+import Preferences from "./Preferences"
+
+const brim = setupBrim({page: "search"})
+
+test("render preferences", async () => {
+  render(<Preferences />, {store: brim.store})
+})

--- a/src/js/components/Preferences/usePreferencesForm.ts
+++ b/src/js/components/Preferences/usePreferencesForm.ts
@@ -20,7 +20,7 @@ const checkFile = (path) => {
 export const useConfigsForm = (): FormConfig => {
   const dispatch = useDispatch()
   const configs = useSelector(Configs.all)
-
+  console.log(configs)
   const formConfig: FormConfig = {}
   configs.forEach((config) => {
     Object.values(config.properties).forEach((prop) => {

--- a/src/js/components/Preferences/usePreferencesForm.ts
+++ b/src/js/components/Preferences/usePreferencesForm.ts
@@ -20,7 +20,6 @@ const checkFile = (path) => {
 export const useConfigsForm = (): FormConfig => {
   const dispatch = useDispatch()
   const configs = useSelector(Configs.all)
-  console.log(configs)
   const formConfig: FormConfig = {}
   configs.forEach((config) => {
     Object.values(config.properties).forEach((prop) => {

--- a/src/js/components/SearchResults/ResultsTable.tsx
+++ b/src/js/components/SearchResults/ResultsTable.tsx
@@ -1,7 +1,7 @@
 import nextPageViewerSearch from "app/search/flows/next-page-viewer-search"
 import {isEmpty} from "lodash"
 import React, {useEffect} from "react"
-import {connect, useDispatch} from "react-redux"
+import {connect, useDispatch, useSelector} from "react-redux"
 import {zed} from "zealot"
 import {openLogDetailsWindow} from "../../flows/openLogDetailsWindow"
 import {viewLogDetail} from "../../flows/viewLogDetail"
@@ -26,6 +26,7 @@ import ViewerComponent from "../Viewer/Viewer"
 import getEndMessage from "./getEndMessage"
 import NoResults from "./NoResults"
 import {useRowSelection} from "./selection"
+import ConfigPropValues from "src/js/state/ConfigPropValues"
 
 type StateProps = {
   logs: zed.Record[]
@@ -50,6 +51,7 @@ type Props = StateProps & DispatchProps & OwnProps
 
 export default function ResultsTable(props: Props) {
   const dispatch = useDispatch()
+  const displayConfig = useSelector(ConfigPropValues.get("display"))
   const {parentRef, selection, clicked} = useRowSelection({
     multi: props.multiSelect
   })
@@ -87,6 +89,7 @@ export default function ResultsTable(props: Props) {
   function renderRow(index: number, dimens: ViewerDimens) {
     return (
       <LogRow
+        displayConfig={displayConfig}
         columns={props.tableColumns}
         key={index}
         index={index}

--- a/src/js/flows/exportResults.test.ts
+++ b/src/js/flows/exportResults.test.ts
@@ -2,7 +2,7 @@ import TableColumns from "../models/TableColumns"
 import {prepareProgram} from "./exportResults"
 
 test("prepare program", async () => {
-  const columns = new TableColumns("yo", [])
+  const columns = new TableColumns("yo", [], {}, {})
   const p = prepareProgram("csv", "*", columns)
 
   expect(p).toBe("* | fuse")

--- a/src/js/models/TableColumns.ts
+++ b/src/js/models/TableColumns.ts
@@ -1,3 +1,4 @@
+import {FormatConfig} from "app/core/format"
 import {estimateCellWidth, estimateHeaderWidth} from "app/viewer/measure"
 import {zed} from "zealot"
 import columnOrder from "../lib/columnOrder"
@@ -7,13 +8,16 @@ import {ColumnSettingsMap, TableColumn} from "../state/Columns/types"
 export default class TableColumns {
   cols: TableColumn[]
   id: string
+  config: Partial<FormatConfig>
 
   constructor(
     id: string,
     columns: $Column[] = [],
-    tableSetting: ColumnSettingsMap = {}
+    tableSetting: ColumnSettingsMap = {},
+    config: Partial<FormatConfig> = {}
   ) {
     this.id = id
+    this.config = config
     this.cols = columnOrder(columns)
       .map(
         ({name, type, key}, index): TableColumn => ({
@@ -38,7 +42,7 @@ export default class TableColumns {
       records.forEach((r) => {
         const data = r.try(col.name)
         if (!data) return
-        const width = estimateCellWidth(data, col.name)
+        const width = estimateCellWidth(data, col.name, this.config)
         if (width > max) max = width
       })
       col.width = max

--- a/src/js/state/Columns/selectors.ts
+++ b/src/js/state/Columns/selectors.ts
@@ -1,3 +1,4 @@
+import {FormatConfig, getFormatConfig} from "app/core/format"
 import {createSelector} from "reselect"
 import {zed} from "zealot"
 import TableColumns from "../../models/TableColumns"
@@ -15,18 +16,21 @@ const getCurrentTableColumns = createSelector<
   SchemaMap,
   ColumnsState,
   zed.Record[],
+  FormatConfig,
   TableColumns
 >(
   Viewer.getColumns,
   getColumns,
   Viewer.getRecords,
-  (viewerColumns, columnSettings, logs) => {
+  getFormatConfig,
+  (viewerColumns, columnSettings, logs, config) => {
     const set = createColumnSet(viewerColumns)
     const prefs = columnSettings[set.getName()]
     const table = new TableColumns(
       set.getName() as string,
       set.getUniqColumns(),
-      prefs
+      prefs,
+      config
     )
     table.setWidths(logs.slice(0, 50))
     return table

--- a/test/unit/helpers/setup-brim.ts
+++ b/test/unit/helpers/setup-brim.ts
@@ -28,9 +28,9 @@ class BrimTestContext {
 }
 
 type Args = {
-  page: string
-  workspace: Workspace
-  pool: Pool
+  page?: string
+  workspace?: Workspace
+  pool?: Pool
 }
 const defaults = () => ({
   page: "search",


### PR DESCRIPTION
Adds the thousands separator option to the preferences menu. @philrz what do you think the default should be? I'm leaning towards no separator at all because of all the numeric id fields out there. It looks weird to add commas to those. It almost seems like these options should be on a per-column, opt in, basis in the future. 

Part of #1724 

![uI0nWAgjom](https://user-images.githubusercontent.com/3460638/125385469-6583f380-e34f-11eb-9fae-53ace319153e.gif)
