### PR TITLE
Polish Readonly Query Folders Drag & Drop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22005,9 +22005,9 @@
       }
     },
     "react-arborist": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/react-arborist/-/react-arborist-0.1.12.tgz",
-      "integrity": "sha512-JU4y8dD04srWNmRNEOy4BHTvFvcuvvowCCJPka+OPwjKcJUSplID8pZ2GOfZMBqXM5XgP5z/m7o+ly3WE4kerQ==",
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/react-arborist/-/react-arborist-0.1.14.tgz",
+      "integrity": "sha512-kJ4rF9Fb0h/f/YJa+SaDlvFvfg+8a/+BqSf1NBWMsrWkkk5OIAyRDUiIXzGIlUoiWsWla7EiQeOoaqzc3n1Erg==",
       "requires": {
         "react-dnd": "^14.0.3",
         "react-dnd-html5-backend": "^14.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10258,9 +10258,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.15.4",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
-          "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.0.tgz",
+          "integrity": "sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -22005,9 +22005,9 @@
       }
     },
     "react-arborist": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/react-arborist/-/react-arborist-0.1.11.tgz",
-      "integrity": "sha512-ZuZwcEU7QwE5rKW0mlW28zGXzWHvHisJ6Gl37Uvik68cCN/DxHWlizACZSN1QZ9FVbsHk28COUYrPM4MKCH3og==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/react-arborist/-/react-arborist-0.1.12.tgz",
+      "integrity": "sha512-JU4y8dD04srWNmRNEOy4BHTvFvcuvvowCCJPka+OPwjKcJUSplID8pZ2GOfZMBqXM5XgP5z/m7o+ly3WE4kerQ==",
       "requires": {
         "react-dnd": "^14.0.3",
         "react-dnd-html5-backend": "^14.0.1",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "polished": "^3.6.5",
     "prismjs": "^1.20.0",
     "react": "^16.14.0",
-    "react-arborist": "^0.1.11",
+    "react-arborist": "^0.1.12",
     "react-beautiful-dnd": "^13.0.0",
     "react-dom": "^16.14.0",
     "react-grid-layout": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "polished": "^3.6.5",
     "prismjs": "^1.20.0",
     "react": "^16.14.0",
-    "react-arborist": "^0.1.12",
+    "react-arborist": "^0.1.14",
     "react-beautiful-dnd": "^13.0.0",
     "react-dom": "^16.14.0",
     "react-grid-layout": "^1.2.0",

--- a/src/js/components/LeftPane/QueriesSection.tsx
+++ b/src/js/components/LeftPane/QueriesSection.tsx
@@ -211,8 +211,8 @@ function QueriesSection({isOpen, style, resizeProps, toggleProps}) {
             data={queries}
             getChildren="items"
             isOpen="isOpen"
-            isDraggable={(d) => !dispatch(isBrimLib([d.id]))}
-            isDroppable={(d) => !dispatch(isBrimLib([d.id]))}
+            disableDrag={(d) => !!dispatch(isBrimLib([d.id]))}
+            disableDrop={(d) => d.id === "brim"}
             rowHeight={24}
             width={width}
             height={height}


### PR DESCRIPTION
Fixes #1927 

There were some bugs around the readonly folders. You couldn't drag anything above or below the folders. 

I also changed the <Tree /> component props from isDraggable to disableDrag and disableDrop, inverting them. The disableDrop prop now only works on directories. If a directory matches the disableDrop function, you will not be able to drop an item in it or any of its children.

Here is a video of this branch. You see you can drag items around the readonly folders, but not on it or in it.

https://user-images.githubusercontent.com/3460638/140252498-701d323f-7f55-4c9f-8ea8-647e69cb11a1.mp4



