### PR TITLE
Safer object access in <ErrorNotice />

### DIFF
--- a/src/js/components/ErrorNotice.test.tsx
+++ b/src/js/components/ErrorNotice.test.tsx
@@ -1,0 +1,55 @@
+import React from "react"
+
+import logInto from "../../../test/unit/helpers/loginTo"
+import provide from "../../../test/unit/helpers/provide"
+import Notice from "../state/Notice"
+import ErrorFactory from "../models/ErrorFactory"
+import ErrorNotice from "./ErrorNotice"
+import {screen} from "@testing-library/react"
+
+test("renders Error notice with no details", async () => {
+  const {store} = await logInto("workspace1", "pool1")
+  store.dispatch(
+    Notice.set(
+      ErrorFactory.create({
+        type: "Bad",
+        message: "Test error message"
+      })
+    )
+  )
+  provide(store, <ErrorNotice />)
+  expect(screen.getByRole("alert")).toHaveTextContent("Test error message")
+})
+
+test("renders Error notice with detail string", async () => {
+  const {store} = await logInto("workspace1", "pool1")
+  store.dispatch(
+    Notice.set(
+      ErrorFactory.create({
+        type: "Bad",
+        message: "Test error message",
+        details: "Test detail"
+      })
+    )
+  )
+  provide(store, <ErrorNotice />)
+  expect(screen.getByRole("alert")).toHaveTextContent("Test error message")
+  expect(screen.getByRole("alert")).toHaveTextContent("Test detail")
+})
+
+test("renders Error notice with detail array", async () => {
+  const {store} = await logInto("workspace1", "pool1")
+  store.dispatch(
+    Notice.set(
+      ErrorFactory.create({
+        type: "Bad",
+        message: "Test error message",
+        details: ["Test detail 1", "Test detail 2"]
+      })
+    )
+  )
+  provide(store, <ErrorNotice />)
+  expect(screen.getByRole("alert")).toHaveTextContent("Test error message")
+  expect(screen.getByRole("alert")).toHaveTextContent("Test detail 1")
+  expect(screen.getByRole("alert")).toHaveTextContent("Test detail 2")
+})

--- a/src/js/components/ErrorNotice.test.tsx
+++ b/src/js/components/ErrorNotice.test.tsx
@@ -1,15 +1,20 @@
 import React from "react"
 
-import logInto from "../../../test/unit/helpers/loginTo"
-import provide from "../../../test/unit/helpers/provide"
 import Notice from "../state/Notice"
 import ErrorFactory from "../models/ErrorFactory"
 import ErrorNotice from "./ErrorNotice"
 import {screen} from "@testing-library/react"
