### PR TITLE
query annotation and test fixes

### DIFF
--- a/app/search/flows/histogram-search.test.ts
+++ b/app/search/flows/histogram-search.test.ts
@@ -40,7 +40,7 @@ test("zealot gets the request", async () => {
   const calls = zealot.calls("query")
   expect(calls.length).toBe(1)
   expect(calls[0].args).toEqual(
-    "from '1' | ts >= 2015-03-05T14:15:00Z | ts <= 2015-04-13T09:36:33.751Z | * | every 12h count() by _path"
+    "from '1' | ts >= 2015-03-05T14:15:00.000Z | ts <= 2015-04-13T09:36:33.751Z | * | every 12h count() by _path"
   )
 })
 

--- a/ppl/detail/flows/fetch.test.ts
+++ b/ppl/detail/flows/fetch.test.ts
@@ -44,10 +44,10 @@ describe("zeek log when community_id is found", () => {
     const searches = zealot.calls("query")
     const len = searches.length
     expect(searches[len - 2].args).toMatchInlineSnapshot(
-      `"from '1' | ts >= 2015-03-05T14:15:00Z | ts <= 2015-04-13T09:36:33.751Z | uid==\\"CbOjYpkXn9LfqV51c\\" or \\"CbOjYpkXn9LfqV51c\\" in conn_uids or \\"CbOjYpkXn9LfqV51c\\" in uids or referenced_file.uid==\\"CbOjYpkXn9LfqV51c\\" | head 100"`
+      `"from '1' | ts >= 2015-03-05T14:15:00.000Z | ts <= 2015-04-13T09:36:33.751Z | uid==\\"CbOjYpkXn9LfqV51c\\" or \\"CbOjYpkXn9LfqV51c\\" in conn_uids or \\"CbOjYpkXn9LfqV51c\\" in uids or referenced_file.uid==\\"CbOjYpkXn9LfqV51c\\" | head 100"`
     )
     expect(searches[len - 1].args).toMatchInlineSnapshot(
-      `"from '1' | ts >= 2015-03-05T14:15:00Z | ts <= 2015-04-13T09:36:33.751Z | uid==\\"CbOjYpkXn9LfqV51c\\" or \\"CbOjYpkXn9LfqV51c\\" in conn_uids or \\"CbOjYpkXn9LfqV51c\\" in uids or referenced_file.uid==\\"CbOjYpkXn9LfqV51c\\" or (community_id == \\"1:N7YGmWjwTmMKNhsZHBR618n3ReA=\\" and ts >= 1582646593.978 and ts < 1582646683.994) | head 100"`
+      `"from '1' | ts >= 2015-03-05T14:15:00.000Z | ts <= 2015-04-13T09:36:33.751Z | uid==\\"CbOjYpkXn9LfqV51c\\" or \\"CbOjYpkXn9LfqV51c\\" in conn_uids or \\"CbOjYpkXn9LfqV51c\\" in uids or referenced_file.uid==\\"CbOjYpkXn9LfqV51c\\" or (community_id == \\"1:N7YGmWjwTmMKNhsZHBR618n3ReA=\\" and ts >= 1582646593.978 and ts < 1582646683.994) | head 100"`
     )
   })
 
@@ -76,7 +76,7 @@ describe("zeek log when community_id is not found", () => {
     const {zealot, store} = setup
     await store.dispatch(fetchCorrelation(zeek))
     expect(last<any>(zealot.calls("query")).args).toMatchInlineSnapshot(
-      `"from '1' | ts >= 2015-03-05T14:15:00Z | ts <= 2015-04-13T09:36:33.751Z | uid==\\"CbOjYpkXn9LfqV51c\\" or \\"CbOjYpkXn9LfqV51c\\" in conn_uids or \\"CbOjYpkXn9LfqV51c\\" in uids or referenced_file.uid==\\"CbOjYpkXn9LfqV51c\\" | head 100"`
+      `"from '1' | ts >= 2015-03-05T14:15:00.000Z | ts <= 2015-04-13T09:36:33.751Z | uid==\\"CbOjYpkXn9LfqV51c\\" or \\"CbOjYpkXn9LfqV51c\\" in conn_uids or \\"CbOjYpkXn9LfqV51c\\" in uids or referenced_file.uid==\\"CbOjYpkXn9LfqV51c\\" | head 100"`
     )
   })
 
