### PR TITLE
Loader abort

### DIFF
--- a/app/pools/flows/show-pool-context-menu.ts
+++ b/app/pools/flows/show-pool-context-menu.ts
@@ -28,9 +28,30 @@ const showPoolContextMenu = (pool: BrimPool) => (dispatch, getState) => {
           buttons: ["OK", "Cancel"]
         }).then(({response}) => {
           if (response === 0)
-            dispatch(deletePool(pool.id)).then(() => {
-              toast(`Deleted pool "${pool.name}"`)
-            })
+            toast.promise(
+              dispatch(deletePool(pool.id)),
+              {
+                loading: `Deleting pool "${pool.name}"`,
+                success: `Deleted pool "${pool.name}"`,
+                error: (err) => {
+                  console.error(err)
+                  return "Error deleting pool: " + err.message
+                }
+              },
+              {
+                loading: {
+                  // setTimeout's maximum value is a 32-bit int, so we explicitly specify here
+                  // also, once https://github.com/timolins/react-hot-toast/pull/37 merges, we can set this to -1
+                  duration: 2 ** 31 - 1
+                },
+                success: {
+                  duration: 3000
+                },
+                error: {
+                  duration: 5000
+                }
+              }
+            )
         })
       }
     },

--- a/plugins/brimcap/brimcap-cli.ts
+++ b/plugins/brimcap/brimcap-cli.ts
@@ -116,7 +116,6 @@ export default class BrimcapCLI {
 
   private exec(subCommand: string, opts: searchOptions | indexOptions) {
     const subCommandWithArgs = [subCommand, ...toCliOpts(opts)]
-    const p = spawnSync(this.binPath, subCommandWithArgs)
-    return p
+    return spawnSync(this.binPath, subCommandWithArgs)
   }
 }

