### PR TITLE
use fancy actions/setup-node@v2 features in CI

### DIFF
--- a/.github/workflows/advance-zed.yml
+++ b/.github/workflows/advance-zed.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [14.x]
         os: [ubuntu-18.04]
     timeout-minutes: 60
     steps:
@@ -75,36 +74,13 @@ jobs:
 
       # This section runs typical CI, with an updated Zed. Most of this
       # is no different than the normal CI flow.
+      - uses: actions/setup-node@v2
+        with:
+          cache: npm
+          node-version-file: .nvmrc
       - uses: actions/setup-go@v2
         with:
           go-version: '1.16'
-      - name: setup node version ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ matrix.node-version }}
-      - name: Set NPM Cache Directory
-        id: set-npm-cache-dir
-        run: echo "::set-output name=npm_cache_dir::$(npm config get cache)"
-      - name: Clear Extraneous Runner Cache
-        # Clear on-runner cache before we create our own cache to prevent
-        # slower build times. See https://github.com/brimdata/brim/pull/590
-        # and https://github.com/brimdata/brim/issues/641
-        run: rm -rf "${NPM_CACHE:?}"
-        env:
-          NPM_CACHE: ${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
-        shell: bash
-      - name: Cache node modules
-        uses: actions/cache@v2
-        # Change the cache name any time you want to start with a cleared
-        # cache.
-        env:
-          cache-name: cache-node-modules-ci-v5
-        with:
-          path: ${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-
-
       - name: Update Zed
         run: npm install https://github.com/brimdata/zed#${{ steps.zed_pr.outputs.sha }}
 
@@ -145,7 +121,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: failure() && steps.testIntegration.conclusion == 'failure'
         with:
-          name: artifacts-${{ matrix.os }}-node-${{ matrix.node-version }}
+          name: artifacts-${{ matrix.os }}
           path: /var/tmp/brimdata/playwright-itest
 
       - name: Create Pull Request for Manual Inspection

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,40 +11,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [ 14.x ]
         os: [ macos-10.15, ubuntu-18.04, windows-2019 ]
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v2
-      - name: setup node version ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ matrix.node-version }}
       - uses: actions/setup-go@v2
         with:
           go-version: '1.16'
