### PR TITLE
Only hide menu bar on mac

### DIFF
--- a/src/js/electron/window/SearchWindow.ts
+++ b/src/js/electron/window/SearchWindow.ts
@@ -3,6 +3,7 @@ import randomHash from "../../brim/randomHash"
 import {BrimWindow, WindowName} from "../tron/window-manager"
 import {Dimens, getWindowDimens} from "./dimens"
 import {enable} from "@electron/remote/main"
+import env from "src/app/core/env"
 
 const DEFAULT_DIMENS = {
   x: undefined,
@@ -34,7 +35,7 @@ export class SearchWindow implements BrimWindow {
     this.touchLastFocused()
     this.ref = new BrowserWindow({
       ...getWindowDimens(dimens, DEFAULT_DIMENS, screens),
-      titleBarStyle: "hidden",
+      titleBarStyle: env.isMac ? "hidden" : undefined,
       resizable: true,
       minWidth: 480,
       minHeight: 100,


### PR DESCRIPTION
Fixes #2287 

This is likely because of this diff in our dependencies. Although I coundn't find a mention of it in the electron breaking changes page: https://www.electronjs.org/docs/latest/breaking-changes#removed-browserwindowconstructoroptions-inheriting-from-parent-windows

```diff
-    "electron": "^11.5.0",
+    "electron": "^14.2.2",
```

What it looks like now:

Windows:
<img width="1304" alt="Screen Shot 2022-03-24 at 11 50 14 AM" src="https://user-images.githubusercontent.com/3460638/159989398-4ef3b11d-0036-401c-9320-dd006fe5d7f7.png">

Mac:
<img width="1154" alt="Screen Shot 2022-03-24 at 11 50 27 AM" src="https://user-images.githubusercontent.com/3460638/159989406-81b82215-6c8a-46e2-8dd1-89bfe8371d56.png">

