### PR TITLE
Make hover and active states consistent across the sidebar

### DIFF
--- a/plugins/brimcap/brimcap-plugin.ts
+++ b/plugins/brimcap/brimcap-plugin.ts
@@ -144,7 +144,8 @@ export default class BrimcapPlugin {
     this.api.toolbar.add("detail", {
       ...itemOptions,
       id: detailButtonId,
-      command: brimcapDownloadCurrentCmd
+      command: brimcapDownloadCurrentCmd,
+      label: undefined
     })
 
     // add click handlers for button's emitted commands

--- a/src/css/_finding-card.scss
+++ b/src/css/_finding-card.scss
@@ -6,7 +6,7 @@
   width: 100%;
   overflow: hidden;
   transition: background-color 100ms;
-  
+
   &:hover {
     background-color: rgba(0, 0, 0, 0.03);
   }

--- a/src/css/_finding-card.scss
+++ b/src/css/_finding-card.scss
@@ -5,7 +5,6 @@
   padding-left: 22px;
   width: 100%;
   overflow: hidden;
-  transition: background-color 100ms;
 
   &:hover {
     background-color: rgba(0, 0, 0, 0.03);

--- a/src/css/_finding-card.scss
+++ b/src/css/_finding-card.scss
@@ -5,13 +5,14 @@
   padding-left: 22px;
   width: 100%;
   overflow: hidden;
-
+  transition: background-color 100ms;
+  
   &:hover {
-    background-color: var(--coconut);
+    background-color: rgba(0, 0, 0, 0.03);
   }
 
   &:active {
-    background: rgba(0, 0, 0, 0.08);
+    background-color: rgba(0, 0, 0, 0.08);
   }
 }
 

--- a/src/css/_saved-pools-list.scss
+++ b/src/css/_saved-pools-list.scss
@@ -25,7 +25,6 @@
     list-style-type: none;
     display: flex;
     align-items: center;
-    transition: background-color 100ms;
 
     &:hover {
       background-color: rgba(0, 0, 0, 0.03);

--- a/src/css/_saved-pools-list.scss
+++ b/src/css/_saved-pools-list.scss
@@ -25,14 +25,14 @@
     list-style-type: none;
     display: flex;
     align-items: center;
-    border-radius: 4px;
+    transition: background-color 100ms;
 
     &:hover {
-      background-color: var(--coconut);
+      background-color: rgba(0, 0, 0, 0.03);
     }
 
     &:active {
-      background: rgba(0, 0, 0, 0.08);
+      background-color: rgba(0, 0, 0, 0.08);
     }
   }
 

--- a/src/js/components/SideBar/Item.tsx
+++ b/src/js/components/SideBar/Item.tsx
@@ -32,13 +32,24 @@ const BG = styled.div`
   cursor: default;
   user-select: none;
   outline: none;
+  transition: background-color 100ms;
 
   &.isSelected {
-    background: var(--havelock);
+    transition: none;
+    background-color: var(--havelock);
     color: white;
   }
   &.isOverFolder {
-    background: hsla(0 0% 0% / 0.04);
+    background-color: hsla(0 0% 0% / 0.06);
+  }
+  &:hover:not(.isDragging):not(.isSelected) {
+    background-color: hsla(0 0% 0% / 0.03);
+  }
+  &.isDragging {
+    background-color: hsla(0 0% 0% / 0);
+  }
+  &:active:not(.isDragging):not(.isSelected) {
+    background-color: hsla(0 0% 0% / 0.08);
   }
 `
 
@@ -154,8 +165,9 @@ export default function Item({innerRef, styles, data, state, handlers, tree}) {
       )
 
     handlers.select(e, false)
-    if (!value) return
-    runQuery(value)
+    if (value && !e.meta && !e.shift) {
+      runQuery(value)
+    }
   }
 
   const template: MenuItemConstructorOptions[] = [

--- a/src/js/components/SideBar/Item.tsx
+++ b/src/js/components/SideBar/Item.tsx
@@ -32,24 +32,24 @@ const BG = styled.div`
   cursor: default;
   user-select: none;
   outline: none;
-  transition: background-color 100ms;
+
+  &:hover {
+    background-color: hsla(0 0% 0% / 0.03);
+  }
+  &:active {
+    background-color: hsla(0 0% 0% / 0.08);
+  }
 
   &.isSelected {
-    transition: none;
     background-color: var(--havelock);
     color: white;
   }
   &.isOverFolder {
     background-color: hsla(0 0% 0% / 0.06);
   }
-  &:hover:not(.isDragging):not(.isSelected) {
-    background-color: hsla(0 0% 0% / 0.03);
-  }
-  &.isDragging {
-    background-color: hsla(0 0% 0% / 0);
-  }
-  &:active:not(.isDragging):not(.isSelected) {
-    background-color: hsla(0 0% 0% / 0.08);
+
+  &.isDragging:not(.isSelected) {
+    background-color: inherit;
   }
 `
 

--- a/src/js/components/SideBar/Item.tsx
+++ b/src/js/components/SideBar/Item.tsx
@@ -158,14 +158,14 @@ export default function Item({innerRef, styles, data, state, handlers, tree}) {
     handlers.toggle(e)
   }
 
-  const onItemClick = (e) => {
+  const onItemClick = (e: React.MouseEvent) => {
     if (!currentPool)
       return dispatch(
         Notice.set({type: "NoPoolError", message: "No Pool Selected"})
       )
 
     handlers.select(e, false)
-    if (value && !e.meta && !e.shift) {
+    if (value && !e.metaKey && !e.shiftKey) {
       runQuery(value)
     }
   }


### PR DESCRIPTION
* fixes #1925 Does not issue a query if we are multi-selecting.
* fixes #1926 Adds back active and hover states to sidebar items. 
* fixes #1916 Removes label from packet button on detail window.



https://user-images.githubusercontent.com/3460638/139960320-31fc2207-faa7-4873-af2b-33287d1fbf9e.mp4


![image](https://user-images.githubusercontent.com/3460638/139963464-8f2f8745-4631-4811-bbf2-592e3d47b85f.png)


![image](https://user-images.githubusercontent.com/3460638/139963481-e82b333a-5ce1-4967-9ae9-0676fe5bbd91.png)
