### PR TITLE
Update wiki articles with branch-related changes

### DIFF
--- a/docs/Joining-Data-(v0.25.0+).md
+++ b/docs/Joining-Data-(v0.25.0+).md
@@ -78,16 +78,16 @@ example commands with the creation and population of the separate Pools
 ```
 $ export PATH="/Applications/Brim.app/Contents/Resources/app.asar.unpacked/zdeps:$PATH"
 
-$ zapi create -p fruit -orderby flavor:asc
-pool created: fruit
+$ zapi create -orderby flavor:asc fruit
+pool created: fruit 1xu7lTnMF7n3TcT3Rg3ivZ0Q9N3
 
-$ zapi create -p people -orderby likes:asc
-pool created: people
+$ zapi create -orderby likes:asc people
+pool created: people 1xu7nejkZEysqneOCcBhhkgkbrO
 
-$ zapi load -p fruit fruit.ndjson
+$ zapi load -use fruit@main fruit.ndjson
 1ujTdNNId0s6TmVKd02lFRuwzN2 committed
 
-$ zapi load -p people people.ndjson
+$ zapi load -use people@main people.ndjson
 1ujTeU44ZbqdE5x6DvMoTwSkztS committed
 ```
 
@@ -98,10 +98,10 @@ intend to execute on the data in this Pool, you may wish to specify a different
 `-orderby` setting.
 
 ```
-$ zapi create -p joined -orderby name:asc
+$ zapi create -orderby name:asc joined
 pool created: joined
 
-$ zapi query -I inner-join-pools.zed | zapi load -p joined -
+$ zapi query -I inner-join-pools.zed | zapi load -use joined@main -
 1ujUTZvk5KyAoGlSMSGvzFcUGgy committed
 ```
 

--- a/docs/Remote-Workspaces-(v0.25.0+).md
+++ b/docs/Remote-Workspaces-(v0.25.0+).md
@@ -199,10 +199,13 @@ ubuntu# wget --quiet https://archive.wrccdc.org/pcaps/2018/wrccdc.2018-03-23.010
 ubuntu# gunzip wrccdc.2018-03-23.010014000000000.pcap.gz
 ubuntu# export PATH="/opt/Brim/resources/app.asar.unpacked/zdeps:$PATH"
 
-ubuntu# zapi create -p wrccdc
-pool created: wrccdc
+ubuntu# zapi create wrccdc
+pool created: wrccdc 1xu2rXQ7D6ayTxrJE7XDVDS3mm8
 
-ubuntu# brimcap analyze wrccdc.2018-03-23.010014000000000.pcap | zapi load -p wrccdc -
+ubuntu# zapi use -p wrccdc
+Switched to branch "main" on pool "wrccdc"
+
+ubuntu# brimcap analyze wrccdc.2018-03-23.010014000000000.pcap | zapi load -
 1ulxiph6bNX4ZgubZFeCIIDaozj committed
 
 ubuntu# brimcap index -root ~/.config/Brim/data/brimcap-root -r wrccdc.2018-03-23.010014000000000.pcap
@@ -213,10 +216,13 @@ Zed Lake, we can also use `zapi` on our Linux VM. Here we'll import the Zeek
 TSV logs from our [zed-sample-data](https://github.com/brimdata/zed-sample-data).
 ```
 ubuntu# git clone --quiet --depth=1 https://github.com/brimdata/zed-sample-data
-ubuntu# zapi create -p zed-sample-data
-pool created: zed-sample-data
+ubuntu# zapi create zed-sample-data
+pool created: zed-sample-data 1xu3fug3iq1y17RMQYRiCtORLMC
 
-ubuntu# zapi load -p zed-sample-data zed-sample-data/zeek-default/*
+ubuntu# zapi use -p zed-sample-data
+Switched to branch "main" on pool "zed-sample-data"
+
+ubuntu# zapi load zed-sample-data/zeek-default/*
 1uMRE9bZnbNAIY8tEOfIXOa8c2w committed
 ```
 


### PR DESCRIPTION
The recent Zed changes to add branching changed some of the `zapi` command lines we show in the Brim wiki articles for working outside the app. Here I've updated them after testing them all as a user and confirming everything works as expected with the new command lines.