--- a/plugins/brimcap/brimcap-plugin.ts
+++ b/plugins/brimcap/brimcap-plugin.ts
@@ -271,7 +271,8 @@ export default class BrimcapPlugin {
       params: IngestParams & {poolId: string},
       onProgressUpdate: (value: number | null) => void,
       onWarning: (warning: string) => void,
-      onDetailUpdate: () => void
+      onDetailUpdate: () => void,
+      signal?: AbortSignal
     ): Promise<void> => {
       const {fileListData} = params
       if (fileListData.length > 1)
@@ -289,12 +290,14 @@ export default class BrimcapPlugin {
       cliOpts.config = yamlConfig || ""
 
       onProgressUpdate(0)
-      const p = this.cli.analyze(pcapFilePath, cliOpts)
+      const p = this.cli.analyze(pcapFilePath, cliOpts, signal)
       this.processes[p.pid] = p
+
       let brimcapErr
       p.on("error", (err) => {
         brimcapErr = err
       })
+
       const handleRespMsg = async (jsonMsg) => {
         const {type, ...status} = jsonMsg
         switch (type) {
@@ -327,21 +330,27 @@ export default class BrimcapPlugin {
       // stream analyze output to pool
       const zealot = this.api.getZealot()
       const res = await zealot.pools.add(params.poolId, {
-        data: p.stdout
+        data: p.stdout,
+        signal
       })
       const commitId = get(res, ["value", "commit"], "")
       if (!commitId) throw new Error("No commit obtained from lake add")
+
       await zealot.pools.commit(params.poolId, commitId, {
         author: "brim",
-        message: "automatic import with brimcap analyze"
+        message: "automatic import with brimcap analyze",
+        signal
       })
 
       // generate pcap index
       try {
-        await this.cli.index({
-          root: this.brimcapDataRoot,
-          pcap: pcapFilePath
-        })
+        await this.cli.index(
+          {
+            root: this.brimcapDataRoot,
+            pcap: pcapFilePath
+          },
+          signal
+        )
       } catch (e) {
         console.error(e)
         brimcapErr = e.toString()

--- a/plugins/brimcap/brimcap-plugin.ts
+++ b/plugins/brimcap/brimcap-plugin.ts
@@ -344,13 +344,10 @@ export default class BrimcapPlugin {
 
       // generate pcap index
       try {
-        await this.cli.index(
-          {
-            root: this.brimcapDataRoot,
-            pcap: pcapFilePath
-          },
-          signal
-        )
+        await this.cli.index({
+          root: this.brimcapDataRoot,
+          pcap: pcapFilePath
+        })
       } catch (e) {
         console.error(e)
         brimcapErr = e.toString()

--- a/src/js/api/registries.ts
+++ b/src/js/api/registries.ts
@@ -29,31 +29,45 @@ export class CommandRegistry {
 }
 
 interface Loader {
+  match: string
   load: (
     params: IngestParams & {poolId: string},
     onProgress: (value: number | null) => void,
     onWarning: (warning: string) => void,
-    onDetailUpdate: () => Promise<void>
+    onDetailUpdate: () => Promise<void>,
+    signal?: AbortSignal
   ) => Promise<void>
-  match: string
-  unLoad?: (params: IngestParams) => Promise<void>
+  unload?: (params: IngestParams) => Promise<void>
 }
 
 export class LoaderRegistry {
   private loaders: Loader[] = []
+  private emitter = new EventEmitter()
 
   constructor() {}
 
   add(l: Loader): void {
     this.loaders.push(l)
   }
-
   remove(l: Loader): void {
     if (this.loaders.includes(l)) remove(this.loaders, (l) => l === l)
   }
-
   getMatches(loadType: string): Loader[] {
     return this.loaders.filter((l) => l.match === loadType)
+  }
+  onWillAbort(listener: (...args: any[]) => void): Cleanup {
+    this.emitter.on("will-abort", listener)
+    return () => this.emitter.removeListener("will-abort", listener)
+  }
+  onDidAbort(listener: (...args: any[]) => void): Cleanup {
+    this.emitter.on("did-abort", listener)
+    return () => this.emitter.removeListener("did-abort", listener)
+  }
+  willAbort(handlerId: string): boolean {
+    return this.emitter.emit("will-abort", handlerId)
+  }
+  didAbort(handlerId: string): boolean {
+    return this.emitter.emit("did-abort", handlerId)
   }
 }
 

--- a/src/js/flows/deletePool.ts
+++ b/src/js/flows/deletePool.ts
@@ -21,10 +21,7 @@ const deletePool = (id: string): Thunk<Promise<void>> => async (
 
   // if pool is still loading, use brim api to call abort using its handler id
   if (poolHandler) {
-    api.loaders.willAbort(poolHandler.id)
-    await new Promise((res) => {
-      api.loaders.onDidAbort(res)
-    })
+    await api.loaders.abort(poolHandler.id)
     // upon abort, loader.load() will throw an error triggering a transaction rollback
     // which will handle the actual delete and cleanup
     return Promise.resolve()

--- a/src/js/flows/deletePool.ts
+++ b/src/js/flows/deletePool.ts
@@ -4,13 +4,32 @@ import Current from "../state/Current"
 import Investigation from "../state/Investigation"
 import Pools from "../state/Pools"
 import SystemTest from "../state/SystemTest"
+import Handlers from "../state/Handlers"
 
-const deletePool = (id: string): Thunk<Promise<void>> => (
+const deletePool = (id: string): Thunk<Promise<void>> => async (
   dispatch,
-  getState
+  getState,
+  {api}
 ) => {
   const zealot = dispatch(getZealot())
   const workspaceId = Current.getWorkspaceId(getState())
+
+  const poolHandler = Object.entries(Handlers.get(getState()))
+    .map(([hId, h]) => h.type === "INGEST" && {...h, id: hId})
+    .filter(Boolean)
+    .find((h) => h.poolId === id)
+
+  // if pool is still loading, use brim api to call abort using its handler id
+  if (poolHandler) {
+    api.loaders.willAbort(poolHandler.id)
+    await new Promise((res) => {
+      api.loaders.onDidAbort(res)
+    })
+    // upon abort, loader.load() will throw an error triggering a transaction rollback
+    // which will handle the actual delete and cleanup
+    return Promise.resolve()
+  }
+
   return zealot.pools.delete(id).then(() => {
     dispatch(Investigation.clearPoolInvestigation(workspaceId, id))
     dispatch(Pools.remove(workspaceId, id))

--- a/src/js/flows/ingestFiles.test.ts
+++ b/src/js/flows/ingestFiles.test.ts
@@ -47,8 +47,8 @@ beforeEach(() => {
     getMatches: jest.fn(),
     abort: jest.fn(),
     setAbortHandler: () => jest.fn(),
-    willAbort: jest.fn(),
-    didAbort: jest.fn()
+    didAbort: jest.fn(),
+    requestAbort: jest.fn()
   }
 
   store = initTestStore(zealot.zealot, apiMock)

--- a/src/js/flows/ingestFiles.test.ts
+++ b/src/js/flows/ingestFiles.test.ts
@@ -45,8 +45,8 @@ beforeEach(() => {
   apiMock = mocked(BrimApi)
   apiMock.loaders = {
     getMatches: jest.fn(),
-    onWillAbort: () => jest.fn(),
-    onDidAbort: () => jest.fn(),
+    abort: jest.fn(),
+    setAbortHandler: () => jest.fn(),
     willAbort: jest.fn(),
     didAbort: jest.fn()
   }

--- a/src/js/flows/ingestFiles.test.ts
+++ b/src/js/flows/ingestFiles.test.ts
@@ -44,7 +44,11 @@ beforeEach(() => {
 
   apiMock = mocked(BrimApi)
   apiMock.loaders = {
-    getMatches: jest.fn()
+    getMatches: jest.fn(),
+    onWillAbort: () => jest.fn(),
+    onDidAbort: () => jest.fn(),
+    willAbort: jest.fn(),
+    didAbort: jest.fn()
   }
 
   store = initTestStore(zealot.zealot, apiMock)

--- a/src/js/flows/ingestFiles.ts
+++ b/src/js/flows/ingestFiles.ts
@@ -151,14 +151,10 @@ const executeLoader = (
     const l = loaders[0]
     const abortCtl = new AbortController()
 
-    let didAbort = false
-    const abortHandler = (id) => {
-      if (id === handlerId) {
-        abortCtl.abort()
-        didAbort = true
-      }
+    const abortHandler = () => {
+      abortCtl.abort()
     }
-    const cleanup = api.loaders.onWillAbort(abortHandler)
+    const cleanup = api.loaders.setAbortHandler(handlerId, abortHandler)
     try {
       await l.load(
         params,
@@ -171,7 +167,7 @@ const executeLoader = (
       l.unload && (await l.unload(params))
       throw e
     } finally {
-      if (didAbort) api.loaders.didAbort(handlerId)
+      if (abortCtl.signal.aborted) api.loaders.didAbort(handlerId)
       cleanup()
     }
   }

--- a/zealot/api/pools.ts
+++ b/zealot/api/pools.ts
@@ -55,11 +55,13 @@ export default {
     }
   },
   commit(poolId: string, commitId: string, args: PoolCommitArgs) {
+    const {signal, ...rest} = args
     return {
       headers: new Headers({Accept: "application/json"}),
       path: `/pool/${poolId}/staging/${commitId}`,
       method: "POST",
-      body: JSON.stringify(args)
+      body: JSON.stringify(rest),
+      signal
     }
   }
 }

--- a/zealot/types.ts
+++ b/zealot/types.ts
@@ -43,12 +43,14 @@ export interface SearchArgs {
 
 export interface PoolAddArgs {
   data: NodeJS.ReadableStream
+  signal?: AbortSignal
 }
 
 export interface PoolCommitArgs {
   message: string
   author: string
   date?: number
+  signal?: AbortSignal
 }
 
 export interface PoolArgs {

--- a/zealot/zealot.ts
+++ b/zealot/zealot.ts
@@ -109,7 +109,8 @@ export function createZealot(
         const resp = await nodeFetch(url(host, path), {
           method,
           body,
-          headers
+          headers,
+          signal: args.signal
         })
         const content = await parseContentType(resp)
         return resp.ok ? content : Promise.reject(createError(content))


### PR DESCRIPTION
fixes #1739 

Uses abort controllers and event emitters to coordinate between the `deletePool` thunk, the `ingestFiles` thunk, and the brimcap loader's `load` method. We send "SIGINT" to spawned processes so that they can gracefully terminate. This can sometimes take a little bit of time (not a lot but enough to make the UI seem like there is a short delay upon deleting a pool), so we also wrap this user action in a toast.promise which gives continuous "deleting..." feedback to the user in those cases.