### PR TITLE
Fix End of Results Message

### DIFF
--- a/src/js/components/SearchResults/ResultsTable.tsx
+++ b/src/js/components/SearchResults/ResultsTable.tsx
@@ -103,7 +103,6 @@ export default function ResultsTable(props: Props) {
       return (
         <p className="end-message" style={endMessage(dimens)}>
           {getEndMessage(program, logs.length)}
-          message
         </p>
       )
   }


### PR DESCRIPTION
<img width="277" alt="Screen Shot 2022-03-10 at 11 25 52 AM" src="https://user-images.githubusercontent.com/3460638/157739586-7556819e-44d1-4007-abb4-8c3af5a7ec62.png">

It previously looked like that.

fixes #2266 