### PR TITLE
Add a json export format

### DIFF
--- a/src/js/components/ExportModal.tsx
+++ b/src/js/components/ExportModal.tsx
@@ -102,6 +102,10 @@ const ExportModal = ({onClose}) => {
             <label htmlFor="zng">zng</label>
           </RadioItem>
           <RadioItem>
+            <input type="radio" id="json" value="json" name="format" />
+            <label htmlFor="json">json</label>
+          </RadioItem>
+          <RadioItem>
             <input type="radio" id="ndjson" value="ndjson" name="format" />
             <label htmlFor="ndjson">ndjson</label>
           </RadioItem>


### PR DESCRIPTION
<img width="632" alt="image" src="https://user-images.githubusercontent.com/3460638/157741062-09ac8696-d287-442e-9bd1-50d4430d434f.png">

When this option is selected, you get all the records in a big json array.

<img width="155" alt="image" src="https://user-images.githubusercontent.com/3460638/157741113-865c0cba-a1ef-490e-af7e-a8def1372ad2.png">

fixes #2257 
