### PR TITLE
Use tagged zed version in docs urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,12 +45,12 @@ As you can see below, there've been many changes since the last Brim GA release!
   introduction of Zed lakes causes no immediate change to your favorite Brim
   workflows, they unlock powerful new functionality that will be revealed in
   Brim going forward, including Git-like branching. See the
-  [Zed lake README](https://github.com/brimdata/zed/blob/main/docs/lake/README.md)
+  [Zed lake README](https://github.com/brimdata/zed/blob/main/docs/zed/README.md)
   for details.
 * Enhancements have been made to the Zed language to unify search and
   expression syntax, introduce new operators and functions for data
   exploration and shaping, and more! Review the
-  [Zed language docs](https://github.com/brimdata/zed/blob/main/docs/language/README.md)
+  [Zed language docs](https://github.com/brimdata/zed/blob/main/docs/zq/language.md)
   for details.
 * pcap processing is now handled by a separate, new component
   called Brimcap. Your favorite pcap workflows in Brim have not changed, but
@@ -94,7 +94,7 @@ particular we'd like to bring to your attention first.
   saved custom entries to the Query Library, you'll need to change these
   yourself. Some key changes include `:=` now being used for assignment, `==`
   for equality comparisons, and string values
-  must now be quoted in [field/value](https://github.com/brimdata/zed/tree/main/docs/language/search-syntax.md#fieldvalue-match) matches.
+  must now be quoted in [field/value](https://github.com/brimdata/zed/blob/main/docs/zq/language.md#search-expressions) matches.
 
 The exhaustive set of changes is listed below. Come talk to us on
 [Slack](https://www.brimdata.io/join-slack/) if you have additional
@@ -325,7 +325,7 @@ as usual.
 * Fix an issue where opening/closing a Log Detail window during pcap import canceled the import (#1015)
 * Sort field names in the column chooser alphabetically (#1012)
 * Add a search tool in the column chooser to find field names (#1012)
-* Fix an issue where clicking a link to [ZQL docs](https://github.com/brimdata/zed/tree/main/docs/language) opened an unusable window (#1030)
+* Fix an issue where clicking a link to [ZQL docs](https://github.com/brimdata/zed/blob/main/docs/zq/language.md) opened an unusable window (#1030)
 * Expand the [wiki docs](https://github.com/brimdata/brim/wiki/Troubleshooting#ive-clicked-to-open-a-packet-capture-in-brim-but-it-failed-to-open) for troubleshooting pcap extraction issues (#1020)
 * Fix an issue where the Packets button was not activating after scrolling down in the main events view (#1027)
 * Add the ability to connect Brim to a remote `zqd` (#1007)

--- a/docs/Filesystem-Paths.md
+++ b/docs/Filesystem-Paths.md
@@ -81,9 +81,9 @@ Brim and the bundled Zed/Brimcap tools often make use of temporary storage.
 Some examples:
 
 * The **Zed** backend may use temporary storage to "spill to disk" when
-performing [`sort`](https://github.com/brimdata/zed/tree/main/docs/language/operators.md#sort),
-[`fuse`](https://github.com/brimdata/zed/tree/main/docs/language/operators.md#fuse),
-or [aggregations](https://github.com/brimdata/zed/blob/main/docs/language/aggregate-functions.md) on data sets that cannot fit into allocated system
+performing [`sort`](https://github.com/brimdata/zed/blob/main/docs/zq/operators/sort.md),
+[`fuse`](https://github.com/brimdata/zed/tree/main/docs/zq/operators/fuse.md),
+or [aggregations](https://github.com/brimdata/zed/blob/main/docs/zq/reference.md#aggregate-functions) on data sets that cannot fit into allocated system
 memory. For this, Zed uses a directory with a name that starts with
 `zed-spill-`. The directory is automatically deleted when the operation
 finishes.

--- a/docs/Importing-CSV,-Parquet,-and-ZST.md
+++ b/docs/Importing-CSV,-Parquet,-and-ZST.md
@@ -51,7 +51,7 @@ $ /Applications/Brim.app/Contents/Resources/app.asar.unpacked/zdeps/zq -i csv te
 ```
 
 > **Note:** You may want to perform other preprocessing at this phase, such as
-> invoking [`fuse`](https://github.com/brimdata/zed/tree/main/docs/language/operators.md#fuse).
+> invoking [`fuse`](https://github.com/brimdata/zed/blob/main/docs/zq/operators/fuse.md).
 
 Now our `testxlsx_converted.zng` can be imported into Brim.
 

--- a/docs/Joining-Data.md
+++ b/docs/Joining-Data.md
@@ -39,18 +39,15 @@ ultimately be combined. The Zed [`join` docs](https://github.com/brimdata/zed/tr
 show examples with the [Zed CLI tools](https://github.com/brimdata/zed#quick-start)
 that specify these inputs as named files or pools in a [Zed Lake](https://github.com/brimdata/zed/blob/main/docs/zed/README.md).
 
-Brim release `v0.25.0` introduced initial support for storing data in Zed Lakes.
-However, due to a current limitation ([brim/1618](https://github.com/brimdata/brim/issues/1618)),
-Zed queries issued from within Brim cannot yet access multiple pools
-simultaneously. Instead such queries are currently limited to accessing the
-data from whichever pool is currently selected from the **Pools** list.
+The `join` operator is still experimental and has somewhat hard-to-use syntax,
+though this should be improved soon in a subsequent release.
+The easiest way to join data within Brim is to join two subsets of data
+from the same pool using `switch` to define the parent streams for
+input into the join.
 
-// TODO 
-Because of this limitation, the [streamed input example](https://github.com/brimdata/zed/tree/main/docs/language/operators.md#example-5---streamed-input)
-is the only one shown that can currently be executed as is from within Brim.
-If the example `fruit.ndjson` and `people.ndjson` are already present in a
+In this example, `fruit.ndjson` and `people.ndjson` are already present in a
 single pool (such as if concatenated into a single file and dragged into the
-app), we can see the same query output as shown in the doc.
+app), and we can see the same query output as shown in the doc:
 
 ![Streamed Join Example](media/Join-Streamed.png)
 

--- a/docs/Joining-Data.md
+++ b/docs/Joining-Data.md
@@ -35,9 +35,9 @@ shy!
 # Example Usage
 
 By its nature, a join operation requires two inputs that will
-ultimately be combined. The Zed [`join` docs](https://github.com/brimdata/zed/tree/main/docs/language/operators.md#join)
+ultimately be combined. The Zed [`join` docs](https://github.com/brimdata/zed/tree/main/docs/zq/operators/join.md)
 show examples with the [Zed CLI tools](https://github.com/brimdata/zed#quick-start)
-that specify these inputs as named files or pools in a [Zed Lake](https://github.com/brimdata/zed/blob/main/docs/lake/README.md).
+that specify these inputs as named files or pools in a [Zed Lake](https://github.com/brimdata/zed/blob/main/docs/zed/README.md).
 
 Brim release `v0.25.0` introduced initial support for storing data in Zed Lakes.
 However, due to a current limitation ([brim/1618](https://github.com/brimdata/brim/issues/1618)),
@@ -45,6 +45,7 @@ Zed queries issued from within Brim cannot yet access multiple pools
 simultaneously. Instead such queries are currently limited to accessing the
 data from whichever pool is currently selected from the **Pools** list.
 
+// TODO 
 Because of this limitation, the [streamed input example](https://github.com/brimdata/zed/tree/main/docs/language/operators.md#example-5---streamed-input)
 is the only one shown that can currently be executed as is from within Brim.
 If the example `fruit.ndjson` and `people.ndjson` are already present in a
@@ -63,7 +64,7 @@ you can execute all the other examples shown while accessing data from multiple
 pools. The joined results can be sent into yet another pool for further query
 from within Brim, if desired.
 
-To illustrate this, we'll walk through the [example that shows inputs from pools](https://github.com/brimdata/zed/tree/main/docs/language/operators.md#example-4---inputs-from-pools).
+To illustrate this, we'll walk through the [example that shows inputs from pools](https://github.com/brimdata/zed/blob/main/docs/zq/operators/from.md).
 To ensure API-compatibility with the Zed backend, we'll use the `zed` binary
 found in the `zdeps` directory under the Brim [application binaries](https://github.com/brimdata/brim/wiki/Filesystem-Paths#application-binaries-v0250)
 path, specifically on macOS in this case.
@@ -111,13 +112,13 @@ the split, the multiple branches are _merged_ back into a single stream before
 `join` operates on them.
 
 The first argument to `join` is a Zed
-[expression](https://github.com/brimdata/zed/blob/main/docs/language/expressions.md)
+[expression](https://github.com/brimdata/zed/blob/main/docs/zq/language.md#6-expressions)
 that references fields in the respective left/right data sources to determine
 if a pair of records from each should be joined. In this case, since the field
 we're joining on is named `uid` in both data sources, the simple expression
 `uid=uid` suffices. The next argument is a comma-separated list of field names
 or assignments, similar to how the
-[`cut`](https://github.com/brimdata/zed/tree/main/docs/language/operators.md#cut)
+[`cut`](https://github.com/brimdata/zed/tree/main/docs/zq/operators/cut.md)
 operator is used.
 
 To apply this using `zq`, we employ its `-P` option that allows us to specify
@@ -265,7 +266,7 @@ predicated on query results all falling under a single schema, since the
 headers need to reflect all fields expected in the output.
 
 Now that we're recognized this, we can make a small change to our Zed to address
-it. By adding the [`fuse`](https://github.com/brimdata/zed/tree/main/docs/language/operators.md#fuse)
+it. By adding the [`fuse`](https://github.com/brimdata/zed/tree/main/docs/zq/operators/fuse.md)
 operator, we can ensure all the data is captured under a single, unified
 schema.
 

--- a/docs/Microsoft-Windows-beta-limitations.md
+++ b/docs/Microsoft-Windows-beta-limitations.md
@@ -19,4 +19,4 @@ the "More Info" link in the SmartScreen popup and verify that the installer is
 signed by `Brim Security, Inc.`.
 
 We recommend this blog post if you'd like more info on Windows code signing:
-https://support.sectigo.com/Com_KnowledgeDetailPageFaq?Id=kA01N000000zFJx
+https://sectigo.com/faqs/detail/MS-SmartScreen-and-Application-Reputation/kA01N000000zFJx

--- a/docs/Migration-of-Spaces.md
+++ b/docs/Migration-of-Spaces.md
@@ -3,7 +3,7 @@
 Starting with GA Brim release `v0.25.0`, imported data is now stored in
 pools in a Zed Lake rather than in file-based Spaces as they were previously.
 
-The [Zed Lake README](https://github.com/brimdata/zed/blob/main/docs/lake/README.md)
+The [Zed Lake README](https://github.com/brimdata/zed/blob/main/docs/zed/README.md)
 provides a thorough overview of pools and how they work. In brief, the use of
 pools ultimately enables new functionality that was not previously available in
 Brim, including:

--- a/docs/Remote-Workspaces.md
+++ b/docs/Remote-Workspaces.md
@@ -12,7 +12,7 @@
 # Summary
 
 By default, the Brim application connects to a Lake on the system on which
-it is launched. This Lake includes [Zed Lake](https://github.com/brimdata/zed/blob/main/docs/lake/README.md)
+it is launched. This Lake includes [Zed Lake](https://github.com/brimdata/zed/blob/main/docs/zed/README.md)
 storage on the local filesystem for holding imported data. However, Brim is
 capable of accessing data stored in a Zed Lake in a remote Lake as well.
 This cookbook describes the available options and current limitations.
@@ -59,7 +59,7 @@ However, the overall app experience is powered by a distributed "backend"
 architecture that includes multiple components.
 
 One essential component is the Zed Lake which is accessed via a
-[`zed serve`](https://github.com/brimdata/zed/blob/main/docs/lake/README.md)
+[`zed serve`](https://github.com/brimdata/zed/blob/main/docs/zed/README.md)
 process that manages the storage and querying of imported data. Operations on
 the Zed Lake are invoked via a [REST API](https://en.wikipedia.org/wiki/Representational_state_transfer)
 that's utilized by a "client", such as the Brim app. The

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -88,7 +88,7 @@ and details to [brim/1490](https://github.com/brimdata/brim/issues/1490).
 In all other cases, please [open a new issue](#opening-an-issue).
 
 To begin troubleshooting this, it helps to understand the "backend" of Brim.
-One essential component is a [Zed Lake](https://github.com/brimdata/zed/blob/main/docs/lake/README.md),
+One essential component is a [Zed Lake](https://github.com/brimdata/zed/blob/main/docs/zed/README.md),
 a server-style process that manages the storage and querying of imported data.
 Operations in the pools of a Zed Lake are invoked via a [REST
 API](https://en.wikipedia.org/wiki/Representational_state_transfer) that's

--- a/src/app/core/links.test.ts
+++ b/src/app/core/links.test.ts
@@ -1,0 +1,20 @@
+import links from "./links"
+import nodeFetch from "node-fetch"
+
+const fetchStatusCode = async (link: string): Promise<[string, number]> => {
+  const resp = await nodeFetch(link)
+  return [link, resp.status]
+}
+
+test("no broken links", async () => {
+  const statusCodes = await Promise.all<[string, number]>(
+    Object.values(links).map(fetchStatusCode)
+  )
+  statusCodes.forEach(([link, code]) => {
+    try {
+      expect(code).toBe(200)
+    } catch {
+      throw `Broken link => ${link}: ${code}`
+    }
+  })
+})

--- a/src/app/core/links.ts
+++ b/src/app/core/links.ts
@@ -1,0 +1,11 @@
+import * as brimPackage from "../../../package.json"
+
+const currentZedTag = brimPackage.dependencies.zed.split("#")[1] || "main"
+
+export default {
+  ZED_DOCS_ROOT: `https://github.com/brimdata/zed/blob/${currentZedTag}/docs/zed/README.md`,
+  ZED_DOCS_LANGUAGE: `https://github.com/brimdata/zed/blob/${currentZedTag}/docs/zq/language.md`,
+  ZED_DOCS_FORMATS_ZNG: `https://github.com/brimdata/zed/blob/${currentZedTag}/docs/formats/zng.md`,
+  ZED_DOCS_FORMATS_ZSON: `https://github.com/brimdata/zed/blob/${currentZedTag}/docs/formats/zson.md`,
+  ZED_DOCS_FORMATS_ZST: `https://github.com/brimdata/zed/blob/${currentZedTag}/docs/formats/zst.md`
+}

--- a/src/app/lakes/import.tsx
+++ b/src/app/lakes/import.tsx
@@ -1,6 +1,7 @@
 import LoadFilesInput from "src/ppl/import/LoadFilesInput"
 import React from "react"
 import Link from "src/js/components/common/Link"
+import links from "../core/links"
 
 export default function TabImport() {
   return (
@@ -15,14 +16,8 @@ export default function TabImport() {
             <Link href="https://docs.zeek.org/en/current/log-formats.html#zeek-tsv-format-logs">
               Zeek TSV
             </Link>
-            ,{" "}
-            <Link href="https://github.com/brimdata/zed/blob/main/docs/formats/zng.md">
-              ZNG
-            </Link>
-            ,{" "}
-            <Link href="https://github.com/brimdata/zed/blob/main/docs/formats/zson.md">
-              ZSON
-            </Link>
+            , <Link href={links.ZED_DOCS_FORMATS_ZNG}>ZNG</Link>,{" "}
+            <Link href={links.ZED_DOCS_FORMATS_ZSON}>ZSON</Link>
           </p>
           See{" "}
           <Link href="https://github.com/brimdata/brim/wiki/Importing-CSV%2C-Parquet%2C-and-ZST">
@@ -31,10 +26,7 @@ export default function TabImport() {
           for Zed platform support for{" "}
           <Link href="https://tools.ietf.org/html/rfc4180">CSV</Link>,{" "}
           <Link href="https://parquet.apache.org/">Parquet</Link>, and{" "}
-          <Link href="https://github.com/brimdata/zed/blob/main/docs/formats/zst.md">
-            ZST
-          </Link>{" "}
-          formats.
+          <Link href={links.ZED_DOCS_FORMATS_ZST}>ZST</Link> formats.
         </footer>
       </section>
     </div>

--- a/src/app/legacy/space-migration/space-migration.tsx
+++ b/src/app/legacy/space-migration/space-migration.tsx
@@ -20,6 +20,7 @@ import {AppDispatch} from "src/js/state/types"
 import styled from "styled-components"
 import ToolbarButton from "../../toolbar/button"
 import SpaceMigrator from "./space-migrator"
+import links from "src/app/core/links"
 
 let src
 let dst
@@ -130,11 +131,7 @@ function Modal({onClose}) {
         <Link href="https://github.com/brimdata/brim/wiki/Migration-of-Spaces">
           migration tool
         </Link>{" "}
-        and the{" "}
-        <Link href="https://github.com/brimdata/zed/blob/main/docs/lake/README.md">
-          Zed Lake design
-        </Link>
-        .
+        and the <Link href={links.ZED_DOCS_ROOT}>Zed Lake design</Link>.
       </p>
       <Footer>
         <ButtonGroup>

--- a/src/js/components/SearchBar/MenuAction.tsx
+++ b/src/js/components/SearchBar/MenuAction.tsx
@@ -8,6 +8,7 @@ import open from "../../lib/open"
 import Modal from "../../state/Modal"
 import PopMenuPointy from "../PopMenu/PopMenuPointy"
 import InputAction from "./InputAction"
+import links from "src/app/core/links"
 
 export default function MenuAction() {
   const dispatch = useDispatch()
@@ -21,8 +22,7 @@ export default function MenuAction() {
     {label: "Copy for zq", click: () => dispatch(Modal.show("zq"))},
     {
       label: "Syntax docs",
-      click: () =>
-        open("https://github.com/brimdata/zed/tree/main/docs/language")
+      click: () => open(links.ZED_DOCS_LANGUAGE)
     },
     {
       label: "Kill search",

--- a/src/js/electron/menu/appMenu.ts
+++ b/src/js/electron/menu/appMenu.ts
@@ -7,6 +7,7 @@ import electronIsDev from "../isDev"
 import {encodeSessionState} from "../tron/session-state"
 import {BrimMain} from "../brim"
 import env from "src/app/core/env"
+import links from "src/app/core/links"
 
 export default function(
   send: Function,
@@ -203,9 +204,7 @@ export default function(
       {
         label: "Zed Syntax Docs",
         click() {
-          shell.openExternal(
-            "https://github.com/brimdata/zed/tree/main/docs/language"
-          )
+          shell.openExternal(links.ZED_DOCS_LANGUAGE)
         }
       },
       {


### PR DESCRIPTION
fixes #2209 

This also updates some docs paths which had changed. If those paths change again we will continue to need to make those changes explicitly. But now the docs will correspond to the appropriate version of zed.

NOTE: It may be simpler to wait until the zed docs have settled more before merging this. I'll leave the PR up since that may happen very soon and I can tie up the handful of remaining broken links at that time.