### PR TITLE
Filter == value in menus

### DIFF
--- a/src/js/electron/menu/actions/detailActions.ts
+++ b/src/js/electron/menu/actions/detailActions.ts
@@ -95,7 +95,7 @@ function buildDetailActions() {
     }),
     include: action({
       name: "detail-cell-menu-include",
-      label: "Filter = value in new search",
+      label: "Filter == value in new search",
       listener(dispatch, field: zjson.FieldRootRecord) {
         dispatch(SearchBar.clearSearchBar())
         dispatch(appendQueryInclude(ZealotContext.decodeField(field)))

--- a/src/js/electron/menu/actions/searchActions.ts
+++ b/src/js/electron/menu/actions/searchActions.ts
@@ -99,7 +99,7 @@ function buildSearchActions() {
     }),
     include: action({
       name: "search-cell-menu-include",
-      label: "Filter = value",
+      label: "Filter == value",
       listener(dispatch, data: zjson.FieldRootRecord) {
         dispatch(appendQueryInclude(ZealotContext.decodeField(data)))
         dispatch(submitSearch())

--- a/test/integration/tests/contextMenu.test.ts
+++ b/test/integration/tests/contextMenu.test.ts
@@ -25,7 +25,7 @@ describe("context menu tests", () => {
       const fieldName = "scalar"
       const query = `_path=="${path}" ${fieldName}!=null | cut id, ${fieldName} | sort id`
       const cell = cellContaining(value)
-      return () => runTest(query, cell, "Filter = value")
+      return () => runTest(query, cell, "Filter == value")
     }
     test("mystr", scalarString("mystr"))
     test("-", scalarString("-"))
@@ -51,7 +51,7 @@ describe("context menu tests", () => {
       const fieldName = "scalar"
       const query = `_path=="${path}" ${fieldName}!=null | cut id, ${fieldName} | sort id`
       const cell = cellContaining(value)
-      return () => runTest(query, cell, "Filter = value")
+      return () => runTest(query, cell, "Filter == value")
     }
     test("1.1.1.1", scalarAddr("1.1.1.1"))
     test("fe80::58d2:2d09:e8cb:a8ad", scalarAddr("fe80::58d2:2d09:e8cb:a8ad"))
@@ -63,7 +63,7 @@ describe("context menu tests", () => {
     function scalarUnset(value) {
       const query = `_path=="string" | cut id, scalar | sort -r id | head 10`
       const cell = cellContaining(value)
-      return () => runTest(query, cell, "Filter = value")
+      return () => runTest(query, cell, "Filter == value")
     }
     test("unset", scalarUnset(UNSET))
   })


### PR DESCRIPTION
A simple change to update the context menu labels to match the zed syntax.

Fixes #1839 