### PR TITLE
Advance Brimcap dependency to tag v1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8174,8 +8174,8 @@
       }
     },
     "brimcap": {
-      "version": "github:brimdata/brimcap#c0ae0bfa674e0a28ff7cabea785229fdb24f87cb",
-      "from": "github:brimdata/brimcap#v1.0.1",
+      "version": "github:brimdata/brimcap#bc47b4fa85f88480342c2445cb88a653b9c69437",
+      "from": "github:brimdata/brimcap#v1.0.2",
       "dev": true
     },
     "browser-process-hrtime": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "babel-plugin-inline-react-svg": "^1.1.1",
     "babel-plugin-module-resolver": "^4.0.0",
     "babel-plugin-source-map-support": "^2.1.2",
-    "brimcap": "brimdata/brimcap#v1.0.1",
+    "brimcap": "brimdata/brimcap#v1.0.2",
     "chalk": "^4.1.0",
     "commander": "^2.20.3",
     "cpx": "^1.5.0",


### PR DESCRIPTION
To take advantage of the fix to #1773.