### PR TITLE
Advance Brimcap dependency to tag v1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8174,8 +8174,8 @@
       }
     },
     "brimcap": {
-      "version": "github:brimdata/brimcap#c7db129fe0d12c1c014cfce7bc886642fa109c96",
-      "from": "github:brimdata/brimcap#v1.0.4",
+      "version": "github:brimdata/brimcap#b441824bebfdc6bfd0326eeafc73c2f650b62dbf",
+      "from": "github:brimdata/brimcap#v1.1.0",
       "dev": true
     },
     "browser-process-hrtime": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "babel-plugin-inline-react-svg": "^1.1.1",
     "babel-plugin-module-resolver": "^4.0.0",
     "babel-plugin-source-map-support": "^2.1.2",
-    "brimcap": "brimdata/brimcap#v1.0.4",
+    "brimcap": "brimdata/brimcap#v1.1.0",
     "chalk": "^4.1.0",
     "commander": "^2.20.3",
     "cpx": "^1.5.0",


### PR DESCRIPTION
To take advantage of the fix to brimdata/brimcap#151 in the GA Brim release.