### PR TITLE
Add types to hover

### DIFF
--- a/app/viewer/cell.tsx
+++ b/app/viewer/cell.tsx
@@ -12,7 +12,14 @@ const getTooltipStyle = (el: Element) => {
   return {top: top - 21, left: left + 4}
 }
 
-export default function Cell({width, children, name}) {
+type Props = {
+  width: number
+  children: JSX.Element
+  name: string
+  type: string
+}
+
+export default function Cell({width, children, name, type}: Props) {
   const [hover, setHover] = useState(false)
   const [tooltipStyle, setTooltipStyle] = useState({})
 
@@ -35,7 +42,9 @@ export default function Cell({width, children, name}) {
       {children}
       {hover && (
         <Tooltip style={tooltipStyle}>
-          <span className="field-name">{name}</span>
+          <span className="field-name">
+            {name} ({type})
+          </span>
         </Tooltip>
       )}
     </BG>

--- a/app/viewer/cell.tsx
+++ b/app/viewer/cell.tsx
@@ -42,9 +42,8 @@ export default function Cell({width, children, name, type}: Props) {
       {children}
       {hover && (
         <Tooltip style={tooltipStyle}>
-          <span className="field-name">
-            {name} ({type})
-          </span>
+          <span>{name} </span>
+          <span className="secondary">{type}</span>
         </Tooltip>
       )}
     </BG>

--- a/src/css/_tooltip.scss
+++ b/src/css/_tooltip.scss
@@ -11,6 +11,11 @@
   pointer-events: none;
   user-select: none;
   box-shadow: $box-shadow;
+
+  .secondary {
+    font-size: 10px;
+    opacity: 0.7;
+  }
 }
 
 .__react_component_tooltip.brim-tooltip {

--- a/src/js/components/LogRow.tsx
+++ b/src/js/components/LogRow.tsx
@@ -29,7 +29,12 @@ const LogRow = (props: Props) => {
     const key = `${index}-${colIndex}`
     if (field && field.data && !(field.data instanceof zed.Record)) {
       return (
-        <Cell width={width} key={key} name={field.name}>
+        <Cell
+          width={width}
+          key={key}
+          name={field.name}
+          type={field.data.type.toString()}
+        >
           <Value
             value={field.value}
             field={field}


### PR DESCRIPTION
This seems like an obvious place to highlight the type system. When you hover over a cell, you'll see the name of the cell along with the type.

![image](https://user-images.githubusercontent.com/3460638/127403536-092d64de-5e07-408a-867b-7363cd7d0518.png)

![image](https://user-images.githubusercontent.com/3460638/127403551-4b6aadfb-3324-4f3f-8ff0-c1a815aba222.png)

![image](https://user-images.githubusercontent.com/3460638/127403570-48e0dc44-b886-45cd-a15e-c3b2b60872aa.png)

