### PR TITLE
Don't assume there is a span

### DIFF
--- a/src/js/components/ExportModal.tsx
+++ b/src/js/components/ExportModal.tsx
@@ -68,11 +68,15 @@ const ExportModal = ({onClose}) => {
     const {canceled, filePath} = await showDialog(format)
     if (canceled) return
 
-    toast.promise(dispatch(exportResults(filePath, format as ResponseFormat)), {
-      loading: "Exporting...",
-      success: "Export Complete",
-      error: "Error Exporting"
-    })
+    toast
+      .promise(dispatch(exportResults(filePath, format as ResponseFormat)), {
+        loading: "Exporting...",
+        success: "Export Complete",
+        error: "Error Exporting"
+      })
+      .catch((e) => {
+        console.error(e)
+      })
 
     onClose()
   }

--- a/src/js/flows/exportResults.ts
+++ b/src/js/flows/exportResults.ts
@@ -42,9 +42,14 @@ export default (
   const columns = Columns.getCurrentTableColumns(getState())
   const program = prepareProgram(format, baseProgram, columns)
 
-  const [from, to] = Tab.getSpan(getState())
-    .map(brim.time)
-    .map((t) => t.toDate())
+  let from = null
+  let to = null
+  const span = Tab.getSpan(getState())
+  if (span) {
+    const dates = span.map(brim.time).map((t) => t.toDate())
+    from = dates[0]
+    to = dates[1]
+  }
 
   dispatch(SystemTest.hook("export-start"))
   const query = annotateQuery(program, {from, to, poolId})


### PR DESCRIPTION
Fixes #2252  where an export always fails on a pool with no time span key.