### PR TITLE
Fix advance zed workflow

### DIFF
--- a/.github/workflows/advance-zed.yml
+++ b/.github/workflows/advance-zed.yml
@@ -85,12 +85,13 @@ jobs:
       - run: yarn --inline-builds
       - run: yarn lint
       - run: yarn test
+      - run: yarn build
       - name: End to end tests
         id: playwright
         uses: GabrielBB/xvfb-action@v1
         with:
           options: -screen 0 1280x1024x24
-          run: yarn build && yarn e2e
+          run: yarn e2e
         env:
           DEBUG: pw:api
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
It looks like xvfb maybe updated and now the `yarn build && yarn e2e` doesn't work like it did.

https://github.com/brimdata/brim/runs/5365265103?check_suite_focus=true