### PR TITLE
Always show queries

### DIFF
--- a/src/js/components/LeftPane/QueriesSection.tsx
+++ b/src/js/components/LeftPane/QueriesSection.tsx
@@ -244,13 +244,6 @@ function QueriesSection({isOpen, style, resizeProps, toggleProps}) {
 
   const {ref, width = 1, height = 1} = useResizeObserver<HTMLDivElement>()
   const renderQueries = () => {
-    if (!currentPool)
-      return (
-        <EmptySection
-          icon={<MagnifyingGlass />}
-          message="You must have a pool selected to run queries."
-        />
-      )
     if (!(queries?.items?.length > 0))
       return (
         <EmptySection


### PR DESCRIPTION
Show the query library even if no pool is selected. If you try to run a query you get a simple error saying no pool is selected. Closes #1954 

<img width="930" alt="Screen Shot 2022-02-15 at 2 36 42 PM" src="https://user-images.githubusercontent.com/3460638/154161684-7f31d54b-4430-451d-b578-bda368ebf19c.png">

<img width="930" alt="Screen Shot 2022-02-15 at 2 36 49 PM" src="https://user-images.githubusercontent.com/3460638/154161678-969b2bf1-3c66-44a1-9519-32151e738b41.png">

