### PR TITLE
Inspector fix for type containers

### DIFF
--- a/src/app/features/inspector/views/container-view.ts
+++ b/src/app/features/inspector/views/container-view.ts
@@ -24,26 +24,37 @@ export abstract class ContainerView<T extends zed.Any = zed.Any> extends View<
   inspect() {
     const {ctx} = this.args
 
-    const line = []
-    if (this.args.key) {
-      line.push(key(this))
-    }
-    line.push(container.icon(this))
-    line.push(container.name(this))
-    line.push(space())
-    line.push(container.open(this))
-
     if (this.isExpanded()) {
-      ctx.push(container.anchor(this, line))
+      ctx.push(container.anchor(this, opening(this)))
       ctx.nest()
       for (let view of this.iterate()) view.inspect()
       ctx.unnest()
-      ctx.push(container.close(this))
+      ctx.push(closing(this))
     } else {
+      let line = opening(this)
       for (let view of this.iterate()) line.push(field(view))
-      line.push(container.close(this))
-      if (zed.isTypeAlias(this.args.type)) line.push(typename(this))
+      line = line.concat(closing(this))
       ctx.push(container.anchor(this, line))
     }
   }
+}
+
+function closing(view: ContainerView) {
+  let nodes = []
+  nodes.push(container.close(view))
+  if (zed.isTypeAlias(view.args.type)) nodes.push(typename(view))
+  if (!view.args.last) nodes.push(",")
+  return nodes
+}
+
+function opening(view: ContainerView) {
+  const nodes = []
+  if (view.args.key) {
+    nodes.push(key(view))
+  }
+  nodes.push(container.icon(view))
+  nodes.push(container.name(view))
+  nodes.push(space())
+  nodes.push(container.open(view))
+  return nodes
 }

--- a/src/app/features/inspector/views/create.ts
+++ b/src/app/features/inspector/views/create.ts
@@ -38,6 +38,10 @@ export function createView(args: InspectArgs) {
 
   // * type record
   if (args.value instanceof zed.TypeRecord) return new TypeRecordView(args)
+
+  if (args.value instanceof zed.TypeAlias)
+    return createView({...args, value: args.value.type, type: args.value})
+
   // * type union
   // * type alias
   // * type error


### PR DESCRIPTION
- Add functions for opening and closing a value
- Handle type alias values

## Before
<img width="873" alt="image" src="https://user-images.githubusercontent.com/3460638/157329904-6ab5e0af-c8f5-44a4-98e1-3148b104501e.png">


## After
<img width="791" alt="image" src="https://user-images.githubusercontent.com/3460638/157329811-1a590e00-7613-4a59-9d33-c6cc0bcb05e1.png">
