### PR TITLE
Inspector Strings with New Lines

### DIFF
--- a/src/app/features/inspector/list.styled.tsx
+++ b/src/app/features/inspector/list.styled.tsx
@@ -21,7 +21,6 @@ export const List = styled(FixedSizeList)`
     display: inline-flex;
     white-space: pre;
     align-items: center;
-    margin-left: -3px;
   }
 
   i {

--- a/src/app/features/inspector/list.styled.tsx
+++ b/src/app/features/inspector/list.styled.tsx
@@ -24,9 +24,6 @@ export const List = styled(FixedSizeList)`
     margin-left: -3px;
   }
 
-  span {
-  }
-
   i {
     display: inline-flex;
     align-items: center;

--- a/src/app/features/inspector/views/string-view.ts
+++ b/src/app/features/inspector/views/string-view.ts
@@ -3,6 +3,6 @@ import {zed} from "@brimdata/zealot"
 
 export class StringView extends View<zed.String> {
   render() {
-    return `"${this.args.value.toString()}"`
+    return `"${this.args.value.toString().replaceAll("\n", "\\n")}"`
   }
 }


### PR DESCRIPTION
Escape new lines in the inspector.

Fixes #2291 

<img width="1126" alt="Screen Shot 2022-03-25 at 3 16 56 PM" src="https://user-images.githubusercontent.com/3460638/160209429-43fbc428-7042-4627-bb81-2b3b14d0ff75.png">
