### PR TITLE
Save window state during a reload

### DIFF
--- a/src/js/electron/ipc/windows/mainHandler.ts
+++ b/src/js/electron/ipc/windows/mainHandler.ts
@@ -4,6 +4,7 @@ import {BrimMain} from "../../brim"
 
 let started = false
 
+// Convert this file to the new ipc model
 export default function(brim: BrimMain) {
   ipcMain.handle("windows:initialState", (_e, {id}) => {
     const window = brim.windows.getWindow(id)
@@ -44,5 +45,9 @@ export default function(brim: BrimMain) {
   ipcMain.handle("windows:showSaveDialog", async (e, args) => {
     const win = BrowserWindow.fromWebContents(e.sender)
     return dialog.showSaveDialog(win, args)
+  })
+
+  ipcMain.on("windows:updateState", (e, id, state) => {
+    brim.windows.getWindow(id).initialState = state
   })
 }

--- a/src/js/search.tsx
+++ b/src/js/search.tsx
@@ -13,6 +13,8 @@ import lib from "./lib"
 import theme from "./style-theme"
 import deletePartialPools from "./flows/deletePartialPools"
 import TabHistories from "./state/TabHistories"
+import {getWindowPersistable} from "./state/getPersistable"
+import {ipcRenderer} from "electron"
 
 initialize()
   .then(({store, pluginManager}) => {
@@ -22,6 +24,11 @@ initialize()
       pluginManager.deactivate()
       store.dispatch(deletePartialPools())
       store.dispatch(TabHistories.save(global.tabHistories.serialize()))
+      ipcRenderer.send(
+        "windows:updateState",
+        global.windowId,
+        getWindowPersistable(store.getState())
+      )
     }
     ReactDOM.render(
       <AppErrorBoundary>


### PR DESCRIPTION
It's been annoying to have the state revert back to how it was when brim started every time the page reloads. This PR fixes that. It updates the initial state of the window object in the main process right before the browser window unloads.

This should make development faster. 🎉