### PR TITLE
Query timeout extension

### DIFF
--- a/docs/Code-Base-Walkthrough.md
+++ b/docs/Code-Base-Walkthrough.md
@@ -66,7 +66,7 @@ Additionally, we rely heavily on the node modules listed here:
 **Testing**
 
 - [Jest ](https://jestjs.io/docs/en/getting-started) Unit tests are run with `npm run test`
-- [Spectron](https://www.electronjs.org/spectron) Used for integration testing `npm run itest`
+- [Spectron](https://github.com/electron-userland/spectron) Used for integration testing `npm run itest`
 
 ## Patterns
 

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -8,7 +8,6 @@ tests are better suited as Brim unit tests or tests in the Zed repository.
 The tests use Jest and Spectron.
 
 - https://jestjs.io
-- https://www.electronjs.org/spectron
 - https://github.com/electron-userland/spectron
 
 ## Requirements

--- a/zealot/api/query.ts
+++ b/zealot/api/query.ts
@@ -8,7 +8,8 @@ export default function queryApi(zed: string, args: QueryArgs): FetchArgs {
     path: `/query?${getQueryParams(args)}`,
     body: JSON.stringify({query: zed}),
     headers: getHeaders(args),
-    signal: args.signal
+    signal: args.signal,
+    timeout: args.timeout
   }
 }
 

--- a/zealot/config/query-args.ts
+++ b/zealot/config/query-args.ts
@@ -2,6 +2,7 @@ import {QueryArgs} from "../types"
 
 export function getDefaultQueryArgs(): QueryArgs {
   return {
+    timeout: 30000,
     format: "zjson",
     controlMessages: true,
     enhancers: []

--- a/zealot/config/query-args.ts
+++ b/zealot/config/query-args.ts
@@ -2,7 +2,8 @@ import {QueryArgs} from "../types"
 
 export function getDefaultQueryArgs(): QueryArgs {
   return {
-    timeout: 30000,
+    // 5min
+    timeout: 300000,
     format: "zjson",
     controlMessages: true,
     enhancers: []

--- a/zealot/types.ts
+++ b/zealot/types.ts
@@ -33,6 +33,7 @@ export interface QueryArgs {
   format: QueryFormat
   controlMessages?: boolean
   enhancers?: Enhancer[]
+  timeout?: number
   signal?: AbortSignal
 }
 


### PR DESCRIPTION
While verifying the timeout work I added in #1956 I discovered that the query endpoint's streamed response does not get sent back to us as quickly as I'd thought. Below is a breakdown of the request (which you can see for yourself connecting to `Shasta`, the `zng` pool, and then issuing the `Unique Network Connections` query.

Note the 16.46 seconds for TTFB.
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/14865533/142321889-0ba8e14d-8533-414c-bde7-2b063babc741.png">

The workaround I give here is to just explicitly extend the timeout for all of our query requests until we can figure out a better solution. I've set the query timeout to 5min.
