### PR TITLE
Fix links to Zed lake doc

### DIFF
--- a/app/legacy/space-migration/space-migration.tsx
+++ b/app/legacy/space-migration/space-migration.tsx
@@ -131,7 +131,7 @@ function Modal({onClose}) {
           migration tool
         </Link>{" "}
         and the{" "}
-        <Link href="https://github.com/brimdata/zed/blob/main/docs/lake/design.md">
+        <Link href="https://github.com/brimdata/zed/blob/main/docs/lake/README.md">
           Zed Lake design
         </Link>
         .

--- a/docs/Joining-Data-(v0.25.0+).md
+++ b/docs/Joining-Data-(v0.25.0+).md
@@ -41,7 +41,7 @@ shy!
 By its nature, a join operation requires two inputs that will
 ultimately be combined. The Zed [`join` docs](https://github.com/brimdata/zed/tree/main/docs/language/operators#join)
 show examples with the [Zed CLI tools](https://github.com/brimdata/zed/blob/main/cmd/zed/README.md)
-that specify these inputs as named files or Pools in a [Zed Lake](https://github.com/brimdata/zed/blob/main/docs/lake/design.md).
+that specify these inputs as named files or Pools in a [Zed Lake](https://github.com/brimdata/zed/blob/main/docs/lake/README.md).
 
 Brim release `v0.25.0` includes initial support for storing data in Zed Lakes.
 However, due to a current limitation ([brim/1618](https://github.com/brimdata/brim/issues/1618)),

--- a/docs/Migration-of-Spaces-(v0.25.0+).md
+++ b/docs/Migration-of-Spaces-(v0.25.0+).md
@@ -3,7 +3,7 @@
 Starting with GA Brim release `v0.25.0`, imported data will now be stored in
 Pools in a Zed Lake rather than in file-based Spaces as they were previously.
 
-The [Zed Lake design document](https://github.com/brimdata/zed/blob/main/docs/lake/design.md)
+The [Zed Lake README](https://github.com/brimdata/zed/blob/main/docs/lake/README.md)
 provides a thorough overview of Pools and how they work. In brief, the use of
 Pools ultimately enables new functionality that was not previously available in
 Brim, including:

--- a/docs/Remote-Workspaces-(v0.25.0+).md
+++ b/docs/Remote-Workspaces-(v0.25.0+).md
@@ -16,7 +16,7 @@
 # Summary
 
 By default, the Brim application connects to a Workspace on the system on which
-it is launched. This Workspace includes [Zed Lake](https://github.com/brimdata/zed/blob/main/docs/lake/design.md)
+it is launched. This Workspace includes [Zed Lake](https://github.com/brimdata/zed/blob/main/docs/lake/README.md)
 storage on the local filesystem for holding imported data. However, Brim is
 capable of accessing data stored in a Zed Lake in a remote Workspace as well.
 This cookbook describes the available options and current limitations.

--- a/docs/Troubleshooting-(v0.25.0+).md
+++ b/docs/Troubleshooting-(v0.25.0+).md
@@ -91,7 +91,7 @@ and details to [brim/1490](https://github.com/brimdata/brim/issues/1490).
 In all other cases, please [open a new issue](#opening-an-issue).
 
 To begin troubleshooting this, it helps to understand the "backend" of Brim.
-One essential component is a [Zed Lake](https://github.com/brimdata/zed/blob/main/docs/lake/design.md),
+One essential component is a [Zed Lake](https://github.com/brimdata/zed/blob/main/docs/lake/README.md),
 a server-style process that manages the storage and querying of imported data.
 Operations in the Pools of a Zed Lake are invoked via a [REST
 API](https://en.wikipedia.org/wiki/Representational_state_transfer) that's


### PR DESCRIPTION
brimdata/zed#3034 moved the contents of the former "Zed lake design doc" `design.md` to `README.md`. This PR fixes the links in the app that were pointing to the old location.