@@ -106,7 +106,7 @@ describe("suricata alert when community_id found", () => {
     const {zealot, store} = setup
     await store.dispatch(fetchCorrelation(suricata))
     expect(last<any>(zealot.calls("query")).args).toMatchInlineSnapshot(
-      `"from '1' | ts >= 2015-03-05T14:15:00Z | ts <= 2015-04-13T09:36:33.751Z | community_id==\\"1:N7YGmWjwTmMKNhsZHBR618n3ReA=\\" | head 100"`
+      `"from '1' | ts >= 2015-03-05T14:15:00.000Z | ts <= 2015-04-13T09:36:33.751Z | community_id==\\"1:N7YGmWjwTmMKNhsZHBR618n3ReA=\\" | head 100"`
     )
   })
 

--- a/src/js/flows/search/mod.ts
+++ b/src/js/flows/search/mod.ts
@@ -27,6 +27,8 @@ type annotateArgs = {
 }
 
 export const annotateQuery = (query: string, args: annotateArgs) => {
+  // if query already starts with 'from', we do not annotate it further
+  if (/^from\s*\(?/i.test(query)) return query
   const {
     poolId,
     from = new Date(new Date().getTime() - 30 * 24 * 60 * 60 * 1000), // 30 days
@@ -52,10 +54,10 @@ const isZeroDefaultSpan = (
   )
 }
 
-const dateToNanoTs = (date: Date | Ts | bigint): string => {
+export const dateToNanoTs = (date: Date | Ts | bigint): string => {
   const NanoFormat = new DateTimeFormatterBuilder()
     .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
-    .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
+    .appendFraction(ChronoField.NANO_OF_SECOND, 3, 9, true)
     .appendLiteral("Z")
     .toFormatter()
 

--- a/src/js/flows/search/mod.ts
+++ b/src/js/flows/search/mod.ts
@@ -28,7 +28,7 @@ type annotateArgs = {
 
 export const annotateQuery = (query: string, args: annotateArgs) => {
   // if query already starts with 'from', we do not annotate it further
-  if (/^from\s*\(?/i.test(query)) return query
+  if (/^from[\s(]/i.test(query)) return query
   const {
     poolId,
     from = new Date(new Date().getTime() - 30 * 24 * 60 * 60 * 1000), // 30 days


### PR DESCRIPTION
fixes #1835

The problem with the missing `0`s we see in the indeterminate test is not the backend, it is the `dateToNanoTs` function. It's not entirely a problem so much as an inconsistency: 

The current default behavior is to not include trailing `0`s, which is an acceptable format for the timestamp as the backend parses it. In our tests, we use the date `.toISOString()` method to compare expected values, and that method always includes the full millisecond width, which revealed the formatting difference.

The fix I'm proposing here then is to ensure the decimal width returned by `dateToNanoTs` is at least the full ms, trailing zeros or not, while µs and ns widths may vary by trailing zeros.

Also proposed here is a temporary workaround for the query annotator, as discussed with @nwt: If a query looks like it begins with any sort of `from ` then we will *NOT* annotate it at all and just pass it on as is to the request. This way we can expose the feature of querying from multiple pools while still supporting the existing/expected search behavior. Ultimately, we should discuss the "pool search" vs "lake search" (searching across multiple pools in a lake) workflows a bit more to come up with a better solution for this.  


Signed-off-by: Mason Fish <mason@brimsecurity.com>