### PR TITLE
Kill Search & Aborted Searches

### DIFF
--- a/app/core/context.tsx
+++ b/app/core/context.tsx
@@ -1,0 +1,31 @@
+import React, {useContext, ReactElement} from "react"
+import {Provider} from "react-redux"
+import BrimApi from "src/js/api"
+import AppErrorBoundary from "src/js/components/AppErrorBoundary"
+import {Store} from "src/js/state/types"
+import theme from "src/js/style-theme"
+import {ThemeProvider} from "styled-components"
+
+const BrimApiContext = React.createContext<BrimApi | null>(null)
+
+export function useBrimApi() {
+  const value = useContext(BrimApiContext)
+  if (!value) throw new Error("No Brim Api Provided")
+  return value
+}
+
+export function BrimProvider(props: {
+  store: Store
+  api: BrimApi
+  children: ReactElement
+}) {
+  return (
+    <AppErrorBoundary>
+      <BrimApiContext.Provider value={props.api}>
+        <Provider store={props.store}>
+          <ThemeProvider theme={theme}>{props.children}</ThemeProvider>
+        </Provider>
+      </BrimApiContext.Provider>
+    </AppErrorBoundary>
+  )
+}

--- a/app/core/models/abortables.test.ts
+++ b/app/core/models/abortables.test.ts
@@ -1,0 +1,95 @@
+import {Abortables, Abortable} from "./abortables"
+
+describe("add get remove", () => {
+  function setup() {
+    return {instance: new Abortables()}
+  }
+
+  test("add with no id", () => {
+    const {instance} = setup()
+    const id = instance.add({abort: jest.fn()})
+    const abortable = instance.get(id)
+
+    expect(abortable).toEqual({id, abort: expect.any(Function)})
+  })
+
+  test("remove", () => {
+    const {instance} = setup()
+    const id = instance.add({abort: jest.fn()})
+
+    instance.remove(id)
+
+    expect(instance.all()).toEqual([])
+  })
+
+  test("remove by tab", () => {
+    const {instance} = setup()
+    instance.add({abort: jest.fn(), tab: "a"})
+    instance.add({abort: jest.fn(), tab: "a"})
+    instance.add({abort: jest.fn(), tab: "b"})
+
+    instance.remove({tab: "a"})
+
+    expect(instance.all()).toHaveLength(1)
+  })
+})
+
+describe("filter and abort", () => {
+  function ids(a: Abortable[]) {
+    return a.map((a) => a.id)
+  }
+  function setup() {
+    const instance = new Abortables()
+    const a1 = {id: "1", tab: "a", tag: "main", abort: jest.fn()}
+    const a2 = {id: "2", tab: "b", tag: "main", abort: jest.fn()}
+    const a3 = {id: "3", tab: "a", tag: "detail", abort: jest.fn()}
+    instance.add(a1)
+    instance.add(a2)
+    instance.add(a3)
+    return {instance, a1, a2, a3}
+  }
+
+  test("filter by area", () => {
+    const {instance} = setup()
+
+    const result = instance.filter({tag: "main"})
+
+    expect(ids(result)).toEqual(["1", "2"])
+  })
+
+  test("filter by tab", () => {
+    const {instance} = setup()
+
+    const result = instance.filter({tab: "a"})
+
+    expect(ids(result)).toEqual(["1", "3"])
+  })
+
+  test("filter by tab and area", () => {
+    const {instance} = setup()
+
+    const result = instance.filter({tab: "a", tag: "detail"})
+
+    expect(ids(result)).toEqual(["3"])
+  })
+
+  test("abort", () => {
+    const {instance, a1, a2, a3} = setup()
+
+    instance.abort()
+
+    expect(a1.abort).toHaveBeenCalled()
+    expect(a2.abort).toHaveBeenCalled()
+    expect(a3.abort).toHaveBeenCalled()
+  })
+
+  test("abort by tab", () => {
+    const {instance, a1, a2, a3} = setup()
+
+    instance.abort({tab: "b"})
+
+    expect(a1.abort).not.toHaveBeenCalled()
+    expect(a2.abort).toHaveBeenCalled()
+    expect(a3.abort).not.toHaveBeenCalled()
+  })
+})

