### PR TITLE
Fetch stats when initializing a pool

### DIFF
--- a/src/js/flows/initPool.ts
+++ b/src/js/flows/initPool.ts
@@ -1,3 +1,4 @@
+import interop from "../brim/interop"
 import Current from "../state/Current"
 import Pools from "../state/Pools"
 import {Thunk} from "../state/types"
@@ -10,10 +11,11 @@ export const initPool = (poolId: string): Thunk<Promise<void>> => (
   const workspaceId = Current.getWorkspaceId(getState())
   if (!workspaceId) return
   const zealot = dispatch(getZealot())
-  return zealot.pools
-    .get(poolId)
-    .then((data) => {
-      dispatch(Pools.setDetail(workspaceId, data))
+
+  return Promise.all([zealot.pools.get(poolId), zealot.pools.stats(poolId)])
+    .then(([data, rawStats]) => {
+      const stats = interop.poolStatsPayloadToPool(rawStats)
+      dispatch(Pools.setDetail(workspaceId, {...data, ...stats}))
     })
     .catch((error) => {
       console.error(error)

--- a/src/js/flows/refreshPoolNames.ts
+++ b/src/js/flows/refreshPoolNames.ts
@@ -1,33 +1,22 @@
-import {Thunk} from "../state/types"
+import {BrimWorkspace} from "../brim"
 import Current from "../state/Current"
 import Pools from "../state/Pools"
+import {Thunk} from "../state/types"
 import {getZealot} from "./getZealot"
-import {BrimWorkspace} from "../brim"
-import interop from "../brim/interop"
 
+/**
+ * This only gets the list of names from the server, all the
+ * details like the min_time and max_time need to be requested
+ * somewhere else. (like in initPool)
+ */
 export default function refreshPoolNames(
   ws?: BrimWorkspace
 ): Thunk<Promise<void>> {
   return (dispatch, getState) => {
     const zealot = dispatch(getZealot(ws))
-
-    let pools = []
-    return zealot.pools
-      .list()
-      .then((data) => {
-        pools = data || []
-        return Promise.all(
-          pools.map(async (pool, i) => {
-            const stats = interop.poolStatsPayloadToPool(
-              await zealot.pools.stats(pool.id)
-            )
-            pools[i] = {...pool, ...stats}
-          })
-        )
-      })
-      .then(() => {
-        const id = ws?.id || Current.getWorkspaceId(getState())
-        if (id) dispatch(Pools.setPools(id, pools))
-      })
+    return zealot.pools.list().then((pools) => {
+      const id = ws?.id || Current.getWorkspaceId(getState())
+      if (id) dispatch(Pools.setPools(id, pools))
+    })
   }
 }


### PR DESCRIPTION
**What happened?**

Each time the app got an update from the migration process, it would call "refreshSpaceNames". This would ask zqd for all the names of the spaces, then it would request each of their "stats" from the stats endpoint. 

The stats endpoint for the wccdc pool was returning null with 204 No Content (see screenshot) @mattnibs is that a timing race? So when you clicked on it after the migration was complete (it actually didn't matter how quickly you clicked it), you got the default time span (1 second in 1970).

When you click on a pool in the side bar, it "should have" checked that stats are up to date, but it did not.

**The Fix**

Do not request pool stats in "refreshSpaceNames", but do request pool stats in "initPool". 

**History:** The `GET /pool/:id` endpoint used to include the stats, but they have since been moved to `GET /pool/:id/stats`


<img src="https://user-images.githubusercontent.com/3460638/127226603-3e26ff77-cd86-45a8-ab8f-18d8e9c57116.png" width=300 />

Fixes #1743 
