### PR TITLE
Remove Scientific Notation By Default

### DIFF
--- a/app/core/format.test.ts
+++ b/app/core/format.test.ts
@@ -1,0 +1,10 @@
+import {createData} from "test/shared/factories/zed-factory"
+import {zed} from "zealot"
+import {formatPrimitive} from "./format"
+
+test("format a long number", () => {
+  const num = createData(1394668388559068) as zed.Primitive
+  const str = formatPrimitive(num)
+
+  expect(str).toBe("1,394,668,388,559,068")
+})

--- a/app/core/format.ts
+++ b/app/core/format.ts
@@ -77,7 +77,8 @@ function replaceDecimal(string: string, replacement: string | undefined) {
 
 function formatInt(string: number, config: Partial<FormatConfig> = {}) {
   const locale = getNumberLocale(config)
-  return locale.format(",")(string)
+  // https://github.com/d3/d3-format
+  return locale.format(",.0f")(string)
 }
 
 /**


### PR DESCRIPTION
Large integers are no longer formatted with exponent notation. Fixes #1783 

![image](https://user-images.githubusercontent.com/3460638/130293507-afb8ba10-b38c-41e0-997c-c785cc61ec6b.png)
