### PR TITLE
Query-flow ctx menu fix

### DIFF
--- a/src/app/query-home/flows/submit-search.ts
+++ b/src/app/query-home/flows/submit-search.ts
@@ -11,7 +11,6 @@ const submitSearch = (
   _ts: Date = new Date()
 ) => async (dispatch, getState) => {
   dispatch(Notice.dismiss())
-  // TODO: Mason - set filter pins here too?
   const input = SearchBar.getSearchBarInputValue(getState())
   const query = Current.getQuery(getState())
   query.value = input

--- a/src/js/electron/tron/window-manager.ts
+++ b/src/js/electron/tron/window-manager.ts
@@ -127,6 +127,7 @@ export class WindowManager {
 
   async openSearchTab(searchParams: NewTabSearchParams) {
     let isNewWin = true
+    // TODO: when we enable the "query-flow" feature flag this will no longer apply
     const existingWin = this.getAll()
       .sort((a, b) => b.lastFocused - a.lastFocused)
       .find((w) => w.name === "search")

--- a/src/js/flows/openNewSearchWindow.ts
+++ b/src/js/flows/openNewSearchWindow.ts
@@ -2,8 +2,31 @@ import ipc from "../electron/ipc"
 import invoke from "../electron/ipc/invoke"
 import Search from "../state/Search"
 import {Thunk} from "../state/types"
+import {featureIsEnabled} from "src/app/core/feature-flag"
+import {newQuery} from "src/app/query-home/flows/new-query"
+import Current from "../state/Current"
+import SearchBar from "../state/SearchBar"
+import {lakeQueryPath} from "src/app/router/utils/paths"
 
-export const openNewSearchTab = (): Thunk => (dispatch, getState) => {
+export const legacyOpenNewSearchTab = (): Thunk => (dispatch, getState) => {
   const href = Search.createHref(getState())
   invoke(ipc.windows.newSearchTab({href}))
+}
+
+export const openNewSearchTab = (): Thunk => {
+  if (!featureIsEnabled("query-flow")) return legacyOpenNewSearchTab()
+  return (dispatch, getState) => {
+    const state = getState()
+    const lakeId = Current.getLakeId(state)
+    const pool = Current.getQueryPool(state)
+    const {current} = SearchBar.getSearchBar(state)
+    const query = dispatch(
+      newQuery({value: current, pins: {from: pool.id, filters: []}})
+    )
+    invoke(
+      ipc.windows.newSearchTab({
+        href: lakeQueryPath(query.id, lakeId, {isDraft: true})
+      })
+    )
+  }
 }

--- a/src/js/initializers/initNewSearchTab.ts
+++ b/src/js/initializers/initNewSearchTab.ts
@@ -2,6 +2,8 @@ import tabHistory from "src/app/router/tab-history"
 import {NewTabSearchParams} from "../electron/ipc/windows/messages"
 import Tabs from "../state/Tabs"
 import {Store} from "../state/types"
+import {featureIsEnabled} from "../../app/core/feature-flag"
+import submitSearch from "../../app/query-home/flows/submit-search"
 
 export default function(store: Store, params: NewTabSearchParams) {
   const {href, isNewWin} = params
@@ -10,4 +12,5 @@ export default function(store: Store, params: NewTabSearchParams) {
   } else {
     store.dispatch(tabHistory.replace(href))
   }
+  if (featureIsEnabled("query-flow")) store.dispatch(submitSearch())
 }


### PR DESCRIPTION
fixes *most of #2242 

Most of the ctx menu items were already fixed with some of the more recent PRs, but the detail ctx menu had to be re-worked to open new draft queries instead of using the legacy search page flow.

*Additionally, there are still three ctx menu items ("Use as 'start' time", "Use as 'end' time", and "View in full context") which remain broken. All three relate to pins and the currently-non-existent span, and both of those topics are themselves being re-worked in separate tickets. Instead of hacking a fix for this now with our current string pins, I'd like to handle these last fixes as a part of how we [re-work the pins structure](https://github.com/brimdata/brim/issues/2217) in queries (which refactors query pins to be stored as typed pin objects) so that the values properly get set as part of a "range"-type pin.