### PR TITLE
Fix Union Encoding

### DIFF
--- a/zealot/zed/types/type-array.ts
+++ b/zealot/zed/types/type-array.ts
@@ -18,7 +18,7 @@ export class TypeArray implements ContainerTypeInterface {
     return `[${typeId(type)}]`
   }
 
-  create(values: zjson.ArrayValue, typedefs) {
+  create(values: zjson.ArrayValue | null, typedefs) {
     return new Array(
       this,
       isNull(values)

--- a/zealot/zed/types/type-map.ts
+++ b/zealot/zed/types/type-map.ts
@@ -13,15 +13,17 @@ export class TypeMap implements ContainerTypeInterface {
     return `|{` + typeId(keyType) + ":" + typeId(valType) + "}|"
   }
 
-  create(value: [Value, Value][], typedefs) {
+  create(value: [Value, Value][] | null, typedefs) {
     return new ZedMap(
       this,
-      new Map(
-        value.map((entry) => [
-          this.keyType.create(entry[0], typedefs),
-          this.valType.create(entry[1], typedefs)
-        ])
-      )
+      isNull(value)
+        ? null
+        : new Map(
+            value.map((entry) => [
+              this.keyType.create(entry[0], typedefs),
+              this.valType.create(entry[1], typedefs)
+            ])
+          )
     )
   }
 

--- a/zealot/zed/values/union.ts
+++ b/zealot/zed/values/union.ts
@@ -18,7 +18,7 @@ export class Union implements ZedValueInterface {
 
   serialize() {
     if (isNull(this.index) || isNull(this.value)) return null
-    return [this.index.toString(), this.value.toString()]
+    return [this.index.toString(), this.value.serialize()]
   }
 
   isUnset() {

--- a/zealot/zjson.test.ts
+++ b/zealot/zjson.test.ts
@@ -17,8 +17,23 @@ const file = data.getPath("sample.zson")
 test("decode, then encode", () => {
   const input = zq("*", file)
   const ctx = new ZedContext()
+  const decoded = ctx.decode(input)
+  const encoded = ctx.encode(decoded)
 
-  expect(ctx.encode(ctx.decode(input))).toEqual(input)
+  for (let i = 0; i < input.length; ++i) {
+    expect(encoded[i]).toEqual(input[i])
+  }
+})
+
+test("decode, then encode a fused input", () => {
+  const input = zq("fuse", file)
+  const ctx = new ZedContext()
+  const decoded = ctx.decode(input)
+  const encoded = ctx.encode(decoded)
+
+  for (let i = 0; i < input.length; ++i) {
+    expect(encoded[i]).toEqual(input[i])
+  }
 })
 
 test("decode, encode with type values", () => {


### PR DESCRIPTION
fixes #1855 

When encoding a union value back into zjson, we were calling value.toString() instead of value.serialize(). The resulted in the string representation of the value rather than the json value. 

In the original repro, the tags field was a union of "string", "string array", and "null". When we received the data the value was: `["CobaltStrike", "HKKFGL-AS-AP HK Kwaifong Group Limited"]`. When we encoded it back it became `"[CobaltStrike,HKKFGL-AS-AP HK Kwaifong Group Limited]"`. This resulted in bad zjson being saved. When it was read and decoded, it choked on that string value and caused the error.

A test has been added that replicated the error and confirmed that it was fixed.

