### PR TITLE
Fix qlib folder context menu

### DIFF
--- a/src/js/components/SideBar/Item.tsx
+++ b/src/js/components/SideBar/Item.tsx
@@ -129,6 +129,7 @@ export default function Item({innerRef, styles, data, state, handlers, tree}) {
   const currentPool = useSelector(Current.getPool)
   const {isEditing, isSelected} = state
   const {value, id} = data
+  const isGroup = "items" in data
 
   const selected = Array.from(new Set([...tree.getSelectedIds(), data.id]))
   const hasMultiSelected = selected.length > 1
@@ -161,12 +162,12 @@ export default function Item({innerRef, styles, data, state, handlers, tree}) {
   const template: MenuItemConstructorOptions[] = [
     {
       label: "Run Query",
-      enabled: !hasMultiSelected && !!currentPool,
+      enabled: !hasMultiSelected && !!currentPool && !isGroup,
       click: () => runQuery(value)
     },
     {
       label: "Copy Query",
-      enabled: !hasMultiSelected,
+      enabled: !hasMultiSelected && !isGroup,
       click: () => {
         lib.doc.copyToClipboard(value)
         toast("Query copied to clipboard")
@@ -180,7 +181,7 @@ export default function Item({innerRef, styles, data, state, handlers, tree}) {
     },
     {
       label: "Edit",
-      enabled: !hasMultiSelected && !isBrimItem,
+      enabled: !hasMultiSelected && !isBrimItem && !isGroup,
       click: () => {
         // only edit queries
         if ("items" in data) return
@@ -212,7 +213,6 @@ export default function Item({innerRef, styles, data, state, handlers, tree}) {
   ]
 
   const menu = usePopupMenu(template)
-  const isGroup = "items" in data
   const itemIcon = isGroup ? <Folder /> : <StarNoFillIcon />
 
   return (

--- a/src/js/components/SideBar/Item.tsx
+++ b/src/js/components/SideBar/Item.tsx
@@ -162,12 +162,14 @@ export default function Item({innerRef, styles, data, state, handlers, tree}) {
   const template: MenuItemConstructorOptions[] = [
     {
       label: "Run Query",
-      enabled: !hasMultiSelected && !!currentPool && !isGroup,
+      enabled: !hasMultiSelected && !!currentPool,
+      visible: !isGroup,
       click: () => runQuery(value)
     },
     {
       label: "Copy Query",
-      enabled: !hasMultiSelected && !isGroup,
+      enabled: !hasMultiSelected,
+      visible: !isGroup,
       click: () => {
         lib.doc.copyToClipboard(value)
         toast("Query copied to clipboard")
@@ -181,7 +183,8 @@ export default function Item({innerRef, styles, data, state, handlers, tree}) {
     },
     {
       label: "Edit",
-      enabled: !hasMultiSelected && !isBrimItem && !isGroup,
+      enabled: !hasMultiSelected && !isBrimItem,
+      visible: !isGroup,
       click: () => dispatch(Modal.show("edit-query", {query: data}))
     },
     {type: "separator"},

--- a/src/js/components/SideBar/Item.tsx
+++ b/src/js/components/SideBar/Item.tsx
@@ -182,11 +182,7 @@ export default function Item({innerRef, styles, data, state, handlers, tree}) {
     {
       label: "Edit",
       enabled: !hasMultiSelected && !isBrimItem && !isGroup,
-      click: () => {
-        // only edit queries
-        if ("items" in data) return
-        dispatch(Modal.show("edit-query", {query: data}))
-      }
+      click: () => dispatch(Modal.show("edit-query", {query: data}))
     },
     {type: "separator"},
     {


### PR DESCRIPTION
fixes #1907 

Disables `Edit`, `Run Query`, and `Copy Query` if a given item is a group/folder

<img width="484" alt="image" src="https://user-images.githubusercontent.com/14865533/139925787-95e6f4bf-25a6-4f41-8e6f-c57e772534f6.png">


Signed-off-by: Mason Fish <mason@brimsecurity.com>