### PR TITLE
Zed update through brimdata/zed#2976

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26126,8 +26126,8 @@
       }
     },
     "zed": {
-      "version": "git+https://github.com/brimdata/zed.git#63f7117b61f911b04bcef64efe713bc63bc7f460",
-      "from": "git+https://github.com/brimdata/zed.git#63f7117b61f911b04bcef64efe713bc63bc7f460"
+      "version": "git+https://github.com/brimdata/zed.git#f2cae0deaa01d8dc1ad168fc80a7c6cf3863c1e9",
+      "from": "git+https://github.com/brimdata/zed.git#f2cae0deaa01d8dc1ad168fc80a7c6cf3863c1e9"
     },
     "zip-stream": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "tee-1": "^0.2.0",
     "tree-model": "^1.0.7",
     "valid-url": "^1.0.9",
-    "zed": "git+https://github.com/brimdata/zed.git#63f7117b61f911b04bcef64efe713bc63bc7f460"
+    "zed": "git+https://github.com/brimdata/zed.git#f2cae0deaa01d8dc1ad168fc80a7c6cf3863c1e9"
   },
   "optionalDependencies": {
     "electron-installer-debian": "^3.0.0",

--- a/plugins/brimcap/brimcap-plugin.ts
+++ b/plugins/brimcap/brimcap-plugin.ts
@@ -12,7 +12,7 @@ import {reactElementProps} from "../../test/integration/helpers/integration"
 import BrimcapCLI, {analyzeOptions, searchOptions} from "./brimcap-cli"
 import {ChildProcess, spawn} from "child_process"
 import {MenuItemConstructorOptions} from "electron"
-import {compact, get} from "lodash"
+import {compact} from "lodash"
 import env from "app/core/env"
 
 export default class BrimcapPlugin {
@@ -269,7 +269,7 @@ export default class BrimcapPlugin {
 
   private setupLoader() {
     const load = async (
-      params: IngestParams & {poolId: string},
+      params: IngestParams & {poolId: string; branchId: string},
       onProgressUpdate: (value: number | null) => void,
       onWarning: (warning: string) => void,
       onDetailUpdate: () => void,
@@ -330,16 +330,10 @@ export default class BrimcapPlugin {
 
       // stream analyze output to pool
       const zealot = this.api.getZealot()
-      const res = await zealot.pools.add(params.poolId, {
-        data: p.stdout,
-        signal
-      })
-      const commitId = get(res, ["value", "commit"], "")
-      if (!commitId) throw new Error("No commit obtained from lake add")
-
-      await zealot.pools.commit(params.poolId, commitId, {
+      await zealot.pools.load(params.poolId, params.branchId, {
         author: "brim",
         message: "automatic import with brimcap analyze",
+        data: p.stdout,
         signal
       })
 

--- a/plugins/log-loader/index.ts
+++ b/plugins/log-loader/index.ts
@@ -5,7 +5,7 @@ import {Readable} from "stream"
 
 export const activate = (api: BrimApi) => {
   const load = async (
-    params: IngestParams & {poolId: string},
+    params: IngestParams & {poolId: string; branchId: string},
     onProgressUpdate: (value: number | null) => void,
     onWarning: (warning: string) => void,
     onDetailUpdate: () => Promise<void>,
@@ -25,18 +25,13 @@ export const activate = (api: BrimApi) => {
         }
       })
       const stream = file.stream().pipeThrough(progressUpdateTransformStream)
-      const res = await zealot.pools.add(params.poolId, {
+      const res = await zealot.pools.load(params.poolId, params.branchId, {
+        author: "brim",
+        message: "automatic import of " + file.path,
         data: nodeJSReadableStreamFromReadableStream(stream),
         signal
       })
-      const commitId = get(res, ["value", "commit"], "")
-      if (!commitId) throw new Error("No commit obtained from lake add")
       forEach(get(res, ["value", "warnings"], []), onWarning)
-      await zealot.pools.commit(params.poolId, commitId, {
-        author: "brim",
-        message: "automatic import of " + file.path,
-        signal
-      })
     }
     await onDetailUpdate()
     onProgressUpdate(1)

--- a/scripts/test/search.js
+++ b/scripts/test/search.js
@@ -8,11 +8,11 @@ const FILE = join(process.cwd(), process.argv[2])
 const QUERY = process.argv[3]
 
 async function ingest(zealot) {
-  const create = await zealot.pools.create({name: "gen space"})
-  await zealot.pools.load(create.pool.id, create.branch.id, {
+  const {pool, branch} = await zealot.pools.create({name: "gen space"})
+  await zealot.pools.load(pool.id, branch.id, {
     data: createReadStream(FILE)
   })
-  return {poolId: create.pool.id, branchId: create.branch.id}
+  return {poolId: pool.id, branchId: branch.id}
 }
 
 withLake(

--- a/scripts/test/search.js
+++ b/scripts/test/search.js
@@ -8,12 +8,11 @@ const FILE = join(process.cwd(), process.argv[2])
 const QUERY = process.argv[3]
 
 async function ingest(zealot) {
-  const pool = await zealot.pools.create({name: "gen space"})
-  const add = await zealot.pools.add(pool.id, {
+  const create = await zealot.pools.create({name: "gen space"})
+  await zealot.pools.load(create.pool.id, create.branch.id, {
     data: createReadStream(FILE)
   })
-  await zealot.pools.commit(pool.id, add.value.commit, {})
-  return pool.id
+  return {poolId: create.pool.id, branchId: create.branch.id}
 }
 
 withLake(

--- a/src/js/flows/createPool.ts
+++ b/src/js/flows/createPool.ts
@@ -19,9 +19,9 @@ export const createPool = ({name}: Props): Thunk<Promise<void>> => (
     .create({
       name
     })
-    .then((pool) => {
+    .then((create) => {
       dispatch(refreshPoolNames()).then(() =>
-        dispatch(tabHistory.push(lakePath(pool.id, workspaceId)))
+        dispatch(tabHistory.push(lakePath(create.pool.id, workspaceId)))
       )
     })
 }

--- a/src/js/flows/ingestFiles.test.ts
+++ b/src/js/flows/ingestFiles.test.ts
@@ -18,8 +18,14 @@ let store, zealot, apiMock
 beforeEach(() => {
   zealot = createZealotMock()
     .stubPromise("pools.create", {
-      name: "sample.pcap.brim",
-      id: "poolId"
+      pool: {
+        name: "sample.pcap.brim",
+        id: "poolId"
+      },
+      branch: {
+        name: "main",
+        id: "branchId"
+      }
     })
     .stubPromise(
       "pools.get",

--- a/src/js/flows/ingestFiles.ts
+++ b/src/js/flows/ingestFiles.ts
@@ -61,14 +61,14 @@ const validateInput = (files: File[], poolNames) => ({
 
 const createPool = (client: Zealot, gDispatch, workspaceId) => ({
   async do(params: IngestParams) {
-    const create = await client.pools.create({name: params.name})
+    const {pool, branch} = await client.pools.create({name: params.name})
     gDispatch(
       Pools.setDetail(workspaceId, {
-        ...create.pool,
+        ...pool,
         ingest: {progress: 0, warnings: []}
       })
     )
-    return {...params, poolId: create.pool.id, branchId: create.branch.id}
+    return {...params, poolId: pool.id, branchId: branch.id}
   },
   async undo({poolId}: IngestParams & {poolId: string}) {
     await client.pools.delete(poolId)

--- a/src/js/flows/ingestFiles.ts
+++ b/src/js/flows/ingestFiles.ts
@@ -61,15 +61,14 @@ const validateInput = (files: File[], poolNames) => ({
 
 const createPool = (client: Zealot, gDispatch, workspaceId) => ({
   async do(params: IngestParams) {
-    const pool = await client.pools.create({name: params.name})
+    const create = await client.pools.create({name: params.name})
     gDispatch(
       Pools.setDetail(workspaceId, {
-        ...pool,
+        ...create.pool,
         ingest: {progress: 0, warnings: []}
       })
     )
-
-    return {...params, poolId: pool.id}
+    return {...params, poolId: create.pool.id, branchId: create.branch.id}
   },
   async undo({poolId}: IngestParams & {poolId: string}) {
     await client.pools.delete(poolId)

--- a/src/js/hidden.tsx
+++ b/src/js/hidden.tsx
@@ -55,18 +55,18 @@ const Hidden = () => {
       wsSource.addEventListener("pool-delete", (_e) => {
         dispatch(refreshPoolNames(workspace(w)))
       })
-      wsSource.addEventListener("pool-commit", (e) => {
+      wsSource.addEventListener("branch-commit", (e) => {
         let eventData
         try {
           eventData = JSON.parse(e["data"])
         } catch (e) {
           return log.error(
-            new Error("Cannot parse pool-commit event data: " + e)
+            new Error("Cannot parse branch-commit event data: " + e)
           )
         }
         const poolId = eventData && eventData["pool_id"]
         if (!poolId)
-          return log.error(new Error("No 'pool_id' from pool-commit event"))
+          return log.error(new Error("No 'pool_id' from branch-commit event"))
 
         dispatch(refreshPoolInfo({workspaceId: w.id, poolId}))
       })

--- a/test/api/tests/ingest.test.ts
+++ b/test/api/tests/ingest.test.ts
@@ -6,54 +6,48 @@ import fs from "fs"
 
 test("ingest ZNG logs", () => {
   return withLake(async (zealot: Zealot) => {
-    const pool = await zealot.pools.create({name: "pool1"})
-    let stats = await zealot.pools.stats(pool.id)
-    expect(stats).toBeNull()
+    const create = await zealot.pools.create({name: "pool1"})
+    let {size} = await zealot.pools.stats(create.pool.id)
+    expect(size).toBe(0)
     const logStream = fs.createReadStream(data.getPath("sample.zng"))
-    const addResp = await zealot.pools.add(pool.id, {
-      data: logStream
-    })
-    await zealot.pools.commit(pool.id, addResp.value.commit, {
+    await zealot.pools.load(create.pool.id, create.branch.id, {
+      author: "test author",
       message: "test message",
-      author: "test author"
-    })
-    const {size} = await zealot.pools.stats(pool.id)
+      data: logStream
+    });
+    ({size} = await zealot.pools.stats(create.pool.id))
     expect(size).toBe(5250)
   })
 })
 
 test("ingest TSV logs", () => {
   return withLake(async (zealot: Zealot) => {
-    const pool = await zealot.pools.create({name: "pool1"})
-    let stats = await zealot.pools.stats(pool.id)
-    expect(stats).toBeNull()
+    const create = await zealot.pools.create({name: "pool1"})
+    let {size} = await zealot.pools.stats(create.pool.id)
+    expect(size).toBe(0)
     const logStream = fs.createReadStream(data.getPath("sample.tsv"))
-    const addResp = await zealot.pools.add(pool.id, {
-      data: logStream
-    })
-    await zealot.pools.commit(pool.id, addResp.value.commit, {
+    await zealot.pools.load(create.pool.id, create.branch.id, {
+      author: "test author",
       message: "test message",
-      author: "test author"
-    })
-    const {size} = await zealot.pools.stats(pool.id)
+      data: logStream
+    });
+    ({size} = await zealot.pools.stats(create.pool.id))
     expect(size).toBe(4084)
   })
 })
 
 test("ingest NDJSON logs", () => {
   return withLake(async (zealot: Zealot) => {
-    const pool = await zealot.pools.create({name: "pool1"})
-    let stats = await zealot.pools.stats(pool.id)
-    expect(stats).toBeNull()
+    const create = await zealot.pools.create({name: "pool1"})
+    let {size} = await zealot.pools.stats(create.pool.id)
+    expect(size).toBe(0)
     const logStream = fs.createReadStream(data.getPath("custom-sample.ndjson"))
-    const addResp = await zealot.pools.add(pool.id, {
-      data: logStream
-    })
-    await zealot.pools.commit(pool.id, addResp.value.commit, {
+    await zealot.pools.load(create.pool.id, create.branch.id, {
+      author: "test author",
       message: "test message",
-      author: "test author"
-    })
-    const {size} = await zealot.pools.stats(pool.id)
+      data: logStream
+    });
+    ({size} = await zealot.pools.stats(create.pool.id))
     expect(size).toBe(4467)
   })
 })

--- a/test/api/tests/ingest.test.ts
+++ b/test/api/tests/ingest.test.ts
@@ -6,48 +6,48 @@ import fs from "fs"
 
 test("ingest ZNG logs", () => {
   return withLake(async (zealot: Zealot) => {
-    const create = await zealot.pools.create({name: "pool1"})
-    let {size} = await zealot.pools.stats(create.pool.id)
+    const {pool, branch} = await zealot.pools.create({name: "pool1"})
+    let {size} = await zealot.pools.stats(pool.id)
     expect(size).toBe(0)
     const logStream = fs.createReadStream(data.getPath("sample.zng"))
-    await zealot.pools.load(create.pool.id, create.branch.id, {
+    await zealot.pools.load(pool.id, branch.id, {
       author: "test author",
       message: "test message",
       data: logStream
     });
-    ({size} = await zealot.pools.stats(create.pool.id))
+    ({size} = await zealot.pools.stats(pool.id))
     expect(size).toBe(5250)
   })
 })
 
 test("ingest TSV logs", () => {
   return withLake(async (zealot: Zealot) => {
-    const create = await zealot.pools.create({name: "pool1"})
-    let {size} = await zealot.pools.stats(create.pool.id)
+    const {pool, branch} = await zealot.pools.create({name: "pool1"})
+    let {size} = await zealot.pools.stats(pool.id)
     expect(size).toBe(0)
     const logStream = fs.createReadStream(data.getPath("sample.tsv"))
-    await zealot.pools.load(create.pool.id, create.branch.id, {
+    await zealot.pools.load(pool.id, branch.id, {
       author: "test author",
       message: "test message",
       data: logStream
     });
-    ({size} = await zealot.pools.stats(create.pool.id))
+    ({size} = await zealot.pools.stats(pool.id))
     expect(size).toBe(4084)
   })
 })
 
 test("ingest NDJSON logs", () => {
   return withLake(async (zealot: Zealot) => {
-    const create = await zealot.pools.create({name: "pool1"})
-    let {size} = await zealot.pools.stats(create.pool.id)
+    const {pool, branch} = await zealot.pools.create({name: "pool1"})
+    let {size} = await zealot.pools.stats(pool.id)
     expect(size).toBe(0)
     const logStream = fs.createReadStream(data.getPath("custom-sample.ndjson"))
-    await zealot.pools.load(create.pool.id, create.branch.id, {
+    await zealot.pools.load(pool.id, branch.id, {
       author: "test author",
       message: "test message",
       data: logStream
     });
-    ({size} = await zealot.pools.stats(create.pool.id))
+    ({size} = await zealot.pools.stats(pool.id))
     expect(size).toBe(4467)
   })
 })

--- a/test/api/tests/pools.test.ts
+++ b/test/api/tests/pools.test.ts
@@ -10,7 +10,7 @@ test("listing the pool", () => {
 
 test("creating a pool", () => {
   return withLake(async (zealot: any) => {
-    const create = await zealot.pools.create({name: "pool1"})
-    expect(create.pool.name).toBe("pool1")
+    const {pool} = await zealot.pools.create({name: "pool1"})
+    expect(pool.name).toBe("pool1")
   })
 })

--- a/test/api/tests/pools.test.ts
+++ b/test/api/tests/pools.test.ts
@@ -10,7 +10,7 @@ test("listing the pool", () => {
 
 test("creating a pool", () => {
   return withLake(async (zealot: any) => {
-    const pool = await zealot.pools.create({name: "pool1"})
-    expect(pool.name).toBe("pool1")
+    const create = await zealot.pools.create({name: "pool1"})
+    expect(create.pool.name).toBe("pool1")
   })
 })

--- a/test/api/tests/search.test.ts
+++ b/test/api/tests/search.test.ts
@@ -4,17 +4,15 @@ import {withLake} from "../helpers/with-lake"
 import data from "test/shared/data"
 
 async function setup(zealot: any) {
-  const pool = await zealot.pools.create({name: "pool1"})
-  const add = await zealot.pools.add(pool.id, {
-    data: createReadStream(data.getPath("sample.tsv"))
-  })
-  await zealot.pools.commit(pool.id, add.value.commit, {
+  const create = await zealot.pools.create({name: "pool1"})
+  await zealot.pools.load(create.pool.id, create.branch.id, {
+    author: "test author",
     message: "test message",
-    author: "test author"
+    data: createReadStream(data.getPath("sample.tsv"))
   })
 
   zealot.setSearchOptions({
-    poolId: pool.id,
+    poolId: create.pool.id,
     from: new Date(0),
     to: new Date(),
     enhancers: []

--- a/test/api/tests/search.test.ts
+++ b/test/api/tests/search.test.ts
@@ -4,15 +4,15 @@ import {withLake} from "../helpers/with-lake"
 import data from "test/shared/data"
 
 async function setup(zealot: any) {
-  const create = await zealot.pools.create({name: "pool1"})
-  await zealot.pools.load(create.pool.id, create.branch.id, {
+  const {pool, branch} = await zealot.pools.create({name: "pool1"})
+  await zealot.pools.load(pool.id, branch.id, {
     author: "test author",
     message: "test message",
     data: createReadStream(data.getPath("sample.tsv"))
   })
 
   zealot.setSearchOptions({
-    poolId: create.pool.id,
+    poolId: pool.id,
     from: new Date(0),
     to: new Date(),
     enhancers: []

--- a/zealot/api/pools.ts
+++ b/zealot/api/pools.ts
@@ -1,4 +1,4 @@
-import {PoolAddArgs, PoolArgs, PoolCommitArgs} from "../types"
+import {PoolArgs, PoolLoadArgs} from "../types"
 
 export default {
   list() {
@@ -46,21 +46,16 @@ export default {
       body: JSON.stringify(args)
     }
   },
-  add(poolId: string, args: PoolAddArgs) {
+  load(poolId: string, branchId: string, args: PoolLoadArgs) {
+    const {data, signal, ...rest} = args
     return {
-      headers: new Headers({Accept: "application/json"}),
-      path: `/pool/${poolId}/add`,
+      headers: new Headers({
+        Accept: "application/json",
+        "Zed-Commit": JSON.stringify(rest)
+      }),
+      path: `/pool/${poolId}/${branchId}`,
       method: "POST",
-      body: args.data
-    }
-  },
-  commit(poolId: string, commitId: string, args: PoolCommitArgs) {
-    const {signal, ...rest} = args
-    return {
-      headers: new Headers({Accept: "application/json"}),
-      path: `/pool/${poolId}/staging/${commitId}`,
-      method: "POST",
-      body: JSON.stringify(rest),
+      body: data,
       signal
     }
   }

--- a/zealot/types.ts
+++ b/zealot/types.ts
@@ -41,15 +41,11 @@ export interface SearchArgs {
   signal?: AbortSignal
 }
 
-export interface PoolAddArgs {
-  data: NodeJS.ReadableStream
-  signal?: AbortSignal
-}
-
-export interface PoolCommitArgs {
-  message: string
+export interface PoolLoadArgs {
   author: string
   date?: number
+  message: string
+  data: NodeJS.ReadableStream
   signal?: AbortSignal
 }
 
@@ -82,4 +78,15 @@ export interface PoolConfig {
 export interface PoolStats {
   size: number
   span?: Span
+}
+
+export interface BranchConfig {
+  name: string
+  id: string
+  parent: string
+}
+
+export interface BranchMeta {
+  pool: PoolConfig
+  branch: BranchConfig
 }

--- a/zealot/zealot.ts
+++ b/zealot/zealot.ts
@@ -4,14 +4,14 @@ import {getHost} from "./util/host"
 import {getDefaultSearchArgs} from "./config/search_args"
 import nodeFetch from "node-fetch"
 import {
+  BranchMeta,
   SearchArgs,
   Response,
   PoolArgs,
   PoolConfig,
   PoolStats,
   ZealotArgs,
-  PoolCommitArgs,
-  PoolAddArgs
+  PoolLoadArgs
 } from "./types"
 import {Context, Int64, Record, Time} from "./zed"
 import {IndexSearchArgs} from "./api/archive"
@@ -88,7 +88,7 @@ export function createZealot(
         }
         return stats
       },
-      create: async (args: PoolArgs): Promise<PoolConfig> => {
+      create: async (args: PoolArgs): Promise<BranchMeta> => {
         let res = await promise(pools.create(args))
         return res.value
       },
@@ -98,19 +98,11 @@ export function createZealot(
       update: (id: string, args: Partial<PoolArgs>) => {
         return promise(pools.update(id, args))
       },
-      add: async (id: string, args: PoolAddArgs) => {
-        const {path, method, body, headers} = pools.add(id, args)
-        const resp = await nodeFetch(url(host, path), {
-          method,
-          body,
-          headers,
-          signal: args.signal
-        })
+      load: async (poolId: string, branchId: string, args: PoolLoadArgs) => {
+        const {path, ...rest} = pools.load(poolId, branchId, args)
+        const resp = await nodeFetch(url(host, path), rest)
         const content = await parseContentType(resp)
         return resp.ok ? content : Promise.reject(createError(content))
-      },
-      commit: (id: string, commitId: string, args: PoolCommitArgs) => {
-        return promise(pools.commit(id, commitId, args))
       }
     },
     inspect: {


### PR DESCRIPTION
brimdata/zed#2976 contains two Zed API changes.
1. For pool creation, the `POST /pool` response now describes both the pool and the default branch (called main).
2. For loading data, `POST /pool/{pool}/{branch}` replaces the combination of `POST /pool/{pool}/add` followed by `POST /pool/{pool}/staging/{commit}`.