### PR TITLE
Remove leftover react devtools script

### DIFF
--- a/search.html
+++ b/search.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
   <head>
-    <script src="http://localhost:8097"></script>
     <meta charset="utf-8" />
     <title>Brim</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
This is causing an error in the console when the standalone react devs tools isn't running.