### PR TITLE
Increase Unit Test Wait Timeout

### DIFF
--- a/app/core/env.ts
+++ b/app/core/env.ts
@@ -1,0 +1,31 @@
+import {app as electronApp, remote} from "electron"
+const app = electronApp || (remote && remote.app)
+
+export default {
+  get isCI() {
+    return process.env.GITHUB_ACTIONS === "true"
+  },
+  get isIntegrationTest() {
+    return process.env.BRIM_ITEST === "true"
+  },
+  get isTest() {
+    return process.env.NODE_ENV === "test"
+  },
+  get isDevelopment() {
+    const isEnvSet = "ELECTRON_IS_DEV" in process.env
+    const getFromEnv = parseInt(process.env.ELECTRON_IS_DEV, 10) === 1
+    return isEnvSet ? getFromEnv : app && !app.isPackaged
+  },
+  get isRelease() {
+    return app.isPackaged
+  },
+  get isMac() {
+    return process.platform === "darwin"
+  },
+  get isWindows() {
+    return process.platform === "win32"
+  },
+  get isLinux() {
+    return process.platform === "linux"
+  }
+}

--- a/app/release-notes/maybe-show-release-notes.ts
+++ b/app/release-notes/maybe-show-release-notes.ts
@@ -1,15 +1,17 @@
+import env from "app/core/env"
 import {metaClient} from "app/ipc/meta"
 import {releaseNotesPath} from "app/router/utils/paths"
 import Current from "src/js/state/Current"
 import Launches from "src/js/state/Launches"
 import Tabs from "src/js/state/Tabs"
 
