### PR TITLE
Dont persist investigation or tabHistories state

### DIFF
--- a/src/js/state/migrations/202202170834_resetInvestigationsAndTabHistories.test.ts
+++ b/src/js/state/migrations/202202170834_resetInvestigationsAndTabHistories.test.ts
@@ -1,0 +1,15 @@
+import {migrate} from "test/unit/helpers/migrate"
+
+test("migrating 202202170834_resetInvestigationsAndTabHistories", async () => {
+  const next = await migrate({state: "v0.27.0", to: "202202170834"})
+
+  expect.assertions(5)
+
+  // @ts-ignore
+  for (const {state} of Object.values(next.windows)) {
+    expect(state.investigation).toBe(undefined)
+    expect(state.tabHistories).toBe(undefined)
+  }
+
+  expect(next.globalState.investigation).toBe(undefined)
+})

--- a/src/js/state/migrations/202202170834_resetInvestigationsAndTabHistories.ts
+++ b/src/js/state/migrations/202202170834_resetInvestigationsAndTabHistories.ts
@@ -1,0 +1,10 @@
+import {getAllStates} from "./utils/getTestState"
+
+export default function resetInvestigationsAndTabHistories(state: any) {
+  for (const s of getAllStates(state)) {
+    delete s.tabHistories
+    delete s.investigation
+  }
+
+  return state
+}


### PR DESCRIPTION
fixes #2171 

I found that the global `investigation` and window `tabHistories` state included references to poolIds which will not be the same after the lake migration occurs, so this PR resets them.