### PR TITLE
Fix and test release notes style

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Brim Desktop App",
   "repository": "https://github.com/brimdata/brim",
   "license": "BSD-3-Clause",
-  "version": "0.29.0",
+  "version": "0.29.0-rc",
   "main": "dist/js/electron/main.js",
   "author": "Brim Security, Inc.",
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Brim Desktop App",
   "repository": "https://github.com/brimdata/brim",
   "license": "BSD-3-Clause",
-  "version": "0.29.0-rc",
+  "version": "0.29.0",
   "main": "dist/js/electron/main.js",
   "author": "Brim Security, Inc.",
   "workspaces": [

--- a/src/app/release-notes/release-notes.tsx
+++ b/src/app/release-notes/release-notes.tsx
@@ -19,6 +19,20 @@ const BG = styled.div`
     border: none;
     border-top: 1px solid var(--cloudy);
   }
+
+  * {
+    margin: 0.5em 0;
+  }
+
+  li {
+    margin: 0.1em 0;
+  }
+
+  img {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
 `
 
 export default function ReleaseNotes() {


### PR DESCRIPTION
We've never used images in our release notes until today, so the styles need to be changed a bit. I also removed all margin from all elements, but in this case, we needed to add it back.

## Before

<img width="1248" alt="Screen Shot 2022-03-30 at 2 00 10 PM" src="https://user-images.githubusercontent.com/3460638/160930423-d5b52e61-05a3-40f3-8101-5032e924a259.png">

## After
<img width="1248" alt="Screen Shot 2022-03-30 at 2 01 58 PM" src="https://user-images.githubusercontent.com/3460638/160930437-0a3ce2a5-1a48-4c5f-a1a1-a39d9b602381.png">
