### PR TITLE
Use Column Names to Determine Unique Columnsets

### DIFF
--- a/app/search/flows/__snapshots__/viewer-search.test.ts.snap
+++ b/app/search/flows/__snapshots__/viewer-search.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`a normal response sets the Columns columns 1`] = `
 Object {
-  "28": Object {
+  "AARARDTCTTLsZ_pathanswersid.orig_hid.orig_pid.resp_hid.resp_pprotoqclassqclass_nameqtypeqtype_namequeryrcodercode_namerejectedrtttrans_idtsuid": Object {
     "AA:bool": Object {
       "isVisible": true,
     },


### PR DESCRIPTION
In the past we used the name and the type to determine if a column set was unique. Now we just use the the names. So if there is a schema with the same fields as another schema (regardless of order) we will display the data in a table with column headers.

Fixes #1826 
Fixes #1827

![image](https://user-images.githubusercontent.com/3460638/135143120-40b83efe-726e-4529-bdc4-24626f51cf85.png)
![image](https://user-images.githubusercontent.com/3460638/135143170-85908dcd-3fce-41e2-87cd-c75605cf7445.png)

And the fix for 1827

![image](https://user-images.githubusercontent.com/3460638/135146589-36dd9562-d968-4a12-9855-3e2e207b89d8.png)
