### PR TITLE
Add Troubleshooting section about antivirus false positive

### DIFF
--- a/docs/Troubleshooting-(v0.25.0+).md
+++ b/docs/Troubleshooting-(v0.25.0+).md
@@ -285,7 +285,7 @@ its origin.
 * Each Brim release points at a [Brimcap release](https://github.com/brimdata/brim/blob/b288fae1654bd6b848a0714583f6570d22e91d97/package.json#L68)
   that's bundled by Brim's own [release automation](https://github.com/brimdata/brim/blob/v0.25.0/.github/workflows/win-release-candidate.yml).
 
-To summarize, the executable consists of minimally-enhanced Python that's been
+To summarize, the executable consists of a minimally-enhanced Suricata-Update that's been
 turned into an executable by other open source tools. If your conclusion
 matches our own that this is a "false positive", you can help others by
 [flagging it as harmless in VirusTotal](https://support.virustotal.com/hc/en-us/articles/115002146769-Comments),

--- a/docs/Troubleshooting-(v0.25.0+).md
+++ b/docs/Troubleshooting-(v0.25.0+).md
@@ -235,7 +235,7 @@ behavior as consistent with that of ["backdoor"](https://en.wikipedia.org/wiki/B
 malware that may reach out to arbitrary network destinations in the name of
 transmitting sensitive information or providing network channels for
 nefarious remote logins. Of course, the [functionality of Suricata-Update](https://suricata.readthedocs.io/en/suricata-6.0.0/rule-management/suricata-update.html)
-as described by the OISF is of course quite benign: In its default
+as described by the OISF is quite benign: In its default
 configuration as it's used by Brimcap/Brim, the network destinations it
 reaches out to are servers associated with providing the
 [Emerging Threats Open](https://rules.emergingthreats.net/open/) ruleset.

--- a/docs/Troubleshooting-(v0.25.0+).md
+++ b/docs/Troubleshooting-(v0.25.0+).md
@@ -12,7 +12,7 @@ before you [open an issue](#opening-an-issue).
   * [I've clicked in Brim to extract a flow from my pcap into Wireshark, but the flow looks different than when I isolate it in the original pcap file in Wireshark](#ive-clicked-in-brim-to-extract-a-flow-from-my-pcap-into-wireshark-but-the-flow-looks-different-than-when-i-isolate-it-in-the-original-pcap-file-in-wireshark)
   * [Brim seems unable to restart normally, such as after a bad crash](#brim-seems-unable-to-restart-normally-such-as-after-a-bad-crash)
   * [Brim shows "Connection Error: The service at localhost:9867 could not be reached"](#brim-shows-connection-error-the-service-at-localhost9867-could-not-be-reached)
-  * [My antivirus software has flagged Brim as potentially malicious](http://localhost:6419/#my-antivirus-software-has-flagged-brim-as-potentially-malicious)
+  * [My antivirus software has flagged Brim as potentially malicious](#my-antivirus-software-has-flagged-brim-as-potentially-malicious)
 - [Gathering Info](#gathering-info)
   * [Sensitive Information (important!)](#sensitive-information-important)
   * [Screenshots/Videos](#screenshotsvideos)

--- a/docs/Troubleshooting-(v0.25.0+).md
+++ b/docs/Troubleshooting-(v0.25.0+).md
@@ -272,7 +272,7 @@ its origin.
 * A [build-suricata repo](https://github.com/brimdata/build-suricata) contains automation that's
   used to create the Suricata packages that are bundled with Brimcap. This
   includes [script code](https://github.com/brimdata/build-suricata/blob/9847f9ba72b24a132aa7068a15b9d3ff9e63af1b/.github/workflows/windows-build.yaml#L103-L109)
-  that unpacks the enhanced Python and runs PyInstaller to generate the
+  that unpacks the enhanced Suricata-Update and runs PyInstaller to generate the
   `suricata-update.exe` executable. The same automation also creates the
   Suricata artifacts on the repo's
   [GitHub Releases](https://github.com/brimdata/build-suricata/releases) page.

--- a/docs/Troubleshooting-(v0.25.0+).md
+++ b/docs/Troubleshooting-(v0.25.0+).md
@@ -236,7 +236,7 @@ malware that may reach out to arbitrary network destinations in the name of
 transmitting sensitive information or providing network channels for
 nefarious remote logins. Of course, the [functionality of Suricata-Update](https://suricata.readthedocs.io/en/suricata-6.0.0/rule-management/suricata-update.html)
 as described by the OISF is quite benign: In its default
-configuration as it's used by Brimcap/Brim, the network destinations it
+configuration as it's used by Brimcap and Brim, the network destinations it
 reaches out to are servers associated with providing the
 [Emerging Threats Open](https://rules.emergingthreats.net/open/) ruleset.
 


### PR DESCRIPTION
As discussed in a [thread on public Slack](https://brimsec.slack.com/archives/C010DR0HHMF/p1631036993069800), a user recently made us aware that our `suricata-update.exe` binary gets flagged as possible malware. Here's my attempt at writing an article to address the topic proactively or via link should it come up again with other users. In addition to pointing our own users at it, I expect I might also be able to reference it from:

1.  The "comments" area of the [Community](https://www.virustotal.com/gui/file/b184511d689d547fa5fd524c7ca120586fcffc60f338f932d41800c63961d723/community) tab for the VirusTotal entry, as was recommended to me by one community user in that Slack thread.
2.  Forms or emails with which we might contact the antivirus providers to make the case that it be considered a false positive.

I admit this content was a little awkward to write. Obviously I'd prefer to not have gone into such extensive detail when describing the origin of the file i question. At the same time, just saying "don't worry, it's a false positive" would have felt sleazy (isn't that exactly what a malware-provider would say?), and saying "it's open source... go convince yourself" without some detail would have felt like a lazy attempt to distract. Given that we're open source, I figured I might as well put it all out there in the open.

In addition to our own PR review process, I'll also bring this PR to the attention of the community user that offered some initial guidance and will hold off on merging until they've had a chance to offer feedback as well.