### PR TITLE
default loader: handle error status

### DIFF
--- a/plugins/log-loader/index.ts
+++ b/plugins/log-loader/index.ts
@@ -21,6 +21,8 @@ export const activate = (api: BrimApi) => {
     // @ts-ignore
     for await (const {type, ...status} of stream) {
       switch (type) {
+        case "Error":
+          throw new Error(status.error)
         case "UploadProgress":
           onProgressUpdate(status.progress)
           await onDetailUpdate()


### PR DESCRIPTION
fixes #1749 

When this logic got moved into a loader plugin, the error case handling didn't come with it. Putting it back now. When the zed service changes it's error message it should get passed through the app properly now instead of being swallowed.