-      - name: Set NPM Cache Directory
-        id: set-npm-cache-dir
-        run: echo "::set-output name=npm_cache_dir::$(npm config get cache)"
-      - name: Clear Extraneous Runner Cache
-        # Clear on-runner cache before we create our own cache to prevent
-        # slower build times. See https://github.com/brimdata/brim/pull/590
-        # and https://github.com/brimdata/brim/issues/641
-        run: rm -rf "${NPM_CACHE:?}"
-        env:
-          NPM_CACHE: ${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
-        shell: bash
-      - name: Cache node modules
-        uses: actions/cache@v2
-        # Change the cache name any time you want to start with a cleared
-        # cache.
-        env:
-          cache-name: cache-node-modules-ci-v5
+      - uses: actions/setup-node@v2
         with:
-          path: ${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-
+          cache: npm
+          node-version-file: .nvmrc
       - run: npm install --no-audit
       - run: npm run format-check
       - run: npm run build
@@ -69,7 +46,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [ 14.x ]
         os: [ macos-10.15, ubuntu-18.04 ]
     needs: build
     steps:
@@ -78,27 +54,10 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '1.16'
-      - name: setup node version ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
-      - name: Set NPM Cache Directory
-        id: set-npm-cache-dir
-        run: echo "::set-output name=npm_cache_dir::$(npm config get cache)"
-      - name: Clear Extraneous Runner Cache
-        run: rm -rf "${NPM_CACHE:?}"
-        env:
-          NPM_CACHE: ${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
-        shell: bash
-      - name: Cache node modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-node-modules-ci-v5
-        with:
-          path: ${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-
+          cache: npm
+          node-version-file: .nvmrc
       - run: npm install --no-audit
       - run: npm run build
       - name: Download Linux packages
@@ -123,5 +82,5 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: artifacts-${{ matrix.os }}-node-${{ matrix.node-version }}
+          name: artifacts-${{ matrix.os }}
           path: /var/tmp/brimdata/playwright-itest

--- a/.github/workflows/linux-release-candidate.yml
+++ b/.github/workflows/linux-release-candidate.yml
@@ -21,27 +21,10 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: '1.16'
-    - name: setup node
-      uses: actions/setup-node@v2
+    - uses: actions/setup-node@v2
       with:
-        node-version: 14.x
-    - name: Set NPM Cache Directory
-      id: set-npm-cache-dir
-      run: echo "::set-output name=npm_cache_dir::$(npm config get cache)"
-    - name: Clear Extraneous Runner Cache
-      run: rm -rf "${NPM_CACHE:?}"
-      env:
-        NPM_CACHE: ${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
-      shell: bash
-    - name: Cache node modules
-      uses: actions/cache@v2
-      env:
-        cache-name: cache-node-modules-ci-v5
-      with:
-        path: ${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-
+        cache: npm
+        node-version-file: .nvmrc
     - if: ${{ !startsWith(steps.extract_branch.outputs.branch, 'rc-v') }}
       name: Set version string for ad hoc builds
       run: echo "ADHOC_VERSION_STRING=$(npm version preminor --no-git-tag-version --preid prerelease-${GITHUB_SHA:0:8})" >> $GITHUB_ENV

--- a/.github/workflows/macos-release-candidate.yml
+++ b/.github/workflows/macos-release-candidate.yml
@@ -19,32 +19,10 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: '1.16'
-    - name: setup node
-      uses: actions/setup-node@v2
+    - uses: actions/setup-node@v2
       with:
-        node-version: 14.x
-    - name: Set NPM Cache Directory
-      id: set-npm-cache-dir
-      run: echo "::set-output name=npm_cache_dir::$(npm config get cache)"
-    - name: Clear Extraneous Runner Cache
-      # Clear on-runner cache before we create our own cache to prevent
-      # slower build times. See https://github.com/brimdata/brim/pull/590
-      # and https://github.com/brimdata/brim/issues/641
-      run: rm -rf "${NPM_CACHE:?}"
-      env:
-        NPM_CACHE: ${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
-      shell: bash
-    - name: Cache node modules
-      uses: actions/cache@v2
-      # Change the cache name any time you want to start with a cleared
-      # cache.
-      env:
-        cache-name: cache-node-modules-ci-v5
-      with:
-        path: ${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-
+        cache: npm
+        node-version-file: .nvmrc
     - if: ${{ !startsWith(steps.extract_branch.outputs.branch, 'rc-v') }}
       name: Set version string for ad hoc builds
       run: echo "ADHOC_VERSION_STRING=$(npm version preminor --no-git-tag-version --preid prerelease-${GITHUB_SHA:0:8})" >> $GITHUB_ENV

--- a/.github/workflows/win-release-candidate.yml
+++ b/.github/workflows/win-release-candidate.yml
@@ -20,32 +20,10 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: '1.16'
-    - name: setup node
-      uses: actions/setup-node@v2
+    - uses: actions/setup-node@v2
       with:
-        node-version: 14.x
-    - name: Set NPM Cache Directory
-      id: set-npm-cache-dir
-      run: echo "::set-output name=npm_cache_dir::$(npm config get cache)"
-    - name: Clear Extraneous Runner Cache
-      # Clear on-runner cache before we create our own cache to prevent
-      # slower build times. See https://github.com/brimdata/brim/pull/590
-      # and https://github.com/brimdata/brim/issues/641
-      run: rm -rf "${NPM_CACHE:?}"
-      env:
-        NPM_CACHE: ${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
-      shell: bash
-    - name: Cache node modules
-      uses: actions/cache@v2
-      # Change the cache name any time you want to start with a cleared
-      # cache.
-      env:
-        cache-name: cache-node-modules-ci-v5
-      with:
-        path: ${{ steps.set-npm-cache-dir.outputs.npm_cache_dir }}
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-
+        cache: npm
+        node-version-file: .nvmrc
     - if: ${{ !startsWith(steps.extract_branch.outputs.branch, 'rc-v') }}
       name: Set version string for ad hoc builds
       run: echo "ADHOC_VERSION_STRING=$(npm version preminor --no-git-tag-version --preid prerelease-${GITHUB_SHA:0:8})" >> $GITHUB_ENV


### PR DESCRIPTION
The actions/setup-node@v2 action can save and restore the npm cache and
set up the exact Node version specified in .nvmrc.  Update workflows to
use these features.