### PR TITLE
Reltime Error Fix

### DIFF
--- a/app/search/flows/initial-viewer-search.ts
+++ b/app/search/flows/initial-viewer-search.ts
@@ -14,9 +14,12 @@ const initialViewerSearch = () => (dispatch, getState) => {
   const program = brim.program(params.program, params.pins)
   const perPage = program.hasAnalytics() ? ANALYTIC_MAX_RESULTS : PER_PAGE
   const query = addHeadProc(program.string(), perPage)
-  const [from, to] = brim.span(params.spanArgs).toDateTuple()
-
-  return dispatch(viewerSearch({query, from, to, keep: params.keep}))
+  try {
+    const [from, to] = brim.span(params.spanArgs).toDateTuple()
+    return dispatch(viewerSearch({query, from, to, keep: params.keep}))
+  } catch (e) {
+    console.error(e)
+  }
 }
 
 export default initialViewerSearch

--- a/app/search/utils/search-params.test.ts
+++ b/app/search/utils/search-params.test.ts
@@ -34,3 +34,13 @@ test("decode search path", () => {
     keep: false
   })
 })
+
+test("decode with negative time", () => {
+  const path = "from=-1800.1000000&to=0.1000000"
+  const record = decodeSearchParams(path)
+
+  expect(record.spanArgs).toEqual([
+    {sec: -1800, ns: 1000000},
+    {sec: 0, ns: 1000000}
+  ])
+})

--- a/app/search/utils/search-params.ts
+++ b/app/search/utils/search-params.ts
@@ -78,7 +78,7 @@ export const encodeSpanArg = (arg) => {
 
 const decodeSpanArg = (arg): TimeArg | null => {
   if (!arg) return null
-  if (/^\d+\.\d+$/.test(arg)) {
+  if (/^-?\d+\.\d+$/.test(arg)) {
     const [sec, ns] = arg.split(".").map((i) => parseInt(i))
     return {sec, ns}
   } else {

--- a/src/js/@types/global.d.ts
+++ b/src/js/@types/global.d.ts
@@ -11,11 +11,11 @@ declare global {
       SVGElement: any
       windowId: string
       windowName: "search" | "detail" | "about" | "hidden"
-      getState: () => any
       feature: (name: FeatureName, value: boolean) => void
       tabHistories: Histories
       windowHistory: BrowserHistory
       navTo: (path: string) => void
+      dev: DevGlobal
     }
 
     interface Process {

--- a/src/js/flows/ingestFiles.ts
+++ b/src/js/flows/ingestFiles.ts
@@ -76,7 +76,7 @@ const createPool = (client: Zealot, gDispatch, workspaceId) => ({
   async do(params: IngestParams) {
     let createParams
     if (params.dataDir) {
-      createParams = {data_path: params.dataDir}
+      createParams = {data_path: params.dataDir, name: params.name}
     } else {
       createParams = {name: params.name}
     }

--- a/src/js/initializers/initDebugGlobals.ts
+++ b/src/js/initializers/initDebugGlobals.ts
@@ -1,0 +1,23 @@
+import Current from "../state/Current"
+import Tabs from "../state/Tabs"
+import {Store} from "../state/types"
+
+export class DevGlobal {
+  constructor(readonly store: Store) {}
+
+  get url() {
+    return Current.getLocation(this.store.getState())
+  }
+
+  get state() {
+    return this.store.getState()
+  }
+
+  get currentTabState() {
+    return Tabs.getActiveTab(this.store.getState())
+  }
+}
+
+export default function(store) {
+  global.dev = new DevGlobal(store)
+}

--- a/src/js/initializers/initGlobals.ts
+++ b/src/js/initializers/initGlobals.ts
@@ -8,7 +8,6 @@ import {createMemoryHistory} from "history"
 import tabHistory from "app/router/tab-history"
 
 export default function initGlobals(store: Store) {
-  global.getState = store.getState
   global.windowId = getUrlSearchParams().id
   global.windowName = getWindowName()
   global.feature = (name, status) => store.dispatch(Feature.set(name, status))

--- a/src/js/initializers/initialize.ts
+++ b/src/js/initializers/initialize.ts
@@ -1,3 +1,5 @@
+import BrimApi from "../api"
+import initDebugGlobals from "./initDebugGlobals"
 import initDOM from "./initDOM"
 import initGlobals from "./initGlobals"
 import initIpcListeners from "./initIpcListeners"
@@ -5,7 +7,6 @@ import initMenuActionListeners from "./initMenuActionListeners"
 import initPlugins from "./initPlugins"
 import initStore from "./initStore"
 import initWorkspaceParams from "./initWorkspaceParams"
-import BrimApi from "../api"
 
 export default async function initialize() {
   const api = new BrimApi()
@@ -19,5 +20,6 @@ export default async function initialize() {
   initIpcListeners(store, pluginManager)
   initMenuActionListeners(store)
   initWorkspaceParams(store)
+  initDebugGlobals(store)
   return {store, pluginManager}
 }


### PR DESCRIPTION
Fixes #1769 

The app won't crash if the user clicks "last 30 minutes". There is more work to be done than just this quick fix. We need to hide the span controls if the backend provides a null span for a pool. We also need to consider bad "from" and "to" values provided by the user. It's not handled very clearly right now.