### PR TITLE
Set hidden window lastFocused to 0

### DIFF
--- a/src/js/electron/brim-start.test.ts
+++ b/src/js/electron/brim-start.test.ts
@@ -42,8 +42,14 @@ test("start opens default windows and in correct focus order", async () => {
   await brim.start()
   expect(brim.windows.count()).toBe(2)
   const windows = brim.windows.getAll()
-  expect(windows[0].name).toBe("hidden")
-  expect(windows[1].name).toBe("search")
+  try {
+    expect(windows[0].name).toBe("hidden")
+    expect(windows[1].name).toBe("search")
+  } catch (e) {
+    // this try block has been proven to be indeterminate, log windows too if it fails so we can see why
+    console.error("windows are: ", windows)
+    throw e
+  }
 })
 
 test("start installs dev extensions if is dev", async () => {

--- a/src/js/electron/tron/window-manager.ts
+++ b/src/js/electron/tron/window-manager.ts
@@ -190,7 +190,7 @@ export class WindowManager {
         id,
         ref,
         name,
-        lastFocused: new Date().getTime(),
+        lastFocused: name === "hidden" ? 0 : new Date().getTime(),
         initialState,
         close: () => Promise.resolve(),
         async confirmClose() {


### PR DESCRIPTION
We have a flaky test, as seen in https://github.com/brimdata/brim/actions/runs/1296027268 

I ran this 100 times in a loop on my machine and could not reproduce the issue, but my hypothesis is that either the lastFocused times are off due to a race condition in electron's window creation such that the search window is created first, OR (and more likely, I think) that when they are created with the same time timestamp then the sort function just preserves the nondeterministic order that `Object.values()` had provided in the `brim.windows.getAll()` method.

To handle this, I'm proposing we set the hidden window's lastFocused to `0` on creation, which should handle both possibilities.

As a side note, I also considered setting the `focusable: false` option to electron's window creator but the electron [documentation](https://www.electronjs.org/docs/api/browser-window#winfocusable-windows-macos) indicates that will produce different behaviors for all the OS's we support, which I'm hesitant to instate. It also wouldn't solve this problem.

> focusable Boolean (optional) - Whether the window can be focused. Default is true. On Windows setting focusable: false also implies setting skipTaskbar: true. On Linux setting focusable: false makes the window stop interacting with wm, so the window will always stay on top in all workspaces.

Finally, I threw in a catch-log in case all of this is wrong and we want to capture the failure state. (which we can remove if we don't see this again)

Signed-off-by: Mason Fish <mason@brimsecurity.com>