### PR TITLE
activate fix

### DIFF
--- a/src/js/components/LogDetailsWindow/test.tsx
+++ b/src/js/components/LogDetailsWindow/test.tsx
@@ -25,8 +25,6 @@ test("right click => new search focuses search window", async () => {
   fireEvent.click(screen.getByText(/new search with this value/i))
   await flushPromises()
 
-  const searchWindow = main.windows
-    .getWindows()
-    .find((w) => w.name === "search")
+  const searchWindow = main.windows.getAll().find((w) => w.name === "search")
   expect(searchWindow.ref.focus).toHaveBeenCalled()
 })

--- a/src/js/electron/brim-start.test.ts
+++ b/src/js/electron/brim-start.test.ts
@@ -41,7 +41,7 @@ test("activate when one or more windows open", async () => {
 test("start opens default windows and in correct focus order", async () => {
   await brim.start()
   expect(brim.windows.count()).toBe(2)
-  const windows = brim.windows.getWindows()
+  const windows = brim.windows.getAll()
   expect(windows[0].name).toBe("hidden")
   expect(windows[1].name).toBe("search")
 })

--- a/src/js/electron/brim.ts
+++ b/src/js/electron/brim.ts
@@ -21,6 +21,7 @@ import tron, {Session} from "./tron"
 import formatSessionState from "./tron/formatSessionState"
 import {sessionStateFile} from "./tron/session"
 import windowManager, {$WindowManager} from "./tron/windowManager"
+import log from "electron-log"
 
 type QuitOpts = {
   saveSession?: boolean
@@ -69,7 +70,9 @@ export class BrimMain {
   }
 
   activate() {
-    if (this.windows.count() === 0) this.windows.init()
+    log.info("activate fired! window count: ", this.windows.count())
+    if (this.windows.count() === 0 || this.windows.count() === 1)
+      this.windows.init()
   }
 
   async resetState() {

--- a/src/js/electron/brim.ts
+++ b/src/js/electron/brim.ts
@@ -21,7 +21,6 @@ import tron, {Session} from "./tron"
 import formatSessionState from "./tron/formatSessionState"
 import {sessionStateFile} from "./tron/session"
 import windowManager, {$WindowManager} from "./tron/windowManager"
-import log from "electron-log"
 
 type QuitOpts = {
   saveSession?: boolean

--- a/src/js/electron/brim.ts
+++ b/src/js/electron/brim.ts
@@ -70,9 +70,7 @@ export class BrimMain {
   }
 
   activate() {
-    log.info("activate fired! window count: ", this.windows.count())
-    if (this.windows.count() === 0 || this.windows.count() === 1)
-      this.windows.init()
+    if (!this.windows.getVisible().length) this.windows.init()
   }
 
   async resetState() {

--- a/src/js/electron/ipc/globalStore/mainHandler.ts
+++ b/src/js/electron/ipc/globalStore/mainHandler.ts
@@ -12,7 +12,7 @@ export default function(brim: BrimMain) {
 
   ipcMain.handle("globalStore:dispatch", (e, {action}) => {
     brim.store.dispatch(action)
-    for (const win of brim.windows.getWindows()) {
+    for (const win of brim.windows.getAll()) {
       // Don't send it back to the sender, their store will have already been updated.
       if (!win.ref.isDestroyed() && e.sender !== win.ref.webContents) {
         sendTo(

--- a/src/js/electron/tron/windowManager.test.ts
+++ b/src/js/electron/tron/windowManager.test.ts
@@ -52,3 +52,17 @@ test("when all closed waits until windows are done", (done) => {
     done()
   })
 })
+
+test("prevent multiple hidden windows", async () => {
+  const manager = tron.windowManager()
+  manager.openHidden()
+  let windows = manager.getWindows()
+  expect(windows).toHaveLength(1)
+  expect(windows[0].name).toEqual("hidden")
+
+  // try again, still expect only 1
+  manager.openHidden()
+  windows = manager.getWindows()
+  expect(windows).toHaveLength(1)
+  expect(windows[0].name).toEqual("hidden")
+})

--- a/src/js/electron/tron/windowManager.test.ts
+++ b/src/js/electron/tron/windowManager.test.ts
@@ -55,14 +55,30 @@ test("when all closed waits until windows are done", (done) => {
 
 test("prevent multiple hidden windows", async () => {
   const manager = tron.windowManager()
-  manager.openHidden()
-  let windows = manager.getWindows()
+  manager.ensureHiddenRenderer()
+  let windows = manager.getAll()
   expect(windows).toHaveLength(1)
   expect(windows[0].name).toEqual("hidden")
 
   // try again, still expect only 1
-  manager.openHidden()
-  windows = manager.getWindows()
+  manager.ensureHiddenRenderer()
+  windows = manager.getAll()
   expect(windows).toHaveLength(1)
   expect(windows[0].name).toEqual("hidden")
+})
+
+test("window getters filter properly", async () => {
+  const manager = tron.windowManager()
+  manager.openWindow("search")
+  expect(manager.getVisible()).toHaveLength(1)
+  let windows = manager.getAll()
+  expect(windows).toHaveLength(1)
+  expect(windows[0].name).toEqual("search")
+  expect(manager.getHidden()).toHaveLength(0)
+
+  manager.openWindow("hidden")
+  windows = manager.getAll()
+  expect(windows).toHaveLength(2)
+  expect(manager.getVisible()).toHaveLength(1)
+  expect(manager.getHidden()).toHaveLength(1)
 })

--- a/src/js/electron/tron/windowManager.ts
+++ b/src/js/electron/tron/windowManager.ts
@@ -47,7 +47,7 @@ export default function windowManager(
   return {
     init() {
       // hidden renderer/window is never persisted, so always open it with rest
-      this.openWindow("hidden")
+      this.openHidden()
 
       if (!session || (session && session.order.length === 0)) {
         this.openWindow("search")
@@ -205,6 +205,12 @@ export default function windowManager(
         windows[id] = win
         return win
       }
+    },
+
+    openHidden() {
+      // only open hidden window if one doesn't already exist
+      if (this.getWindows().find((w) => w.name === "hidden")) return
+      this.openWindow("hidden")
     },
 
     openAbout() {


### PR DESCRIPTION
fixes #1770 

Part of the activation handler was still conditional to there being zero windows rendered, which should ideally never exist since there should always be at least a hidden window. This adjusts the logic accordingly. I also found a way to render multiple hidden windows using this activation flow, so I've included some protection around that as well.