### PR TITLE
Relax the shortcuts for Zoom In and Out

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11216,6 +11216,22 @@
         }
       }
     },
+    "electron-is-accelerator": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/electron-is-accelerator/-/electron-is-accelerator-0.1.2.tgz",
+      "integrity": "sha1-UJ5RDCala1Xhf4Y6SwThEYRqsns="
+    },
+    "electron-localshortcut": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/electron-localshortcut/-/electron-localshortcut-3.2.1.tgz",
+      "integrity": "sha512-DWvhKv36GsdXKnaFFhEiK8kZZA+24/yFLgtTwJJHc7AFgDjNRIBJZ/jq62Y/dWv9E4ypYwrVWN2bVrCYw1uv7Q==",
+      "requires": {
+        "debug": "^4.0.1",
+        "electron-is-accelerator": "^0.1.0",
+        "keyboardevent-from-electron-accelerator": "^2.0.0",
+        "keyboardevents-areequal": "^0.2.1"
+      }
+    },
     "electron-log": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-4.2.2.tgz",
@@ -18434,6 +18450,16 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
       "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+    },
+    "keyboardevent-from-electron-accelerator": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/keyboardevent-from-electron-accelerator/-/keyboardevent-from-electron-accelerator-2.0.0.tgz",
+      "integrity": "sha512-iQcmNA0M4ETMNi0kG/q0h/43wZk7rMeKYrXP7sqKIJbHkTU8Koowgzv+ieR/vWJbOwxx5nDC3UnudZ0aLSu4VA=="
+    },
+    "keyboardevents-areequal": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/keyboardevents-areequal/-/keyboardevents-areequal-0.2.2.tgz",
+      "integrity": "sha512-Nv+Kr33T0mEjxR500q+I6IWisOQ0lK1GGOncV0kWE6n4KFmpcu7RUX5/2B0EUtX51Cb0HjZ9VJsSY3u4cBa0kw=="
     },
     "keytar": {
       "version": "7.3.0",

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "date-fns": "^2.16.1",
     "electron-devtools-installer": "^3.1.1",
     "electron-dl": "^3.0.1",
+    "electron-localshortcut": "^3.2.1",
     "electron-log": "^4.2.2",
     "electron-updater": "^4.3.8",
     "extract-zip": "^1.6.7",

--- a/src/js/electron/brim.ts
+++ b/src/js/electron/brim.ts
@@ -1,10 +1,11 @@
 import {app} from "electron"
 import keytar from "keytar"
-import url from "url"
+import {join} from "path"
 import os from "os"
 import path from "path"
 import {Lake} from "ppl/lake/lake"
 import {Store} from "redux"
+import url from "url"
 import {
   deserializeState,
   toAccessTokenKey,
@@ -17,6 +18,7 @@ import {installExtensions} from "./extensions"
 import ipc from "./ipc"
 import sendTo from "./ipc/sendTo"
 import isDev from "./isDev"
+import requireAll from "./require-all"
 import tron, {Session} from "./tron"
 import formatSessionState from "./tron/formatSessionState"
 import {sessionStateFile} from "./tron/session"
@@ -61,10 +63,12 @@ export class BrimMain {
   }
 
   async start(opts = {backend: true}) {
+    requireAll(join(__dirname, "./initializers"))
     if (opts.backend) {
       this.lake.start()
     }
     if (this.isDev()) await installExtensions()
+
     this.windows.init()
   }
 

--- a/src/js/electron/brim.ts
+++ b/src/js/electron/brim.ts
@@ -1,6 +1,5 @@
 import {app} from "electron"
 import keytar from "keytar"
-import {join} from "path"
 import os from "os"
 import path from "path"
 import {Lake} from "ppl/lake/lake"
@@ -18,7 +17,6 @@ import {installExtensions} from "./extensions"
 import ipc from "./ipc"
 import sendTo from "./ipc/sendTo"
 import isDev from "./isDev"
-import requireAll from "./require-all"
 import tron, {Session} from "./tron"
 import formatSessionState from "./tron/formatSessionState"
 import {sessionStateFile} from "./tron/session"
@@ -63,7 +61,6 @@ export class BrimMain {
   }
 
   async start(opts = {backend: true}) {
-    requireAll(join(__dirname, "./initializers"))
     if (opts.backend) {
       this.lake.start()
     }

--- a/src/js/electron/initializers/shortcuts.ts
+++ b/src/js/electron/initializers/shortcuts.ts
@@ -1,0 +1,20 @@
+import {BrowserWindow} from "electron"
+import shortcuts from "electron-localshortcut"
+
+function zoom(dir: "in" | "out", win: BrowserWindow | undefined) {
+  const web = win && win.webContents
+  if (!web) return
+  const level = web.getZoomLevel()
+  web.setZoomLevel(level + (dir === "in" ? 0.5 : -0.5))
+}
+
+// Had to add our own zoom handlers because of a bug in electron
+// https://github.com/electron/electron/issues/15496
+// https://github.com/electron/electron/issues/1507
+// This registers a shortcut whenever our app is focused
+shortcuts.register("CommandOrControl+=", () => {
+  zoom("in", BrowserWindow.getFocusedWindow())
+})
+shortcuts.register("CommandOrControl+Shift+-", () => {
+  zoom("out", BrowserWindow.getFocusedWindow())
+})

--- a/src/js/electron/main.ts
+++ b/src/js/electron/main.ts
@@ -23,6 +23,8 @@ import {windowsPre25Exists} from "./windows-pre-25"
 import {meta} from "app/ipc/meta"
 import secureWebContents from "./secure-web-contents"
 import env from "app/core/env"
+import {join} from "path"
+import requireAll from "./require-all"
 
 console.time("init")
 
@@ -33,6 +35,7 @@ function mainDefaults() {
 }
 
 export async function main(opts = mainDefaults()) {
+  requireAll(join(__dirname, "./initializers"))
   secureWebContents()
   if (handleSquirrelEvent(app)) return
   if (await windowsPre25Exists()) {

--- a/src/js/electron/require-all.ts
+++ b/src/js/electron/require-all.ts
@@ -1,7 +1,17 @@
 import fs from "fs"
 import {join} from "path"
 
-export default async function requireAll(directory: string) {
-  const files = fs.readdirSync(directory).map((f) => join(directory, f))
-  return files.map((f) => require(f))
+export default function requireAll(directory: string) {
+  const files = fs
+    .readdirSync(directory)
+    .map((f) => join(directory, f.replace(/\.(js|ts)$/, "")))
+  return files.map((f) => {
+    try {
+      return require(f)
+    } catch (e) {
+      console.error("Could not require: " + f)
+      console.error(e)
+      throw e
+    }
+  })
 }

--- a/src/js/electron/require-all.ts
+++ b/src/js/electron/require-all.ts
@@ -1,0 +1,7 @@
+import fs from "fs"
+import {join} from "path"
+
+export default async function requireAll(directory: string) {
+  const files = fs.readdirSync(directory).map((f) => join(directory, f))
+  return files.map((f) => require(f))
+}

--- a/test/unit/__mocks__/electron.ts
+++ b/test/unit/__mocks__/electron.ts
@@ -18,6 +18,7 @@ class WebContents extends EventEmitter {
   }
 }
 export class BrowserWindow {
+  static getAllWindows = jest.fn(() => [])
   webContents = new WebContents()
   isDestroyed = jest.fn(() => false)
   focus = jest.fn()

--- a/test/unit/helpers/setup-brim.ts
+++ b/test/unit/helpers/setup-brim.ts
@@ -49,7 +49,10 @@ export function setupBrim(opts: Args = defaults()) {
   const context = new BrimTestContext()
 
   beforeEach(async () => {
-    context.assign(await bootBrim(opts))
+    // If this fails, the tests will still run. When we're on
+    // jest 27, this will fail the test as expected.
+    const props = await bootBrim(opts)
+    context.assign(props)
     if (opts.workspace) {
       context.dispatch(Workspaces.add(opts.workspace))
       if (opts.pool) {


### PR DESCRIPTION
It is now possible to zoom the window with `CmdOrCtrl++` or `CmdOrCtrl+Shift++`. The same goes for zoom out. `CmdOrCtrl+-` and `CmdOrCtrl+Shift+-`

This was done by adding out own app wide shortcuts that re-implement the zoom in and out behavior for the currently focused window.

I also added a folder called `electron/initializers`. Any file in it will get required during the "start" phase of the brim app. We can put anything there that only needs to be set up in the main process once.

Fixes #1818 