### PR TITLE
remote-queries v0

### DIFF
--- a/src/js/components/LeftPane/remote-queries.ts
+++ b/src/js/components/LeftPane/remote-queries.ts
@@ -1,0 +1,118 @@
+import {Thunk} from "src/js/state/types"
+import {getZealot} from "../../flows/getZealot"
+import {Query} from "../../state/Queries/types"
+import {zed} from "@brimdata/zealot"
+import Pools from "src/js/state/Pools"
+import Current from "src/js/state/Current"
+import {Readable} from "stream"
+import RemoteQueries from "src/js/state/RemoteQueries"
+import {intersection} from "lodash"
+import {Pool} from "src/js/state/Pools/types"
+import {BrimWorkspace} from "../../brim"
+
+export const remoteQueriesPoolName = "_remote-queries"
+
+const recordToQuery = (r: zed.Record): Query => {
+  const id = r.get<zed.String>("id").toString()
+  const name = r.get<zed.String>("name").toString()
+  const description = r.get<zed.String>("description").toString()
+  const value = r.get<zed.String>("value").toString()
+
+  return {
+    description,
+    id,
+    name,
+    tags: [],
+    value
+  }
+}
+
+export const isRemoteLib = (ids: string[]) => (_, getState) => {
+  const remoteIds = RemoteQueries.get(getState())?.items.map((i) => i.id)
+  return intersection(ids, remoteIds).length > 0
+}
+
+export const getRemotePoolForLake = (lakeId: string): Thunk<Pool> => {
+  return (_d, getState) => {
+    return Pools.getByName(lakeId, remoteQueriesPoolName)(getState())
+  }
+}
+
+export const refreshRemoteQueries = (
+  lake?: BrimWorkspace
+): Thunk<Promise<void>> => {
+  return async (dispatch) => {
+    const zealot = dispatch(getZealot(lake))
+    try {
+      const queryReq = await zealot.query(
+        `from '${remoteQueriesPoolName}'
+        | split (
+          => query_id:={id:id,ts:ts} | sort query_id
+          => ts:=max(ts) by id | sort this
+        )
+        | join on query_id=this
+        | tombstone==false
+        | cut name, value, description, id`
+      )
+      const remoteRecords = await queryReq.records()
+      dispatch(RemoteQueries.set(remoteRecords.map<Query>(recordToQuery)))
+    } catch (e) {
+      if (/pool not found/.test(e.message)) {
+        dispatch(RemoteQueries.set([]))
+        return
+      } else throw e
+    }
+  }
+}
+
+/*
+ setRemoteQuery will create, update, or delete (by setting a 'tombstone' record)
+ a remote query by id . Remote queries are stored in a special pool defined in
+ the 'remoteQueriesPoolName' constant, and this function will create that pool
+ if it does not exist. To determine that existence, we rely on redux's list of
+ existing pools which means that this thunk depends on that state being populated
+ */
+export const setRemoteQueries = (
+  queries: Query[],
+  shouldDelete?: boolean
+): Thunk<Promise<void>> => {
+  return async (dispatch, getState) => {
+    const zealot = dispatch(getZealot())
+    let rqPoolId = Pools.getByName(
+      Current.getWorkspaceId(getState()),
+      remoteQueriesPoolName
+    )(getState())?.id
+    if (!rqPoolId) {
+      // create remote-queries pool if it doesn't already exist
+      const createResp = await zealot.pools.create({
+        name: remoteQueriesPoolName
+      })
+      rqPoolId = createResp.pool.id
+    }
+
+    try {
+      const data = new Readable()
+      const loadPromise = zealot.pools.load(rqPoolId, "main", {
+        author: "brim",
+        body:
+          "automatic remote query load for id(s): " +
+          queries.map((q) => q.id).join(", "),
+        data
+      })
+      queriesToRemoteQueries(queries, shouldDelete).forEach((d) =>
+        data.push(JSON.stringify(d))
+      )
+      data.push(null)
+      await loadPromise
+    } catch (e) {
+      throw new Error("error loading remote query: " + e)
+    }
+  }
+}
+
+const queriesToRemoteQueries = (qs: Query[], isTombstone = false) =>
+  qs.map((q) => ({
+    ...q,
+    tombstone: isTombstone,
+    ts: Date.now()
+  }))

