### PR TITLE
Prevent Next Page Search When Not Needed

### DIFF
--- a/src/js/state/Viewer/reducer.ts
+++ b/src/js/state/Viewer/reducer.ts
@@ -6,7 +6,7 @@ import {createSelection} from "./helpers/selection"
 
 const init = (): ViewerState => ({
   records: [],
-  endStatus: "INCOMPLETE",
+  endStatus: "INIT",
   status: "INIT",
   columns: {},
   scrollPos: {x: 0, y: 0},

--- a/src/js/state/Viewer/types.ts
+++ b/src/js/state/Viewer/types.ts
@@ -2,7 +2,12 @@ import {zed} from "zealot"
 import {ScrollPosition} from "../../types"
 import {SearchStatus} from "../../types/searches"
 
-export type ViewerStatus = "FETCHING" | "INCOMPLETE" | "COMPLETE" | "LIMIT"
+export type ViewerStatus =
+  | "INIT"
+  | "FETCHING"
+  | "INCOMPLETE"
+  | "COMPLETE"
+  | "LIMIT"
 
 export type SchemaMap = {[name: string]: zed.Schema}
 export type ViewerSelectionData = {


### PR DESCRIPTION
The `Viewer.endStatus` enum is used to determine if we should fetch the next page of results. It used to default to "Incomplete" which was the signal to fetch the next page. Now it defaults to "INIT" so that we don't fetch the next page unnecessarily.

Fixes #1825

This was the source of the problem. isIncomplete was set to true every time we clear the viewer.

```js
// ResultsTable.tsx

  function onLastChunk() {
    if (props.isIncomplete && !props.isFetching) {
      props.dispatch(nextPageViewerSearch())
    }
  }
```