### PR TITLE
Use our npm package for electron mock ipc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3153,6 +3153,12 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@brimdata/electron-mock-ipc": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@brimdata/electron-mock-ipc/-/electron-mock-ipc-0.0.1.tgz",
+      "integrity": "sha512-l/D9agbN3tZbuV9lj6QqiqP0owc8uDmcFFXqNL3YWsWLmNsDa7o4bc0C1k2B9kaIljzry259zX3vIMjYWv8uHA==",
+      "dev": true
+    },
     "@cnakazawa/watch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -11220,11 +11226,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-4.2.2.tgz",
       "integrity": "sha512-lBpLh1Q8qayrTxFIrTPcNjSHsosvUfOYyZ8glhiLcx7zCNPDGuj8+nXlEaaSS6LRiQQbLgLG+wKpuvztNzBIrA=="
-    },
-    "electron-mock-ipc": {
-      "version": "github:brimdata/electron-mock-ipc#7a19e9a933a6a2156960ca378cc335b8b3fd6cb2",
-      "from": "github:brimdata/electron-mock-ipc#master",
-      "dev": true
     },
     "electron-notarize": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "electron": "^11.2.1",
     "electron-builder": "^22.9.1",
     "electron-builder-notarize": "^1.2.0",
-    "electron-mock-ipc": "brimdata/electron-mock-ipc#master",
+    "@brimdata/electron-mock-ipc": "^0.0.1",
     "electron-notarize": "^0.2.1",
     "eslint": "^7.8.1",
     "eslint-config-prettier": "^6.11.0",

--- a/test/unit/__mocks__/electron.ts
+++ b/test/unit/__mocks__/electron.ts
@@ -1,5 +1,5 @@
 import {join} from "path"
-import createIPCMock from "electron-mock-ipc"
+import createIPCMock from "@brimdata/electron-mock-ipc"
 import EventEmitter from "events"
 
 const mockIpc = createIPCMock()


### PR DESCRIPTION
I had to fork electron-mock-ipc because they had a bug that hasn't been merged upstream yet. But in order to depend on the fork, we have to build the project and publish it somewhere. So I've created a brimdata npm org and put this package under it. Now we depend on the npm hosted package.

This might be able to fix our ci problems. CI doesn't need to download another version of electron just to build the electron-mock library.