### PR TITLE
Pin setup-gcloud to v0 instead of master

### DIFF
--- a/.github/workflows/linux-release-candidate.yml
+++ b/.github/workflows/linux-release-candidate.yml
@@ -33,7 +33,7 @@ jobs:
       - name: build packages
         run: yarn electron-builder --linux
       - name: Setup Google Cloud Platform
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: "290.0.1"
           project_id: ${{ secrets.GCLOUD_PROJECT_ID }}

--- a/.github/workflows/linux-release-promotion.yml
+++ b/.github/workflows/linux-release-promotion.yml
@@ -13,7 +13,7 @@ jobs:
       run: echo "##[set-output name=tag;]$(echo ${GITHUB_REF#refs/tags/})"
       id: extract_tag
     - name: Setup Google Cloud Platform
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         version: '290.0.1'
         project_id: ${{ secrets.GCLOUD_PROJECT_ID }}

--- a/.github/workflows/macos-release-candidate.yml
+++ b/.github/workflows/macos-release-candidate.yml
@@ -69,7 +69,7 @@ jobs:
       - name: run gatekeeper assessment on notarized package
         run: spctl --assess --type execute --verbose --ignore-cache --no-cache dist/installers/mac/Brim.app
       - name: Setup Google Cloud Platform
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: "290.0.1"
           project_id: ${{ secrets.GCLOUD_PROJECT_ID }}

--- a/.github/workflows/macos-release-promotion.yml
+++ b/.github/workflows/macos-release-promotion.yml
@@ -13,7 +13,7 @@ jobs:
       run: echo "##[set-output name=tag;]$(echo ${GITHUB_REF#refs/tags/})"
       id: extract_tag
     - name: Setup Google Cloud Platform
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         version: '290.0.1'
         project_id: ${{ secrets.GCLOUD_PROJECT_ID }}

--- a/.github/workflows/win-release-candidate.yml
+++ b/.github/workflows/win-release-candidate.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           python-version: 3.7
       - name: Setup Google Cloud Platform
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         env:
           CLOUDSDK_PYTHON: ${{ env.pythonLocation }}\python.exe
         with:

--- a/.github/workflows/win-release-promotion.yml
+++ b/.github/workflows/win-release-promotion.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         python-version: 3.7
     - name: Setup Google Cloud Platform
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       env:
         CLOUDSDK_PYTHON: ${{ env.pythonLocation }}\python.exe
       with:


### PR DESCRIPTION
setup-gcloud will be updating the branch name from master to main in
a future release. Even though GitHub will establish redirects, this
will break any GitHub Actions workflows that pin to master. This PR
updates your GitHub Actions workflows to pin to v0, which is the
recommended best practice.