### PR TITLE
Fix bug with primitive type values

### DIFF
--- a/zealot/zed/context.ts
+++ b/zealot/zed/context.ts
@@ -55,7 +55,9 @@ export class ZedContext {
       // Primitives
       case "primitive":
         var type = primitives[obj.name]
-        if (!type) throw `Implement primitive: ${obj.name}`
+        if (!type) {
+          throw `Implement primitive: ${obj.name}`
+        }
         return type
 
       // Containers

--- a/zealot/zed/types/type-primitives.ts
+++ b/zealot/zed/types/type-primitives.ts
@@ -45,6 +45,7 @@ const primitives = {
   error: TypeError
 } as const
 
-export type PrimitiveTypes = typeof primitives[keyof typeof primitives]
-
 export default primitives
+
+export type PrimitiveName = keyof typeof primitives
+export type PrimitiveTypes = typeof primitives[PrimitiveName]

--- a/zealot/zed/types/type-type.test.ts
+++ b/zealot/zed/types/type-type.test.ts
@@ -1,0 +1,7 @@
+import {TypeType} from "./type-type"
+
+test("primitive types", () => {
+  const typeValue = TypeType.create("string", {})
+
+  expect(typeValue.toString()).toEqual("string")
+})

--- a/zealot/zed/types/type-type.ts
+++ b/zealot/zed/types/type-type.ts
@@ -1,6 +1,7 @@
 import {isNull} from "../utils"
 import {TypeValue} from "../values/type"
 import {BasePrimitive} from "./base-primitive"
+import primitives from "./type-primitives"
 
 export class TypeOfType extends BasePrimitive<TypeValue> {
   name = "type"
@@ -9,7 +10,11 @@ export class TypeOfType extends BasePrimitive<TypeValue> {
     if (isNull(value)) {
       return new TypeValue(null)
     } else {
-      return new TypeValue(typedefs[value])
+      if (value in primitives) {
+        return new TypeValue(primitives[value])
+      } else {
+        return new TypeValue(typedefs[value])
+      }
     }
   }
 

--- a/zealot/zed/types/type-type.ts
+++ b/zealot/zed/types/type-type.ts
@@ -1,7 +1,6 @@
-import {isNull} from "../utils"
+import {isNull, getPrimitiveType, isPrimitiveName} from "../utils"
 import {TypeValue} from "../values/type"
 import {BasePrimitive} from "./base-primitive"
-import primitives from "./type-primitives"
 
 export class TypeOfType extends BasePrimitive<TypeValue> {
   name = "type"
@@ -10,8 +9,8 @@ export class TypeOfType extends BasePrimitive<TypeValue> {
     if (isNull(value)) {
       return new TypeValue(null)
     } else {
-      if (value in primitives) {
-        return new TypeValue(primitives[value])
+      if (isPrimitiveName(value)) {
+        return new TypeValue(getPrimitiveType(value))
       } else {
         return new TypeValue(typedefs[value])
       }

--- a/zealot/zed/utils.ts
+++ b/zealot/zed/utils.ts
@@ -1,4 +1,5 @@
 import {TypeAlias, Uint16, Uint32, Uint64, Uint8} from "./index"
+import primitives, {PrimitiveName} from "./types/type-primitives"
 import {ZedType} from "./types/types"
 import {BString} from "./values/bstring"
 import {Duration} from "./values/duration"
@@ -76,4 +77,12 @@ export function isDuration(value: unknown): value is Duration {
 
 export function isFloat64(value): value is Float64 {
   return value instanceof Float64
+}
+
+export function getPrimitiveType(name: PrimitiveName) {
+  return primitives[name]
+}
+
+export function isPrimitiveName(name: string): name is PrimitiveName {
+  return name in primitives
 }


### PR DESCRIPTION
Fixes #1819

Check if the value of a type is one of the primitive keywords. If so, use the type for that primitive as the value. Here is the repro example now fixed.

![image](https://user-images.githubusercontent.com/3460638/135137285-1708ae9b-b6d1-4e4f-bad9-f6b677e36223.png)

![image](https://user-images.githubusercontent.com/3460638/135137569-097350c2-b529-416e-a99b-6c9fa973e5af.png)
