### PR TITLE
Update reference to Google Cloud Action in release promotion workflow

### DIFF
--- a/.github/workflows/linux-release-promotion.yml
+++ b/.github/workflows/linux-release-promotion.yml
@@ -13,7 +13,7 @@ jobs:
       run: echo "##[set-output name=tag;]$(echo ${GITHUB_REF#refs/tags/})"
       id: extract_tag
     - name: Setup Google Cloud Platform
-      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@master
       with:
         version: '290.0.1'
         project_id: ${{ secrets.GCLOUD_PROJECT_ID }}

--- a/.github/workflows/macos-release-promotion.yml
+++ b/.github/workflows/macos-release-promotion.yml
@@ -13,7 +13,7 @@ jobs:
       run: echo "##[set-output name=tag;]$(echo ${GITHUB_REF#refs/tags/})"
       id: extract_tag
     - name: Setup Google Cloud Platform
-      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@master
       with:
         version: '290.0.1'
         project_id: ${{ secrets.GCLOUD_PROJECT_ID }}

--- a/.github/workflows/win-release-promotion.yml
+++ b/.github/workflows/win-release-promotion.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         python-version: 3.7
     - name: Setup Google Cloud Platform
-      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@master
       env:
         CLOUDSDK_PYTHON: ${{ env.pythonLocation }}\python.exe
       with:


### PR DESCRIPTION
I've been doing some release testing in a Brim fork and bumped into some bit rot that needs to be addressed ([link](https://stackoverflow.com/questions/68516559/github-actions-failing)).