--- a/src/js/components/QueriesModals/EditQueryModal.tsx
+++ b/src/js/components/QueriesModals/EditQueryModal.tsx
@@ -13,10 +13,11 @@ const StyledContent = styled(Content)`
 const EditQueryModal = ({onClose}) => {
   const modalArgs = useSelector(Modal.getArgs)
   const query = get(modalArgs, "query", null)
+  const isRemote = get(modalArgs, "isRemote", null)
   return (
     <StyledContent>
       <SmallTitle>Edit Query</SmallTitle>
-      <QueryForm query={query} onClose={onClose} />
+      <QueryForm query={query} onClose={onClose} isRemote={isRemote} />
     </StyledContent>
   )
 }

--- a/src/js/components/QueriesModals/NewQueryModal.tsx
+++ b/src/js/components/QueriesModals/NewQueryModal.tsx
@@ -8,10 +8,11 @@ import get from "lodash/get"
 const NewQueryModal = ({onClose}) => {
   const modalArgs = useSelector(Modal.getArgs)
   const value = get(modalArgs, "value", null)
+  const isRemote = get(modalArgs, "isRemote", false)
   return (
     <Content>
-      <SmallTitle>New Query</SmallTitle>
-      <QueryForm value={value} onClose={onClose} />
+      <SmallTitle>New {isRemote && "Remote "}Query</SmallTitle>
+      <QueryForm value={value} onClose={onClose} isRemote={isRemote} />
     </Content>
   )
 }

--- a/src/js/components/SavedPoolsList.tsx
+++ b/src/js/components/SavedPoolsList.tsx
@@ -19,6 +19,7 @@ import {WorkspaceStatus} from "../state/WorkspaceStatuses/types"
 import EmptySection from "./common/EmptySection"
 import PoolIcon from "./PoolIcon"
 import ProgressIndicator from "./ProgressIndicator"
+import {remoteQueriesPoolName} from "./LeftPane/remote-queries"
 
 type Props = {
   pools: Pool[]
@@ -103,6 +104,8 @@ export default function SavedPoolsList({pools, workspaceStatus}: Props) {
       {pools
         .sort((a, b) => (a.name > b.name ? 1 : -1))
         .map((pool) => {
+          // Do not show remote queries pool in list
+          if (pool.name === remoteQueriesPoolName) return
           return <PoolListItem key={pool.id} pool={pool} />
         })}
     </menu>

--- a/src/js/components/SideBar/Item.tsx
+++ b/src/js/components/SideBar/Item.tsx
@@ -22,6 +22,8 @@ import exportQueryLib from "../../flows/exportQueryLib"
 import {AppDispatch} from "../../state/types"
 import {brimQueryLib} from "../../../../test/playwright/helpers/locators"
 import {showContextMenu} from "../../lib/System"
+import {isRemoteLib, setRemoteQueries} from "../LeftPane/remote-queries"
+import {Query} from "../../state/Queries/types"
 
 const BG = styled.div`
   padding-left: 12px;
