### PR TITLE
Request zjson format from query endpoint 

### DIFF
--- a/src/js/flows/refreshPoolInfo.ts
+++ b/src/js/flows/refreshPoolInfo.ts
@@ -7,7 +7,6 @@ import {PoolConfig, PoolStats} from "../../../zealot/types"
 import interop from "../brim/interop"
 import Workspaces from "../state/Workspaces"
 import workspace from "../brim/workspace"
-import log from "electron-log"
 
 type refreshPoolInfoArgs = {
   workspaceId: string

--- a/src/js/flows/refreshPoolInfo.ts
+++ b/src/js/flows/refreshPoolInfo.ts
@@ -7,6 +7,7 @@ import {PoolConfig, PoolStats} from "../../../zealot/types"
 import interop from "../brim/interop"
 import Workspaces from "../state/Workspaces"
 import workspace from "../brim/workspace"
+import log from "electron-log"
 
 type refreshPoolInfoArgs = {
   workspaceId: string
@@ -15,7 +16,7 @@ type refreshPoolInfoArgs = {
 
 export default function refreshPoolInfo(
   refreshPoolInfoArgs?: refreshPoolInfoArgs
-): Thunk {
+): Thunk<Promise<void>> {
   return (dispatch, getState) => {
     const ws = refreshPoolInfoArgs?.workspaceId
       ? workspace(Workspaces.id(refreshPoolInfoArgs.workspaceId)(getState()))
@@ -26,7 +27,7 @@ export default function refreshPoolInfo(
 
     let config: PoolConfig
     let stats: PoolStats
-    Promise.all([
+    return Promise.all([
       zealot.pools.get(poolId).then((data: PoolConfig) => {
         config = data
       }),

--- a/src/js/hidden.tsx
+++ b/src/js/hidden.tsx
@@ -68,7 +68,9 @@ const Hidden = () => {
         if (!poolId)
           return log.error(new Error("No 'pool_id' from branch-commit event"))
 
-        dispatch(refreshPoolInfo({workspaceId: w.id, poolId}))
+        dispatch(refreshPoolInfo({workspaceId: w.id, poolId})).catch((e) => {
+          log.error("branch-commit update failed: ", e)
+        })
       })
     })
 

--- a/test/integration/helpers/createTestBrim.ts
+++ b/test/integration/helpers/createTestBrim.ts
@@ -9,7 +9,8 @@ import waitForHook from "./appStep/api/waitForHook"
 // TODO in a future PR: remove direct logStep uses here.
 import logStep from "./appStep/util/logStep"
 import {retryUntil} from "./control"
-import newAppInstance from "./newAppInstance"
+import newAppInstance, {defaultTimeout} from "./newAppInstance"
+import {Application} from "spectron"
 
 export default (name: string) => {
   let app
@@ -25,6 +26,11 @@ export default (name: string) => {
   })
 
   return {
+    async withImplicitTimeout(timeout: number, cb: () => Promise<any>) {
+      app.client.setTimeout({implicit: timeout})
+      await cb()
+      app.client.setTimeout({implicit: defaultTimeout})
+    },
     $(locator: Locator | string): WebdriverIO.Element {
       if (isString(locator)) return app.client.$(locator)
       else return app.client.$(locator.css)
@@ -39,7 +45,7 @@ export default (name: string) => {
       return app.client.execute((path) => navTo(path), path)
     },
 
-    getApp() {
+    getApp(): Application {
       return app
     },
 

--- a/test/integration/helpers/newAppInstance.ts
+++ b/test/integration/helpers/newAppInstance.ts
@@ -9,6 +9,8 @@ import {itestDir, repoDir} from "./env"
 import {LOG} from "./log"
 import env from "app/core/env"
 
+export const defaultTimeout = 25000
+
 export default (name: string, idx: number): Application => {
   const macInstallPath = "/Applications/Brim.app/Contents/MacOS/Brim"
   const linuxInstallPath = "/usr/bin/brim"
@@ -20,7 +22,7 @@ export default (name: string, idx: number): Application => {
   let appArgs = {
     chromeDriverArgs: [`--user-data-dir=${userDataDir}`],
     startTimeout: 60000,
-    waitTimeout: 25000,
+    waitTimeout: defaultTimeout,
     quitTimeout: 10000,
     chromeDriverLogPath: path.join(userDataDir, "chromedriver.log"),
     webdriverLogPath: path.join(userDataDir, webdriverLogDir),

--- a/test/integration/tests/zed-events.test.ts
+++ b/test/integration/tests/zed-events.test.ts
@@ -1,0 +1,47 @@
+import createTestBrim from "../helpers/createTestBrim"
+import {createZealot} from "../../../zealot"
+import {Readable} from "stream"
+import {selectors} from "../helpers/integration"
+import {poolItem} from "../helpers/locators"
+
+describe("Handle Zed server events", () => {
+  const zealot = createZealot("localhost:9867")
+  const brim = createTestBrim("zed-events-tests")
+  let poolId
+
+  beforeAll(async () => {
+    await brim.ingest("sample.zng")
+    poolId = (await zealot.pools.list())[0].id
+  })
+
+  test("branch-commit", async () => {
+    const data = new Readable()
+    data._read = () => {}
+    const loadPromise = zealot.pools.load(poolId, "main", {
+      author: "itest author",
+      body: "itest body",
+      data
+    })
+    data.push(`{"testKey": "testValue"}`)
+    data.push(null)
+    await loadPromise
+
+    await brim.waitForHTMLText(
+      selectors.infoNotice,
+      /More data is now available\./s
+    )
+  })
+
+  test("pool-new/update/delete", async () => {
+    const {
+      pool: {id}
+    } = await zealot.pools.create({name: "test-pool-new"})
+    expect(await brim.getText(poolItem)).toBe("test-pool-new")
+    await zealot.pools.update(id, {name: "test-pool-update"})
+    expect(await brim.getText(poolItem)).toBe("test-pool-update")
+    await zealot.pools.delete(id)
+    await brim.withImplicitTimeout(500, async () => {
+      expect(await brim.isNotVisible(poolItem)).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
fixes #1946 
adds integration tests to ensure #1921 is resolved but depends on https://github.com/brimdata/brim/pull/1945

The itest is not related to this specific format change other than how the commit-notification breakage (which it tests) encouraged us to re-examine the requested response format change that is included here. That changes consists of requesting and unpacking zjson into js pool config objects instead of unpacking json.