-const isItest = process.env.BRIM_ITEST === "true"
-
 export function maybeShowReleaseNotes() {
   return async (dispatch, getState) => {
     const version = await metaClient.version()
-    if (!isItest && Launches.firstRunOfVersion(getState(), version)) {
+    if (
+      !env.isIntegrationTest &&
+      Launches.firstRunOfVersion(getState(), version)
+    ) {
       dispatch(showReleaseNotes())
       dispatch(Launches.touchVersion(version))
     }

--- a/app/routes/app-wrapper.tsx
+++ b/app/routes/app-wrapper.tsx
@@ -1,4 +1,5 @@
 import ColumnsModal from "app/columns/columns-modal"
+import env from "app/core/env"
 import SpaceMigration from "app/legacy/space-migration/space-migration"
 import HookLog from "app/system-test/HookLog"
 import React from "react"
@@ -77,7 +78,7 @@ export default function AppWrapper({children}) {
       <BrimTooltip />
       <SpaceMigration />
 
-      {process.env.BRIM_ITEST === "true" && <HookLog />}
+      {env.isIntegrationTest && <HookLog />}
     </div>
   )
 }

--- a/plugins/brimcap/brimcap-cli.ts
+++ b/plugins/brimcap/brimcap-cli.ts
@@ -1,3 +1,4 @@
+import env from "app/core/env"
 import {spawnSync, spawn, ChildProcess} from "child_process"
 import {compact, isEmpty} from "lodash"
 import flatMap from "lodash/flatMap"
@@ -96,7 +97,7 @@ export default class BrimcapCLI {
     signal?: AbortSignal
   ): ChildProcess {
     const subCommandWithArgs = ["analyze", ...toCliOpts(opts), pcapPath]
-    const isWin = process.platform === "win32"
+    const isWin = env.isWindows
     // don't detach if is windows
     const spawnOpts = isWin ? undefined : {detached: true}
     const p = spawn(this.binPath, subCommandWithArgs, spawnOpts)

--- a/plugins/brimcap/brimcap-plugin.ts
+++ b/plugins/brimcap/brimcap-plugin.ts
@@ -13,6 +13,7 @@ import BrimcapCLI, {analyzeOptions, searchOptions} from "./brimcap-cli"
 import {ChildProcess, spawn} from "child_process"
 import {MenuItemConstructorOptions} from "electron"
 import {compact, get} from "lodash"
+import env from "app/core/env"
 
 export default class BrimcapPlugin {
   private pluginNamespace = "brimcap"
@@ -49,7 +50,7 @@ export default class BrimcapPlugin {
     // RFC: what interface do we want the app to provide for this sort of data?
     const {dataRoot, zdepsDirectory} = api.getAppConfig()
 
-    const commandName = process.platform === "win32" ? "brimcap.exe" : "brimcap"
+    const commandName = env.isWindows ? "brimcap.exe" : "brimcap"
     this.brimcapBinPath = path.join(zdepsDirectory, commandName)
     this.cli = new BrimcapCLI(this.brimcapBinPath)
 
@@ -389,8 +390,7 @@ export default class BrimcapPlugin {
 
   private async updateSuricata() {
     const {zdepsDirectory} = this.api.getAppConfig()
-    const cmdName =
-      process.platform === "win32" ? "suricataupdater.exe" : "suricataupdater"
+    const cmdName = env.isWindows ? "suricataupdater.exe" : "suricataupdater"
     const cmdPath = path.join(zdepsDirectory, "suricata", cmdName)
     const proc = spawn(cmdPath)
     this.processes[proc.pid] = proc

--- a/src/js/components/HTMLContextMenu.tsx
+++ b/src/js/components/HTMLContextMenu.tsx
@@ -19,6 +19,7 @@ import lib from "../lib"
 import useEventListener from "./hooks/useEventListener"
 
 import {reactElementProps} from "../../../test/integration/helpers/integration"
+import env from "app/core/env"
 
 export default function HTMLContextMenu() {
   const [template, setTemplate] = useState(null)
@@ -59,7 +60,7 @@ function HTMLMenuItem({item}) {
 }
 
 function stubIpcSend(name, ...args) {
-  if (process.env.BRIM_ITEST === "true") {
+  if (env.isIntegrationTest) {
     /*
     This is for integration tests when we are testing the real ipc communication
     Since ipcRendere inherits from EventEmitter, we can simply emit this event

--- a/src/js/electron/autoUpdater.ts
+++ b/src/js/electron/autoUpdater.ts
@@ -1,3 +1,4 @@
+import env from "app/core/env"
 import {meta} from "app/ipc/meta"
 import {app, dialog} from "electron"
 import log from "electron-log"
@@ -51,7 +52,7 @@ const autoUpdateLinux = async () => {
 }
 
 export async function setupAutoUpdater() {
-  if (process.platform === "linux") {
+  if (env.isLinux) {
     setUpdateRepeater(() => {
       autoUpdateLinux().catch((err) => log.error(err))
     })
@@ -65,7 +66,7 @@ export async function setupAutoUpdater() {
       buttons: ["Restart", "Later"],
       title: "Application Update",
       // releaseNotes are not available for windows, so use name instead
-      message: process.platform === "win32" ? releaseNotes : releaseName,
+      message: env.isWindows ? releaseNotes : releaseName,
       detail:
         "A new version of Brim has been downloaded. Restart the application to apply the update."
     }

--- a/src/js/electron/extensions.ts
+++ b/src/js/electron/extensions.ts
@@ -1,3 +1,4 @@
+import env from "app/core/env"
 import installExtension, {
   REACT_DEVELOPER_TOOLS,
   REDUX_DEVTOOLS
@@ -6,7 +7,7 @@ import installExtension, {
 import log from "electron-log"
 
 export function installExtensions() {
-  if (process.env.BRIM_ITEST === "true") return
+  if (env.isIntegrationTest) return
   return installExtension([REDUX_DEVTOOLS, REACT_DEVELOPER_TOOLS])
     .then(() => log.info("Devtools loaded"))
     .catch((err) => log.error("Devtools error occurred: ", err))

--- a/src/js/electron/main.ts
+++ b/src/js/electron/main.ts
@@ -22,6 +22,7 @@ import {paths} from "app/ipc/paths"
 import {windowsPre25Exists} from "./windows-pre-25"
 import {meta} from "app/ipc/meta"
 import secureWebContents from "./secure-web-contents"
+import env from "app/core/env"
 
 console.time("init")
 
@@ -88,7 +89,7 @@ app.disableHardwareAcceleration()
 const gotTheLock = app.requestSingleInstanceLock()
 if (gotTheLock) {
   main().then(() => {
-    if (process.env.BRIM_ITEST === "true") require("./itest")
+    if (env.isIntegrationTest) require("./itest")
   })
 } else {
   app.quit()

--- a/src/js/electron/menu/appMenu.test.ts
+++ b/src/js/electron/menu/appMenu.test.ts
@@ -4,13 +4,15 @@ import {BrimMain} from "../brim"
 const mockSend = jest.fn()
 
 test("app menu mac", async () => {
-  const menu = appMenu(mockSend, new BrimMain(), "darwin")
+  Object.defineProperty(process, "platform", {value: "darwin"})
+  const menu = appMenu(mockSend, new BrimMain())
 
   expect(menu).toMatchSnapshot()
 })
 
 test("app menu windows", async () => {
-  const menu = appMenu(mockSend, new BrimMain(), "win32")
+  Object.defineProperty(process, "platform", {value: "win32"})
+  const menu = appMenu(mockSend, new BrimMain())
 
   expect(menu).toMatchSnapshot()
 })

--- a/src/js/electron/menu/appMenu.ts
+++ b/src/js/electron/menu/appMenu.ts
@@ -6,13 +6,13 @@ import path from "path"
 import electronIsDev from "../isDev"
 import formatSessionState from "../tron/formatSessionState"
 import {BrimMain} from "../brim"
+import env from "app/core/env"
 
 export default function(
   send: Function,
-  brim: BrimMain,
-  platform: string = process.platform
+  brim: BrimMain
 ): MenuItemConstructorOptions[] {
-  const mac = platform === "darwin"
+  const mac = env.isMac
   const __: MenuItemConstructorOptions = {type: "separator"}
 
   const newWindow: MenuItemConstructorOptions = {
@@ -45,7 +45,7 @@ export default function(
 
   const preferences: MenuItemConstructorOptions = {
     id: "preferences",
-    label: platform === "darwin" ? "Preferences..." : "Settings",
+    label: env.isMac ? "Preferences..." : "Settings",
     click: () => brim.windows.openPreferences()
   }
 

--- a/src/js/electron/quitter.ts
+++ b/src/js/electron/quitter.ts
@@ -1,3 +1,4 @@
+import env from "app/core/env"
 import {app} from "electron"
 import {BrimMain} from "./brim"
 
@@ -9,7 +10,7 @@ export function handleQuit(brim: BrimMain) {
   })
 
   app.on("window-all-closed", async () => {
-    if (process.platform === "darwin") return
+    if (env.isMac) return
     // Strangely, this event fires before the "closed" event on the window is fired,
     // where we dereference the window. Here we check to make sure all the windows
     // have indeed been dereferenced before we quit the app.

--- a/src/js/lib/System.ts
+++ b/src/js/lib/System.ts
@@ -1,13 +1,11 @@
+import env from "app/core/env"
 import {MenuItemConstructorOptions, remote, PopupOptions} from "electron"
-
-const isTest =
-  process.env.BRIM_ITEST === "true" || process.env.NODE_ENV === "test"
 
 export function showContextMenu(
   template: MenuItemConstructorOptions[],
   opts: PopupOptions = {}
 ) {
-  if (isTest) {
+  if (env.isTest) {
     document.dispatchEvent(
       new CustomEvent("nativeContextMenu", {detail: template})
     )
@@ -18,7 +16,7 @@ export function showContextMenu(
 }
 
 export function showMessageBox(opts: Electron.MessageBoxOptions) {
-  if (isTest) {
+  if (env.isTest) {
     return Promise.resolve({response: 0})
     // To do, mock the options and give the test case a way to select some
   } else {

--- a/src/js/lib/open.ts
+++ b/src/js/lib/open.ts
@@ -1,5 +1,7 @@
 "use strict"
 
+import env from "app/core/env"
+
 require("regenerator-runtime/runtime")
 
 const isWsl = require("is-wsl")
@@ -50,7 +52,7 @@ export default async function open(target: string, options?: Opts) {
     options.app = options.app[0]
   }
 
-  if (process.platform === "darwin") {
+  if (env.isMac) {
     command = "open"
 
     if (options.newWindow) {
@@ -64,7 +66,7 @@ export default async function open(target: string, options?: Opts) {
     if (options.app) {
       cliArguments.push("-a", options.app)
     }
-  } else if (process.platform === "win32" || isWsl) {
+  } else if (env.isWindows || isWsl) {
     command = "cmd" + (isWsl ? ".exe" : "")
     cliArguments.push("/c", "start", '""', "/b")
     target = target.replace(/&/g, "^&")
@@ -108,7 +110,7 @@ export default async function open(target: string, options?: Opts) {
 
   cliArguments.push(target)
 
-  if (process.platform === "darwin" && appArguments.length > 0) {
+  if (env.isMac && appArguments.length > 0) {
     cliArguments.push("--args", ...appArguments)
   }
 

--- a/src/js/state/SystemTest/index.ts
+++ b/src/js/state/SystemTest/index.ts
@@ -1,3 +1,5 @@
+import env from "app/core/env"
+
 export type HookName =
   | "import-start"
   | "import-complete"
@@ -25,7 +27,7 @@ function getHooks(state): SystemTestState {
 }
 
 export default {
-  reducer: process.env.BRIM_ITEST === "true" ? reducer : (s = []) => s,
+  reducer: env.isIntegrationTest ? reducer : (s = []) => s,
   hook,
   getHooks
 }

--- a/test/integration/helpers/env.ts
+++ b/test/integration/helpers/env.ts
@@ -1,7 +1,5 @@
 import path from "path"
 
-export const isCI = (): boolean => process.env.GITHUB_ACTIONS === "true"
-
 export const repoDir = (): string =>
   path.resolve(path.join(__dirname, "..", "..", ".."))
 

--- a/test/integration/helpers/newAppInstance.ts
+++ b/test/integration/helpers/newAppInstance.ts
@@ -5,8 +5,9 @@ import {mkdirpSync} from "fs-extra"
 import electronPath from "electron"
 import {Application} from "spectron"
 
-import {isCI, itestDir, repoDir} from "./env"
+import {itestDir, repoDir} from "./env"
 import {LOG} from "./log"
+import env from "app/core/env"
 
 export default (name: string, idx: number): Application => {
   const macInstallPath = "/Applications/Brim.app/Contents/MacOS/Brim"
@@ -46,14 +47,10 @@ export default (name: string, idx: number): Application => {
   // If we are CI, on a platform whose CI is expected to build releases,
   // and a release is installed, point to that. Otherwise run out of
   // dev. In some CI cases, we will not build releases and install them.
-  if (isCI() && process.platform === "darwin" && existsSync(macInstallPath)) {
+  if (env.isCI && env.isMac && existsSync(macInstallPath)) {
     appArgs = {...appArgs, path: macInstallPath}
     LOG.debug("Chose installed MacOS app location", macInstallPath)
-  } else if (
-    isCI() &&
-    process.platform === "linux" &&
-    existsSync(linuxInstallPath)
-  ) {
+  } else if (env.isCI && env.isLinux && existsSync(linuxInstallPath)) {
     appArgs = {...appArgs, path: linuxInstallPath}
     LOG.debug("Chose installed Linux app location", linuxInstallPath)
   } else {

--- a/test/integration/tests/detail-pane.test.ts
+++ b/test/integration/tests/detail-pane.test.ts
@@ -1,7 +1,8 @@
 import itest from "../helpers/itest"
 import {toLower} from "lodash"
+import env from "app/core/env"
 
-const maybeSkip = process.platform === "win32" ? describe.skip : describe
+const maybeSkip = env.isWindows ? describe.skip : describe
 
 maybeSkip("Detail Pane", () => {
   // Names of the sections to test for

--- a/test/unit/setup/after-env/index.ts
+++ b/test/unit/setup/after-env/index.ts
@@ -3,3 +3,9 @@ import "@testing-library/jest-dom"
 import "./mock-network"
 import "./polyfill-dom"
 import "./polyfill-fetch"
+import {configure} from "@testing-library/react"
+import env from "app/core/env"
+
+if (env.isCI) {
+  configure({asyncUtilTimeout: 5000})
+}


### PR DESCRIPTION
I made a module in `app/core/env.ts` that holds all the methods needed for inquiring about the environment.

```js
env.isCI
env.isDevelopment
env.isTest
env.isIntegrationTest
env.isMac
env.isLinux
env.isWindows
```

I also increased the @testing-library timeout setting from 1 second to 5 seconds.

This is to fix some CI flakiness.