### PR TITLE
Format Ingest Error

### DIFF
--- a/app/lakes/import.tsx
+++ b/app/lakes/import.tsx
@@ -2,6 +2,7 @@ import LoadFilesInput from "ppl/import/LoadFilesInput"
 import React from "react"
 import toast from "react-hot-toast"
 import {useDispatch} from "react-redux"
+import {TransactionError} from "src/js/lib/transaction"
 import Link from "../../src/js/components/common/Link"
 import errors from "../../src/js/errors"
 import ingestFiles from "../../src/js/flows/ingestFiles"
@@ -10,24 +11,28 @@ import ErrorFactory from "../../src/js/models/ErrorFactory"
 import Notice from "../../src/js/state/Notice"
 import {AppDispatch} from "../../src/js/state/types"
 
+function handleError(e: TransactionError, dispatch: AppDispatch) {
+  const cause = e.cause
+  if (/(Failed to fetch)|(network error)/.test(cause.message)) {
+    dispatch(Notice.set(errors.importInterrupt()))
+  } else if (/format detection error/i.test(cause.message)) {
+    dispatch(Notice.set(errors.formatDetection(cause.message)))
+  } else {
+    dispatch(Notice.set(ErrorFactory.create(e.cause)))
+  }
+
+  dispatch(refreshPoolNames())
+  console.error(e.message)
+}
+
 export default function TabImport() {
   const dispatch = useDispatch<AppDispatch>()
 
   function onChange(_e, files) {
     if (!files.length) return
     dispatch(ingestFiles(files))
-      .then(() => {
-        toast.success("Import complete.")
-      })
-      .catch((e) => {
-        const regex = /(Failed to fetch)|(network error)/
-        regex.test(e.cause.message)
-          ? dispatch(Notice.set(errors.importInterrupt()))
-          : dispatch(Notice.set(ErrorFactory.create(e.cause)))
-
-        dispatch(refreshPoolNames())
-        console.error(e.message)
-      })
+      .then(() => toast.success("Import complete."))
+      .catch((e) => handleError(e, dispatch))
   }
 
   return (

--- a/src/css/_notice-banner.scss
+++ b/src/css/_notice-banner.scss
@@ -2,6 +2,7 @@
   @include error-bg;
   padding: $space-s $space-m;
   font-size: 14px;
+  font-weight: 500;
   margin: 0;
 
   p {
@@ -13,6 +14,7 @@
     text-decoration: underline;
     cursor: pointer;
     user-select: none;
+    font-weight: 400;
 
     &:hover {
       color: var(--slate);
@@ -26,9 +28,9 @@
   .error-details {
     margin-top: 12px;
     p {
-      font-weight: bold;
-      font-size: 10px;
-      margin-bottom: 3px;
+      font-size: 12px;
+      font-weight: 400;
+      line-height: 17px;
     }
   }
 

--- a/src/js/components/LeftPane/QueriesSection.tsx
+++ b/src/js/components/LeftPane/QueriesSection.tsx
@@ -152,7 +152,10 @@ function QueriesSection({isOpen, style, resizeProps, toggleProps}) {
   const menu = usePopupMenu(template)
 
   function onItemClick(_, item) {
-    if (!currentPool) return dispatch(Notice.set(new Error("No pool selected")))
+    if (!currentPool)
+      return dispatch(
+        Notice.set({type: "NoPoolError", message: "No Pool Selected"})
+      )
 
     if (!item.value) return
 

--- a/src/js/errors/index.ts
+++ b/src/js/errors/index.ts
@@ -13,5 +13,10 @@ export default {
     type: "ImportInterruptError",
     message: "The import was interrupted.",
     details: ["To prevent this, keep your computer awake during the import."]
+  }),
+  formatDetection: (s: string) => ({
+    type: "FormatDetectionError",
+    message: "Format Detection Error",
+    details: [s.replace("format detection error", "").trim()]
   })
 }

--- a/src/js/errors/types.ts
+++ b/src/js/errors/types.ts
@@ -1,11 +1,5 @@
-export type BrimErrorType =
-  | "PCAPIngestError"
-  | "NetworkError"
-  | "LogsIngestError"
-  | "PoolDeletedError"
-
 export type BrimError = {
-  type: BrimErrorType
+  type: string
   message: string
   details?: string[]
 }

--- a/src/js/flows/deletePools.ts
+++ b/src/js/flows/deletePools.ts
@@ -8,7 +8,13 @@ const deletePools = (ids: string[]): Thunk<Promise<void[] | void>> => (
 ) => {
   return Promise.all(ids.map((id) => dispatch(deletePool(id))))
     .catch((e) => {
-      dispatch(Notice.set(new Error(`Error deleting pools: ${e.message}`)))
+      dispatch(
+        Notice.set({
+          type: "PoolDeleteError",
+          message: "Error Deleting Pools",
+          details: e.message
+        })
+      )
     })
     .finally(() => dispatch(refreshPoolNames()))
 }

--- a/src/js/lib/transaction.ts
+++ b/src/js/lib/transaction.ts
@@ -57,7 +57,7 @@ class UndoError extends Error {
   }
 }
 
-class TransactionError extends Error {
+export class TransactionError extends Error {
   cause: Error
   undoErrors: UndoError[]
 

--- a/src/js/models/AppError.ts
+++ b/src/js/models/AppError.ts
@@ -1,6 +1,6 @@
 import startCase from "lodash/startCase"
 
-import {BrimError, BrimErrorType} from "../errors/types"
+import {BrimError} from "../errors/types"
 
 export type RawError = any
 export type ErrorContext = any
@@ -59,7 +59,7 @@ export default class AppError {
 
   toBrimError(): BrimError {
     return {
-      type: this.constructor.name as BrimErrorType,
+      type: this.constructor.name,
       message: this.message(),
       details: this.details()
     }

--- a/src/js/state/Notice/actions.ts
+++ b/src/js/state/Notice/actions.ts
@@ -1,8 +1,9 @@
-import {NOTICE_CLEAR, NOTICE_DISMISS, NOTICE_SET} from "./types"
+import {BrimError} from "src/js/errors/types"
 import AppError from "../../models/AppError"
+import {NOTICE_CLEAR, NOTICE_DISMISS, NOTICE_SET} from "./types"
 
 export default {
-  set: (error: any): NOTICE_SET => ({
+  set: (error: AppError | BrimError): NOTICE_SET => ({
     type: "NOTICE_SET",
     error: error instanceof AppError ? error.toBrimError() : error
   }),

--- a/src/js/style-theme/index.ts
+++ b/src/js/style-theme/index.ts
@@ -32,7 +32,7 @@ const labelSmall = css`
 const labelNormal = css`
   font-family: system-ui, sans-serif;
   font-size: 13px;
-  line-height: 16px;
+  line-height: 18px;
   font-weight: 400;
 `
 


### PR DESCRIPTION
Closes #1775 

Before we switched to the "add/commit" endpoints to ingest data, we would send all the files to the "logs" endpoint. If one of the files was an unknown format, the rest of the files would be ingested fine, and the user would get a warning in the UI saying that some files did not make it. It was all one request and the backend returned "Warning" messages in the response for files that it could not parse.

Now, we loop through the files and call "and" them "commit" for each. If an unknown file is included in the files, the "add" endpoint will return a 500 with the error text seen in the issue. This aborts the whole ingest, the pool gets deleted, and even the good files are not added.

In the short term, I've just formatted this error correctly in the UI as shown below. In the future we need to update the app with this logic:

1. If all files fail, display an error, delete the pool
2. If some files file, display a warning for those that failed, keep the pool

![image](https://user-images.githubusercontent.com/3460638/130290516-f2c09fce-37fb-40ce-94a6-9d3440875746.png)

