### PR TITLE
Catch and display errors from the backend

### DIFF
--- a/app/search/flows/viewer-search.ts
+++ b/app/search/flows/viewer-search.ts
@@ -32,17 +32,18 @@ export function viewerSearch(args: Args): Thunk<void> {
 
     const prevRows = Viewer.getRecords(getState())
 
-    const res = await dispatch(
-      search({
-        id,
-        query: args.query,
-        poolId: Current.mustGetPool(getState()).id,
-        from: args.from,
-        to: args.to,
-        initial: !args.append
-      })
-    )
+    let res
     try {
+      res = await dispatch(
+        search({
+          id,
+          query: args.query,
+          poolId: Current.mustGetPool(getState()).id,
+          from: args.from,
+          to: args.to,
+          initial: !args.append
+        })
+      )
       await res.collect(({rows, shapesMap}) => {
         dispatch(Viewer.setRecords(tabId, [...prevRows, ...rows]))
         dispatch(Viewer.updateColumns(tabId, shapesMap))


### PR DESCRIPTION
closes #2192 

<img width="841" alt="Screen Shot 2022-02-21 at 10 50 49 AM" src="https://user-images.githubusercontent.com/3460638/155012268-e572dd10-4f47-4e90-be2a-5a07a685f516.png">

This is not the most beautiful design, but it gets the job done for this release.