@@ -152,6 +154,7 @@ export default function Item({innerRef, styles, data, state, handlers, tree}) {
   const hasMultiSelected = selected.length > 1
 
   const isBrimItem = dispatch(isBrimLib([id]))
+  const isRemoteItem = dispatch(isRemoteLib([id]))
   const hasBrimItemSelected = dispatch(isBrimLib(selected))
 
   const runQuery = (value) => {
@@ -241,7 +244,11 @@ export default function Item({innerRef, styles, data, state, handlers, tree}) {
       label: "Edit",
       enabled: !hasMultiSelected && !isBrimItem,
       visible: !isGroup,
-      click: () => dispatch(Modal.show("edit-query", {query: data}))
+      click: () => {
+        const modalArgs = {query: data, isRemote: false}
+        if (isRemoteItem) modalArgs.isRemote = true
+        dispatch(Modal.show("edit-query", modalArgs))
+      }
     },
     {type: "separator"},
     {
@@ -261,7 +268,21 @@ export default function Item({innerRef, styles, data, state, handlers, tree}) {
             buttons: ["OK", "Cancel"]
           })
           .then(({response}) => {
-            if (response === 0) dispatch(Queries.removeItems(selected))
+            if (response === 0) {
+              if (isRemoteItem) {
+                const remoteQueries = selected.map<Query>((id) => ({
+                  id,
+                  value: "",
+                  name: "",
+                  description: "",
+                  tags: []
+                }))
+                dispatch(setRemoteQueries(remoteQueries, true))
+                return
+              }
+
+              dispatch(Queries.removeItems(selected))
+            }
           })
       }
     }

--- a/src/js/hidden.tsx
+++ b/src/js/hidden.tsx
@@ -14,6 +14,11 @@ import workspace from "./brim/workspace"
 import {AppDispatch} from "./state/types"
 import {subscribeEvents} from "./flows/subscribeEvents"
 import refreshPoolInfo from "./flows/refreshPoolInfo"
