### PR TITLE
Fix zed-events test

### DIFF
--- a/test/integration/tests/zed-events.test.ts
+++ b/test/integration/tests/zed-events.test.ts
@@ -36,9 +36,9 @@ describe("Handle Zed server events", () => {
     const {
       pool: {id}
     } = await zealot.pools.create({name: "test-pool-new"})
-    expect(await brim.getText(poolItem)).toBe("test-pool-new")
+    await brim.hasText("test-pool-new", poolItem)
     await zealot.pools.update(id, {name: "test-pool-update"})
-    expect(await brim.getText(poolItem)).toBe("test-pool-update")
+    await brim.hasText("test-pool-update", poolItem)
     await zealot.pools.delete(id)
     await brim.withImplicitTimeout(500, async () => {
       expect(await brim.isNotVisible(poolItem)).toBe(true)


### PR DESCRIPTION
Sometimes the update event does not get processed before this test checks for the containing text. The `hasText()` method will retry if it does not find what it's looking for and should fix this issue.

Signed-off-by: Mason Fish <mason@brimsecurity.com>