### PR TITLE
simplify .github/workflows/ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,57 +30,23 @@ jobs:
       - run: npm test -- --maxWorkers=2 --ci
       - run: npm run test:api
       - run: npm run generate-responses -- --silent
-      - name: Build Linux Packages
+      - name: Build and install package
         if: runner.os == 'Linux'
         run: |
           set -x
-          npx electron-builder --linux
-      - name: Persist Linux packages
-        if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v2
+          npx electron-builder --linux=deb
+          sudo apt install -y --no-install-recommends ./dist/installers/*.deb
+      - name: Playwright tests
+        id: playwright
+        if: runner.os != 'Windows'
+        uses: GabrielBB/xvfb-action@v1
         with:
-          name: linux-release
-          path: dist/installers/Brim-*
-
-  playwright_integration_test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ macos-10.15, ubuntu-18.04 ]
-    needs: build
-    steps:
-      - run: git config --global core.autocrlf false
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '1.16'
-      - uses: actions/setup-node@v2
-        with:
-          cache: npm
-          node-version-file: .nvmrc
-      - run: npm install --no-audit
-      - run: npm run build
-      - name: Download Linux packages
-        if: runner.os == 'Linux'
-        uses: actions/download-artifact@v2
-        with:
-          name: linux-release
-          path: linux-release
-      - name: Integration Tests (Debian Linux)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt install -y ./linux-release/Brim*.deb
-          xvfb-run --auto-servernum -s "-screen 0 1280x1024x24" npm run test:playwright -- --ci --forceExit
-        env:
-          WORKSPACE: /var/tmp/brimdata
-      - name: Integration Tests (non-Linux)
-        if: runner.os != 'Linux'
-        run: npm run test:playwright -- --ci --forceExit
+          options: -screen 0 1280x1024x24
+          run: npm run test:playwright -- --ci --forceExit
         env:
           DEBUG: pw:api
-          WORKSPACE: /var/tmp/brimdata
       - uses: actions/upload-artifact@v2
-        if: failure()
+        if: failure() && steps.playwright.outcome == 'failure'
         with:
           name: artifacts-${{ matrix.os }}
-          path: /var/tmp/brimdata/playwright-itest
+          path: run/playwright-itest


### PR DESCRIPTION
* Use a single job to eliminate repeated steps and uploading and
  downloading Linux packages.
* Stop building the RPM package since it's unused.
* Use a single step for Playwright tests.
* Don't bother with the WORKSPACE environment variable.

This appears to shorten the workflow's running time by four minutes.