### PR TITLE
fix non-integer Ts.ns in dateToTs()

### DIFF
--- a/src/js/brim/time.ts
+++ b/src/js/brim/time.ts
@@ -81,7 +81,7 @@ function dateToTs(date: Date): Ts {
   const ms = date.getTime()
   const secFloat = ms / 1000
   const sec = Math.floor(secFloat)
-  const ns = +(secFloat - sec).toFixed(3) * 1e9
+  const ns = Math.round((secFloat - sec) * 1e3) * 1e6
   return {
     sec,
     ns


### PR DESCRIPTION
The nanosecond calculation in dateToTs() sometimes returns a non-integer
value, leading to a RangeError when time().toBigInt() tries to convert
the value to a BigInt.  Fix by using Math.round() instead of
Number.prototype.toFixed() in the calculation.

Fixes CI failures like https://github.com/brimdata/brim/runs/4216942185?check_suite_focus=true#step:19:27.