### PR TITLE
Update electron-mock-ipc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11222,8 +11222,9 @@
       "integrity": "sha512-lBpLh1Q8qayrTxFIrTPcNjSHsosvUfOYyZ8glhiLcx7zCNPDGuj8+nXlEaaSS6LRiQQbLgLG+wKpuvztNzBIrA=="
     },
     "electron-mock-ipc": {
-      "version": "github:brimdata/electron-mock-ipc#7a19e9a933a6a2156960ca378cc335b8b3fd6cb2",
-      "from": "github:brimdata/electron-mock-ipc#master",
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/electron-mock-ipc/-/electron-mock-ipc-0.3.10.tgz",
+      "integrity": "sha512-PUuIw8u6QQKxO8URgob9Ndw0hPExm6IAgJgQcQiLybzwTUniz+Mp6fixbXXXWO9/b7akd9bp0NACSvjr2Xdgow==",
       "dev": true
     },
     "electron-notarize": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "electron": "^11.2.1",
     "electron-builder": "^22.9.1",
     "electron-builder-notarize": "^1.2.0",
-    "electron-mock-ipc": "brimdata/electron-mock-ipc#master",
+    "electron-mock-ipc": "^0.3.10",
     "electron-notarize": "^0.2.1",
     "eslint": "^7.8.1",
     "eslint-config-prettier": "^6.11.0",


### PR DESCRIPTION
The changes have been merged upstream! Now we don't depend on the fork.

This will take the place of #1756 