--- a/app/core/models/abortables.test.ts
+++ b/app/core/models/abortables.test.ts
@@ -24,7 +24,7 @@ describe("add get remove", () => {
 
   test("remove by tab", () => {
     const {instance} = setup()
-    instance.add({abort: jest.fn(), tab: "a"})
+    instance.add({abort: jest.fn(() => Promise.resolve()), tab: "a"})
     instance.add({abort: jest.fn(), tab: "a"})
     instance.add({abort: jest.fn(), tab: "b"})
 
@@ -73,14 +73,23 @@ describe("filter and abort", () => {
     expect(ids(result)).toEqual(["3"])
   })
 
-  test("abort", () => {
+  test("abort all", async () => {
     const {instance, a1, a2, a3} = setup()
 
-    instance.abort()
+    await instance.abortAll()
 
     expect(a1.abort).toHaveBeenCalled()
     expect(a2.abort).toHaveBeenCalled()
     expect(a3.abort).toHaveBeenCalled()
+  })
+
+  test("abort by id", async () => {
+    const {instance, a1} = setup()
+
+    await instance.abort(a1.id)
+    await instance.abort("no-id")
+
+    expect(a1.abort).toHaveBeenCalled()
   })
 
   test("abort by tab", () => {

--- a/app/core/models/abortables.ts
+++ b/app/core/models/abortables.ts
@@ -14,8 +14,17 @@ type NewAbortable = Omit<Abortable, "id">
 export class Abortables {
   registry: Abortable[] = []
 
-  abort(predicate?: Partial<Abortable>) {
-    this.filter(predicate).forEach((a) => a.abort())
+  async abort(predicate: string | Partial<Abortable>) {
+    if (isString(predicate)) {
+      const a = this.get(predicate)
+      if (a) return await a.abort()
+    } else {
+      return Promise.all(this.filter(predicate).map((a) => a.abort()))
+    }
+  }
+
+  async abortAll() {
+    return Promise.all(this.all().map((a) => a.abort()))
   }
 
   add(a: Abortable | NewAbortable) {
@@ -25,11 +34,11 @@ export class Abortables {
   }
 
   all() {
-    return this.registry
+    return [...this.registry]
   }
 
   filter(predicate?: Partial<Abortable>) {
-    if (!predicate) return this.registry
+    if (!predicate) return this.all()
     return this.registry.filter(this.matchFn(predicate))
   }
 

--- a/app/core/models/abortables.ts
+++ b/app/core/models/abortables.ts
@@ -1,0 +1,54 @@
+import {nanoid} from "@reduxjs/toolkit"
+import {isString, remove} from "lodash"
+
+export type Abortable<Meta extends any = any> = {
+  id: string
+  tab?: string
+  tag?: string
+  meta?: Meta
+  abort: () => void | Promise<void>
+}
+
+type NewAbortable = Omit<Abortable, "id">
+
+export class Abortables {
+  registry: Abortable[] = []
+
+  abort(predicate?: Partial<Abortable>) {
+    this.filter(predicate).forEach((a) => a.abort())
+  }
+
+  add(a: Abortable | NewAbortable) {
+    const id = "id" in a ? a.id : nanoid()
+    this.registry.push({id, ...a})
+    return id
+  }
+
+  all() {
+    return this.registry
+  }
+
+  filter(predicate?: Partial<Abortable>) {
+    if (!predicate) return this.registry
+    return this.registry.filter(this.matchFn(predicate))
+  }
+
+  get(id: string) {
+    return this.registry.find((a) => a.id === id) || null
+  }
+
+  remove(predicate?: string | Partial<Abortable>) {
+    if (!predicate) {
+      this.registry = []
+    } else if (isString(predicate)) {
+      remove(this.registry, (a) => a.id === predicate)
+    } else {
+      remove(this.registry, this.matchFn(predicate))
+    }
+  }
+
+  private matchFn(predicate) {
+    return (a) =>
+      Object.keys(predicate).every((key) => a[key] === predicate[key])
+  }
+}

--- a/app/search/flows/histogram-search.test.ts
+++ b/app/search/flows/histogram-search.test.ts
@@ -1,7 +1,6 @@
 import tabHistory from "app/router/tab-history"
 import {lakePath} from "app/router/utils/paths"
 import Chart from "src/js/state/Chart"
-import Handlers from "src/js/state/Handlers"
 import Pools from "src/js/state/Pools"
 import Workspaces from "src/js/state/Workspaces"
 import fixtures from "test/unit/fixtures"

--- a/app/search/flows/histogram-search.test.ts
+++ b/app/search/flows/histogram-search.test.ts
@@ -50,27 +50,6 @@ test("the chart status updates", async () => {
   expect(select(Chart.getStatus)).toBe("SUCCESS")
 })
 
-test("registers historgram request then cleans it up", async (done) => {
-  const promise = submit()
-  expect(select(Handlers.get)["Histogram"]).toEqual(
-    expect.objectContaining({type: "SEARCH"})
-  )
-  await promise
-  // The promise only waits for the table, might be good to return two
-  // promises so people can decide what they want to wait for.
-  setTimeout(() => {
-    expect(select(Handlers.get)["Histogram"]).toBe(undefined)
-    done()
-  })
-})
-
-test("aborts previous histogram request", async () => {
-  const abort = jest.fn()
-  dispatch(Handlers.register("Histogram", {type: "SEARCH", abort}))
-  await submit()
-  expect(abort).toHaveBeenCalledTimes(1)
-})
-
 test("populates the chart", async () => {
   await submit()
   expect(select(Chart.getData)).toMatchSnapshot()

--- a/app/search/flows/viewer-search.test.ts
+++ b/app/search/flows/viewer-search.test.ts
@@ -1,7 +1,6 @@
 import tabHistory from "app/router/tab-history"
 import {lakePath} from "app/router/utils/paths"
 import Columns from "src/js/state/Columns"
-import Handlers from "src/js/state/Handlers"
 import SearchBar from "src/js/state/SearchBar"
 import Pools from "src/js/state/Pools"
 import Viewer from "src/js/state/Viewer"

--- a/app/search/flows/viewer-search.test.ts
+++ b/app/search/flows/viewer-search.test.ts
@@ -81,22 +81,6 @@ describe("a normal response", () => {
     expect(select(Viewer.getEndStatus)).toBe("COMPLETE")
   })
 
-  test("registers a table request then cleans it up", async () => {
-    const promise = submit()
-    expect(select(Handlers.get)["Table"]).toEqual(
-      expect.objectContaining({type: "SEARCH"})
-    )
-    await promise
-    expect(select(Handlers.get)["Table"]).toBe(undefined)
-  })
-
-  test("aborts previous table request", async () => {
-    const abort = jest.fn()
-    dispatch(Handlers.register("Table", {type: "SEARCH", abort}))
-    await submit()
-    expect(abort).toHaveBeenCalledTimes(1)
-  })
-
   test("sets the viewer columns", async () => {
     await submit()
     expect(select(Viewer.getColumns)).toMatchSnapshot()

--- a/src/js/api/index.ts
+++ b/src/js/api/index.ts
@@ -12,8 +12,10 @@ import {
 } from "./registries"
 import {ConfigsApi, ToolbarApi} from "./ui-apis"
 import {StorageApi} from "./storage"
+import {Abortables} from "app/core/models/abortables"
 
 export default class BrimApi {
+  public abortables = new Abortables()
   public commands = new CommandRegistry()
   public loaders = new LoaderRegistry()
   public contextMenus = {

--- a/src/js/components/SearchBar/MenuAction.tsx
+++ b/src/js/components/SearchBar/MenuAction.tsx
@@ -1,6 +1,7 @@
 import {useBrimApi} from "app/core/context"
 import React from "react"
 import {useDispatch, useSelector} from "react-redux"
+import Tabs from "src/js/state/Tabs"
 import {reactElementProps} from "../../../../test/integration/helpers/integration"
 import ThreeDotsIcon from "../../icons/ThreeDotsIcon"
 import open from "../../lib/open"
@@ -13,6 +14,7 @@ export default function MenuAction() {
   const dispatch = useDispatch()
   const api = useBrimApi()
   const isFetching = useSelector(Tab.isFetching)
+  const tab = useSelector(Tabs.getActive)
 
   const menu = [
     {label: "Debug query", click: () => dispatch(Modal.show("debug"))},
@@ -25,7 +27,7 @@ export default function MenuAction() {
     },
     {
       label: "Kill search",
-      click: () => api.abortables.abort(),
+      click: () => api.abortables.abort({tab}),
       disabled: !isFetching
     }
   ]

--- a/src/js/components/SearchBar/MenuAction.tsx
+++ b/src/js/components/SearchBar/MenuAction.tsx
@@ -1,17 +1,17 @@
-import {useDispatch, useSelector} from "react-redux"
+import {useBrimApi} from "app/core/context"
 import React from "react"
-
+import {useDispatch, useSelector} from "react-redux"
 import {reactElementProps} from "../../../../test/integration/helpers/integration"
-import Handlers from "../../state/Handlers"
-import InputAction from "./InputAction"
-import Modal from "../../state/Modal"
-import PopMenuPointy from "../PopMenu/PopMenuPointy"
-import Tab from "../../state/Tab"
 import ThreeDotsIcon from "../../icons/ThreeDotsIcon"
 import open from "../../lib/open"
+import Modal from "../../state/Modal"
+import Tab from "../../state/Tab"
+import PopMenuPointy from "../PopMenu/PopMenuPointy"
+import InputAction from "./InputAction"
 
 export default function MenuAction() {
   const dispatch = useDispatch()
+  const api = useBrimApi()
   const isFetching = useSelector(Tab.isFetching)
 
   const menu = [
@@ -25,7 +25,7 @@ export default function MenuAction() {
     },
     {
       label: "Kill search",
-      click: () => dispatch(Handlers.abortAll()),
+      click: () => api.abortables.abort(),
       disabled: !isFetching
     }
   ]

--- a/src/js/detail.tsx
+++ b/src/js/detail.tsx
@@ -13,7 +13,7 @@ import lib from "./lib"
 initDetail()
   .then(({store, api, pluginManager}) => {
     window.onbeforeunload = () => {
-      api.abortables.abort()
+      api.abortables.abortAll()
       pluginManager.deactivate()
     }
     ReactDOM.render(

--- a/src/js/detail.tsx
+++ b/src/js/detail.tsx
@@ -1,36 +1,30 @@
+import {BrimProvider} from "app/core/context"
 import AppWindowRouter from "app/router/app-window-router"
 import React from "react"
 import ReactDOM from "react-dom"
-import {Provider} from "react-redux"
 import "regenerator-runtime/runtime"
-import {ThemeProvider} from "styled-components"
-import AppErrorBoundary from "./components/AppErrorBoundary"
 import BrimTooltip from "./components/BrimTooltip"
 import LogDetailsWindow from "./components/LogDetailsWindow"
 import {Modals} from "./components/Modals"
 import StartupError from "./components/StartupError"
 import initDetail from "./initializers/initDetail"
 import lib from "./lib"
-import theme from "./style-theme"
 
 initDetail()
-  .then(({store, pluginManager}) => {
+  .then(({store, api, pluginManager}) => {
     window.onbeforeunload = () => {
+      api.abortables.abort()
       pluginManager.deactivate()
     }
     ReactDOM.render(
-      <AppWindowRouter>
-        <AppErrorBoundary>
+      <BrimProvider store={store} api={api}>
+        <AppWindowRouter>
           <div id="modal-dialog-root" />
-          <Provider store={store}>
-            <ThemeProvider theme={theme}>
-              <LogDetailsWindow />
-              <Modals />
-              <BrimTooltip />
-            </ThemeProvider>
-          </Provider>
-        </AppErrorBoundary>
-      </AppWindowRouter>,
+          <LogDetailsWindow />
+          <Modals />
+          <BrimTooltip />
+        </AppWindowRouter>
+      </BrimProvider>,
       lib.doc.id("app-root")
     )
   })

--- a/src/js/flows/search/handler.ts
+++ b/src/js/flows/search/handler.ts
@@ -22,6 +22,7 @@ export function handle(request: any) {
     function errored(e) {
       flushBufferLazy.cancel()
       if (abortError(e)) {
+        response.emit("status", "ABORTED")
         resolve()
       } else {
         response.emit("status", "ERROR")

--- a/src/js/flows/search/mod.ts
+++ b/src/js/flows/search/mod.ts
@@ -1,12 +1,10 @@
+import Tabs from "src/js/state/Tabs"
+import Current from "../../state/Current"
+import Tab from "../../state/Tab"
 import {Thunk} from "../../state/types"
 import {getZealot} from "../getZealot"
 import {handle} from "./handler"
-import Handlers from "../../state/Handlers"
 import {SearchResponse} from "./response"
-import {Handler} from "src/js/state/Handlers/types"
-import Current from "../../state/Current"
-import Tab from "../../state/Tab"
-import randomHash from "../../brim/randomHash"
 
 type Args = {
   query: string
@@ -22,29 +20,27 @@ export type BrimSearch = {
   abort: () => void
 }
 
-export function search({
-  query,
-  from,
-  to,
-  poolId,
-  id = randomHash()
-}: Args): Thunk<BrimSearch> {
-  return (dispatch, getState) => {
+export function search({query, from, to, poolId, id}: Args): Thunk<BrimSearch> {
+  return (dispatch, getState, {api}) => {
     const [defaultFrom, defaultTo] = Tab.getSpanAsDates(getState())
+    const tab = Tabs.getActive(getState())
     const defaultPoolId = Current.getPoolId(getState())
     const zealot = dispatch(getZealot())
     const ctl = new AbortController()
-    const searchHandle: Handler = {type: "SEARCH", abort: () => ctl.abort()}
+    const abort = () => ctl.abort()
+    const tag = id
+
     poolId = poolId || defaultPoolId
     to = to || defaultTo
     from = from || defaultFrom
     const req = zealot.search(query, {from, to, poolId, signal: ctl.signal})
-    dispatch(Handlers.abort(id, false))
-    dispatch(Handlers.register(id, searchHandle))
 
-    const abort = () => ctl.abort()
+    api.abortables.abort({tab, tag})
+    const aId = api.abortables.add({abort, tab, tag})
+
     const {response, promise} = handle(req)
-    promise.finally(() => dispatch(Handlers.remove(id)))
+    promise.finally(() => api.abortables.remove(aId))
+
     return {response, promise, abort}
   }
 }

--- a/src/js/initializers/initDetail.ts
+++ b/src/js/initializers/initDetail.ts
@@ -6,7 +6,7 @@ import brim from "../brim"
 import initialize from "./initialize"
 
 export default async () => {
-  const {store, pluginManager} = await initialize()
+  const {store, api, pluginManager} = await initialize()
   // Set the span to everything
   const pool = Current.mustGetPool(store.getState())
   pool && store.dispatch(Search.setSpan(brim.pool(pool).everythingSpan()))
@@ -16,5 +16,5 @@ export default async () => {
   store.dispatch(LogDetails.clear())
   log && store.dispatch(viewLogDetail(log))
 
-  return {store, pluginManager}
+  return {store, api, pluginManager}
 }

--- a/src/js/initializers/initialize.ts
+++ b/src/js/initializers/initialize.ts
@@ -21,5 +21,5 @@ export default async function initialize() {
   initMenuActionListeners(store)
   initWorkspaceParams(store)
   initDebugGlobals(store)
-  return {store, pluginManager}
+  return {store, api, pluginManager}
 }

--- a/src/js/search.tsx
+++ b/src/js/search.tsx
@@ -16,7 +16,7 @@ initialize()
     window.onbeforeunload = () => {
       // This runs during reload
       // Visit initIpcListeners.ts#prepareClose for closing window
-      api.abortables.abort()
+      api.abortables.abortAll()
       pluginManager.deactivate()
       store.dispatch(deletePartialPools())
       store.dispatch(TabHistories.save(global.tabHistories.serialize()))

--- a/test/unit/helpers/initTestStore.ts
+++ b/test/unit/helpers/initTestStore.ts
@@ -12,7 +12,7 @@ export type TestStore = {
   clearActions: Function
 } & Store
 
-export default (zealot?: Zealot, api?: BrimApi): TestStore => {
+export default (zealot?: Zealot, api: BrimApi = new BrimApi()): TestStore => {
   const client = zealot || createZealotMock().zealot
   const createZealot = () => client
   const store = configureStore({


### PR DESCRIPTION
So this was a few bugs...

The bug was that the "Kill Search" button would sometimes not work. This was because the main search function registers a handler for the search with an id. If an id is reused, that means cancel the previous search and run this fresh one. It also was because as soon as a request was aborted, that "handler id" was removed. Also, whenever the search ends (aborted succeeded or failed), the code removes the handler with that id as well. So the bug was in this sequence of events.

1. Click search button
2. Abort handler with id = "Table" (also removes the handler)
3. Search and register handler to id = "Table"
4. Before it completes....
5. Click search button again (before first finishes)
6. Abort handler with id = "Table" (removes the handler)
7. Search and register handler to id = "Table"
8. The first search search's "finally" cause is run and removes handler with id = "Table"

At this point there is no handler for the currently running search. If you try to click the Kill search button, nothing will happen.

This PR address this by creating a "tag" for an "abortable" and and unique id. The start of the search aborts other things with the same tag, while the finally block removes that specific abortable by id.

We also we not emitting an "ABORT" status which left the search status in "FETCHING" forever. This was why the spinner never stopped.

If there is a ticket that showed duplicated searches when the space was loaded, this will fix that issue too. 

Here is a video showing everything working now.


https://user-images.githubusercontent.com/3460638/132425440-cd519344-b78c-4fee-86f1-455cd3937f7d.mp4

fixes #1800 