+import {setupBrim} from "../../../test/unit/helpers/setup-brim"
+import {render} from "../../../test/unit/helpers"
+
+const brim = setupBrim()
+
+beforeEach(() => {
+  render(<ErrorNotice />, {store: brim.store})
+})
 
 test("renders Error notice with no details", async () => {
-  const {store} = await logInto("workspace1", "pool1")
-  store.dispatch(
+  brim.store.dispatch(
     Notice.set(
       ErrorFactory.create({
         type: "Bad",
@@ -17,13 +22,11 @@ test("renders Error notice with no details", async () => {
       })
     )
   )
-  provide(store, <ErrorNotice />)
   expect(screen.getByRole("alert")).toHaveTextContent("Test error message")
 })
 
 test("renders Error notice with detail string", async () => {
-  const {store} = await logInto("workspace1", "pool1")
-  store.dispatch(
+  brim.store.dispatch(
     Notice.set(
       ErrorFactory.create({
         type: "Bad",
@@ -32,14 +35,12 @@ test("renders Error notice with detail string", async () => {
       })
     )
   )
-  provide(store, <ErrorNotice />)
   expect(screen.getByRole("alert")).toHaveTextContent("Test error message")
   expect(screen.getByRole("alert")).toHaveTextContent("Test detail")
 })
 
 test("renders Error notice with detail array", async () => {
-  const {store} = await logInto("workspace1", "pool1")
-  store.dispatch(
+  brim.store.dispatch(
     Notice.set(
       ErrorFactory.create({
         type: "Bad",
@@ -48,7 +49,6 @@ test("renders Error notice with detail array", async () => {
       })
     )
   )
-  provide(store, <ErrorNotice />)
   expect(screen.getByRole("alert")).toHaveTextContent("Test error message")
   expect(screen.getByRole("alert")).toHaveTextContent("Test detail 1")
   expect(screen.getByRole("alert")).toHaveTextContent("Test detail 2")

--- a/src/js/components/ErrorNotice.tsx
+++ b/src/js/components/ErrorNotice.tsx
@@ -39,21 +39,28 @@ function None() {
 function Default({error}: {error: BrimError}) {
   const dispatch = useDispatch()
   const msg = upperFirst(error.message)
-  const details = error.details
+
+  const generateErrorDetails = (details) => {
+    if (!details) return null
+    // in case the backend returns a single string instead of array
+    let detailsContent = null
+    if (typeof details === "string" || details instanceof String)
+      detailsContent = <p>{details}</p>
+    else if (Array.isArray(details) && details.length > 0)
+      detailsContent = details
+        .flatMap((s) => s.split("\n"))
+        .map((string, i) => <p key={i}>{string}</p>)
+
+    if (!detailsContent) return null
+
+    return <div className="error-details">{detailsContent}</div>
+  }
   return (
     <>
       <p>
         {msg} <a onClick={() => dispatch(Notice.dismiss())}>Dismiss</a>
       </p>
-      {details && details.length > 0 && (
-        <div className="error-details">
-          {details
-            .flatMap((s) => s.split("\n"))
-            .map((string, i) => (
-              <p key={i}>{string}</p>
-            ))}
-        </div>
-      )}
+      {generateErrorDetails(error.details)}
     </>
   )
 }

--- a/src/js/components/ErrorNotice.tsx
+++ b/src/js/components/ErrorNotice.tsx
@@ -13,7 +13,7 @@ export default function ErrorNotice() {
   const visible = useSelector(Notice.getVisible)
 
   return (
-    <NoticeBanner show={visible}>
+    <NoticeBanner role="alert" show={visible}>
       <ErrorMessage error={error} />
     </NoticeBanner>
   )

--- a/src/js/components/ErrorNotice.tsx
+++ b/src/js/components/ErrorNotice.tsx
@@ -41,19 +41,22 @@ function Default({error}: {error: BrimError}) {
   const msg = upperFirst(error.message)
 
   const generateErrorDetails = (details) => {
-    if (!details) return null
     // in case the backend returns a single string instead of array
     let detailsContent = null
     if (typeof details === "string" || details instanceof String)
-      detailsContent = <p>{details}</p>
+      detailsContent = details.split("\n")
     else if (Array.isArray(details) && details.length > 0)
-      detailsContent = details
-        .flatMap((s) => s.split("\n"))
-        .map((string, i) => <p key={i}>{string}</p>)
+      detailsContent = details.flatMap((s) => s.split("\n"))
 
     if (!detailsContent) return null
 
-    return <div className="error-details">{detailsContent}</div>
+    return (
+      <div className="error-details">
+        {detailsContent.map((detail, i) => (
+          <p key={i}>{detail}</p>
+        ))}
+      </div>
+    )
   }
   return (
     <>

--- a/src/js/components/NoticeBanner.tsx
+++ b/src/js/components/NoticeBanner.tsx
@@ -3,7 +3,7 @@ import classNames from "classnames"
 
 import Animate from "./Animate"
 
-type Props = {show: boolean; children: any; className?: string}
+type Props = {show: boolean; children: any; className?: string; role?: string}
 
 export default function NoticeBanner({
   show,


### PR DESCRIPTION
fixes #1815 

Just adds some type inspection to the error notice renderer. Included a component test which forces the detail string input that caused the original error described in the ticket above for good measure.