+import {
+  getRemotePoolForLake,
+  refreshRemoteQueries
+} from "./components/LeftPane/remote-queries"
+import brim from "./brim"
 
 initialize()
   .then(({store}) => {
@@ -73,6 +78,9 @@ const Hidden = () => {
                 new Error("No 'pool_id' from branch-commit event")
               )
 
+            const remotePool = dispatch(getRemotePoolForLake(w.id))
+            if (poolId === remotePool?.id)
+              dispatch(refreshRemoteQueries(brim.workspace(w)))
             dispatch(refreshPoolInfo({workspaceId: w.id, poolId})).catch(
               (e) => {
                 log.error("branch-commit update failed: ", e)

--- a/src/js/state/Pools/selectors.ts
+++ b/src/js/state/Pools/selectors.ts
@@ -1,4 +1,4 @@
-import {keys} from "lodash"
+import {find, keys} from "lodash"
 import {State} from "../types"
 import {Pool} from "./types"
 
@@ -12,6 +12,10 @@ const selectors = {
   getName: (workspaceId: string, poolId: string) => (state: State) => {
     const pool = getWorkspace(state, workspaceId)[poolId]
     return pool ? pool.name : ""
+  },
+  getByName: (workspaceId: string, name: string) => (state: State) => {
+    const wsPools = getWorkspace(state, workspaceId)
+    return find(wsPools, ["name", name])
   },
   raw: (state: State) => state.pools,
   getPools: (workspaceId: string | null) => (state: State): Pool[] => {

--- a/src/js/state/RemoteQueries/index.ts
+++ b/src/js/state/RemoteQueries/index.ts
@@ -1,0 +1,22 @@
+import {createSlice} from "@reduxjs/toolkit"
+
+const slice = createSlice({
+  name: "$remoteQueries",
+  initialState: {
+    id: "root",
+    name: "root",
+    isOpen: true,
+    items: []
+  },
+  reducers: {
+    set(s, a) {
+      s.items = a.payload
+    }
+  }
+})
+
+export default {
+  reducer: slice.reducer,
+  ...slice.actions,
+  get: (s) => s.remoteQueries
+}

--- a/src/js/state/getPersistable.ts
+++ b/src/js/state/getPersistable.ts
@@ -25,6 +25,7 @@ export function getWindowPersistable(state: State) {
     delete draft.toolbars
     delete draft.configs
     delete draft.modal
+    delete draft.remoteQueries
 
     for (const tab of draft.tabs.data) {
       delete tab.viewer

--- a/src/js/state/globalReducer.ts
+++ b/src/js/state/globalReducer.ts
@@ -9,6 +9,7 @@ import Queries from "./Queries"
 import {QueriesState} from "./Queries/types"
 import Lakes from "./Lakes"
 import {LakesState} from "./Lakes/types"
+import RemoteQueries from "./RemoteQueries"
 
 export type GlobalState = {
   launches: LaunchesState
@@ -18,6 +19,7 @@ export type GlobalState = {
   configPropValues: ConfigPropValuesState
   pluginStorage: PluginStorageState
   queries: QueriesState
+  remoteQueries: QueriesState
 }
 
 export default combineReducers<any, any>({
@@ -27,5 +29,6 @@ export default combineReducers<any, any>({
   configs: Configs.reducer,
   configPropValues: ConfigPropValues.reducer,
   pluginStorage: PluginStorage.reducer,
-  queries: Queries.reducer
+  queries: Queries.reducer,
+  remoteQueries: RemoteQueries.reducer
 })

--- a/src/js/state/rootReducer.ts
+++ b/src/js/state/rootReducer.ts
@@ -21,6 +21,7 @@ import Configs from "./Configs"
 import ConfigPropValues from "./ConfigPropValues"
 import Launches from "./Launches"
 import Appearance from "./Appearance"
+import RemoteQueries from "./RemoteQueries"
 
 const rootReducer = combineReducers<any, any>({
   appearance: Appearance.reducer,
@@ -41,6 +42,7 @@ const rootReducer = combineReducers<any, any>({
   feature: Feature.reducer,
   workspaceStatuses: WorkspaceStatuses.reducer,
   queries: Queries.reducer,
+  remoteQueries: RemoteQueries.reducer,
   tabHistories: TabHistories.reducer,
   url: Url.reducer,
   toolbars: Toolbars.reducer

--- a/src/js/state/types.ts
+++ b/src/js/state/types.ts
@@ -56,6 +56,7 @@ export type State = {
   pluginStorage: PluginStorageState
   workspaceStatuses: WorkspaceStatusesState
   queries: QueriesState
+  remoteQueries: QueriesState
   systemTest: SystemTestState
   feature: FeatureState
   toolbars: ToolbarsState


### PR DESCRIPTION
Here is v0 of the remote-queries feature 🎉 

A remote query is simply a named and described zed value (the same as a query from our local query lib) except that it is persisted in a zed lake instead of on a local file system. This is all facilitated by the app by creating a `_remote-queries` pool, and loading query records in for each create/update/delete operation. We include a timestamp on each query record operation so that we know which record represents the most current state. When a query is deleted, a new query record will include a `tombstone: true` value and will be the most current record. We then filter those deleted records out when retrieving them from the lake.

NOTE: There are several aspects of this feature which we intend to improve but are constrained by the current pool-centric UI. Very soon we will break ground on the new query-centric UI, which should greatly enable these remote queries to be a seamless workflow for third party integrations such as Observable. The primary pieces we are missing, to be added after the UI re-design, are:

* Updating current local/remote query within search page/on search
* Remote query tags (for now we are using the tag view as the means to access the remote queries and would need another ui element/dropdown if we wanted to show a remote query tag filter)
* Remote Query Folders

Select to see remote queries through the queries dropdown in upper right of section header
<img width="437" alt="image" src="https://user-images.githubusercontent.com/14865533/148812433-ec47716d-f8f9-401a-a9f2-3eb0fd06c1c8.png">

Create new remote query with "+" button in header after selecting the remote view from first pic
<img width="509" alt="image" src="https://user-images.githubusercontent.com/14865533/148812471-4daa3a95-8cfd-43ca-b01f-166b208154fc.png">

Fill out query, as usual (note there are no tags for remote queries yet)
<img width="1250" alt="image" src="https://user-images.githubusercontent.com/14865533/148812963-f765b235-8ccc-4e8f-98d6-6021f8001cc4.png">

Run the query just like a local query
<img width="1254" alt="image" src="https://user-images.githubusercontent.com/14865533/148812989-d4331ae6-3043-4508-8fa1-f32051f43b76.png">

