### PR TITLE
fix query sidebar context menus

### DIFF
--- a/src/app/features/sidebar/flows/get-query-item-ctx-menu.ts
+++ b/src/app/features/sidebar/flows/get-query-item-ctx-menu.ts
@@ -1,0 +1,124 @@
+import {isRemoteLib, setRemoteQueries} from "./remote-queries"
+import {isBrimLib} from "../../../../js/state/Queries/flows"
+import Tabs from "../../../../js/state/Tabs"
+import {lakeQueryPath} from "../../../router/utils/paths"
+import {submitSearch} from "../../../../js/flows/submitSearch/mod"
+import lib from "../../../../js/lib"
+import toast from "react-hot-toast"
+import {ipcRenderer, MenuItemConstructorOptions} from "electron"
+import exportQueryLib from "../../../../js/flows/exportQueryLib"
+import * as remote from "@electron/remote"
+import {Query} from "../../../../js/state/Queries/types"
+import Queries from "../../../../js/state/Queries"
+
+const getQueryItemCtxMenu = ({data, tree, handlers, lakeId}) => (
+  dispatch,
+  getState,
+  {api}
+) => {
+  const {value, id} = data
+  const isGroup = "items" in data
+  const hasMultiSelected =
+    tree.getSelectedIds().length > 1 &&
+    !!tree.getSelectedIds().find((id) => id === data.id)
+  const selected = hasMultiSelected ? tree.getSelectedIds() : [id]
+  const isRemoteItem = dispatch(isRemoteLib([id]))
+  const hasBrimItemSelected = dispatch(isBrimLib(selected))
+
+  const runQuery = () => {
+    dispatch(Tabs.activateByUrl(lakeQueryPath(id, lakeId)))
+    dispatch(submitSearch())
+  }
+
+  const handleDelete = () => {
+    const selected = Array.from(new Set([...tree.getSelectedIds(), data.id]))
+    return remote.dialog
+      .showMessageBox({
+        type: "warning",
+        title: "Confirm Delete Query Window",
+        message: `Are you sure you want to delete the ${
+          hasMultiSelected ? selected.length : ""
+        } selected item${hasMultiSelected ? "s" : ""}?`,
+        buttons: ["OK", "Cancel"]
+      })
+      .then(({response}) => {
+        if (response === 0) {
+          if (isRemoteItem) {
+            const remoteQueries = selected.map<Query>((id) => ({
+              id,
+              value: "",
+              name: "",
+              pins: {from: "", filters: []}
+            }))
+            dispatch(setRemoteQueries(remoteQueries, true))
+            return
+          }
+
+          dispatch(Queries.removeItems(selected))
+        }
+      })
+  }
+
+  if (hasMultiSelected)
+    return [
+      {
+        label: "Delete Selected",
+        click: handleDelete
+      }
+    ]
+
+  return [
+    {
+      label: "Run Query",
+      visible: !isGroup,
+      click: () => runQuery()
+    },
+    {
+      label: "Copy Query",
+      visible: !isGroup,
+      click: () => {
+        lib.doc.copyToClipboard(value)
+        toast("Query copied to clipboard")
+      }
+    },
+    {
+      label: "Export Folder as JSON",
+      visible: isGroup,
+      click: async () => {
+        const {canceled, filePath} = await ipcRenderer.invoke(
+          "windows:showSaveDialog",
+          {
+            title: `Save Queries Folder as JSON`,
+            buttonLabel: "Export",
+            defaultPath: `${data.name}.json`,
+            properties: ["createDirectory"],
+            showsTagField: false
+          }
+        )
+        if (canceled) return
+        toast.promise(
+          dispatch(exportQueryLib(filePath, api.exportQueries(id))),
+          {
+            loading: "Exporting Queries...",
+            success: "Export Complete",
+            error: "Error Exporting Queries"
+          }
+        )
+      }
+    },
+    {type: "separator"},
+    {
+      label: "Rename",
+      enabled: !hasBrimItemSelected,
+      click: () => handlers.edit()
+    },
+    {type: "separator"},
+    {
+      label: "Delete",
+      enabled: !hasBrimItemSelected,
+      click: handleDelete
+    }
+  ] as MenuItemConstructorOptions[]
+}
+
+export default getQueryItemCtxMenu

--- a/src/app/features/sidebar/hooks/index.ts
+++ b/src/app/features/sidebar/hooks/index.ts
@@ -4,23 +4,9 @@ import {NativeTypes} from "react-dnd-html5-backend"
 import {DragItem, DragProps} from "src/app/features/import/use-import-on-drop"
 import {useBrimApi} from "src/app/core/context"
 import {useMemo} from "react"
-import {useDispatch, useSelector} from "react-redux"
+import {useSelector} from "react-redux"
 import brim from "src/js/brim"
 import Investigation from "src/js/state/Investigation"
-import {AppDispatch} from "src/js/state/types"
-import Current from "src/js/state/Current"
-import {isRemoteLib, setRemoteQueries} from "../flows/remote-queries"
-import {isBrimLib} from "src/js/state/Queries/flows"
-import SearchBar from "src/js/state/SearchBar"
-import {submitSearch} from "src/js/flows/submitSearch/mod"
-import lib from "src/js/lib"
-import toast from "react-hot-toast"
-import {ipcRenderer, MenuItemConstructorOptions} from "electron"
-import exportQueryLib from "src/js/flows/exportQueryLib"
-import Modal from "src/js/state/Modal"
-import * as remote from "@electron/remote"
-import {Query} from "src/js/state/Queries/types"
-import Queries from "src/js/state/Queries"
 
 export const useSectionTreeDefaults = () => {
   const {ref, width = 1, height = 1} = useResizeObserver<HTMLDivElement>()
@@ -65,118 +51,4 @@ export const useSearchHistory = () => {
       brim.time(a.ts).toDate() < brim.time(b.ts).toDate() ? 1 : -1
     )
   }, [historyEntries])
-}
-
-export const useQueryItemMenu = (data, tree, handlers) => {
-  const dispatch = useDispatch<AppDispatch>()
-  const currentPool = useSelector(Current.getPool)
-  const api = useBrimApi()
-  const {value, id} = data
-  const isGroup = "items" in data
-  const selected = Array.from(new Set([...tree.getSelectedIds(), data.id]))
-  const hasMultiSelected = selected.length > 1
-
-  const isRemoteItem = dispatch(isRemoteLib([id]))
-  const isBrimItem = dispatch(isBrimLib([id]))
-  const hasBrimItemSelected = dispatch(isBrimLib(selected))
-
-  const runQuery = (value) => {
-    dispatch(SearchBar.clearSearchBar())
-    dispatch(SearchBar.changeSearchBarInput(value))
-    dispatch(submitSearch())
-  }
-
-  return [
-    {
-      label: "Run Query",
-      enabled: !hasMultiSelected && !!currentPool,
-      visible: !isGroup,
-      click: () => runQuery(value)
-    },
-    {
-      label: "Copy Query",
-      enabled: !hasMultiSelected,
-      visible: !isGroup,
-      click: () => {
-        lib.doc.copyToClipboard(value)
-        toast("Query copied to clipboard")
-      }
-    },
-    {
-      label: "Export Folder as JSON",
-      visible: isGroup && !hasMultiSelected,
-      click: async () => {
-        const {canceled, filePath} = await ipcRenderer.invoke(
-          "windows:showSaveDialog",
-          {
-            title: `Save Queries Folder as JSON`,
-            buttonLabel: "Export",
-            defaultPath: `${data.name}.json`,
-            properties: ["createDirectory"],
-            showsTagField: false
-          }
-        )
-        if (canceled) return
-        toast.promise(
-          dispatch(exportQueryLib(filePath, api.exportQueries(id))),
-          {
-            loading: "Exporting Queries...",
-            success: "Export Complete",
-            error: "Error Exporting Queries"
-          }
-        )
-      }
-    },
-    {type: "separator"},
-    {
-      label: "Rename",
-      enabled: !isBrimItem,
-      click: () => handlers.edit()
-    },
-    {
-      label: "Edit",
-      enabled: !hasMultiSelected && !isBrimItem,
-      visible: !isGroup,
-      click: () => {
-        const modalArgs = {query: data, isRemote: false}
-        if (isRemoteItem) modalArgs.isRemote = true
-        dispatch(Modal.show("edit-query", modalArgs))
-      }
-    },
-    {type: "separator"},
-    {
-      label: hasMultiSelected ? "Delete Selected" : "Delete",
-      enabled: !hasBrimItemSelected,
-      click: () => {
-        const selected = Array.from(
-          new Set([...tree.getSelectedIds(), data.id])
-        )
-        return remote.dialog
-          .showMessageBox({
-            type: "warning",
-            title: "Confirm Delete Query Window",
-            message: `Are you sure you want to delete the ${
-              selected.length > 1 ? selected.length : ""
-            } selected item${selected.length > 1 ? "s" : ""}?`,
-            buttons: ["OK", "Cancel"]
-          })
-          .then(({response}) => {
-            if (response === 0) {
-              if (isRemoteItem) {
-                const remoteQueries = selected.map<Query>((id) => ({
-                  id,
-                  value: "",
-                  name: "",
-                  pins: {from: "", filters: []}
-                }))
-                dispatch(setRemoteQueries(remoteQueries, true))
-                return
-              }
-
-              dispatch(Queries.removeItems(selected))
-            }
-          })
-      }
-    }
-  ] as MenuItemConstructorOptions[]
 }

--- a/src/app/features/sidebar/queries-section/query-item.tsx
+++ b/src/app/features/sidebar/queries-section/query-item.tsx
@@ -3,13 +3,13 @@ import styled from "styled-components"
 import Current from "src/js/state/Current"
 import {showContextMenu} from "src/js/lib/System"
 import Icon from "src/app/core/icon-temp"
-import {useQueryItemMenu} from "../hooks"
 import {lakeQueryPath} from "src/app/router/utils/paths"
 import {useSelector} from "react-redux"
 import {useDispatch} from "src/app/core/state"
 import Tabs from "src/js/state/Tabs"
 import {Item} from "../item"
 import {NodeRenderer} from "react-arborist"
+import getQueryItemCtxMenu from "../flows/get-query-item-ctx-menu"
 
 const FolderIcon = styled(Icon).attrs({name: "folder"})``
 const QueryIcon = styled(Icon).attrs({name: "doc-plain"})``
@@ -24,9 +24,8 @@ const QueryItem: NodeRenderer<any> = ({
 }) => {
   const {id} = data
   const isGroup = "items" in data
-  const ctxMenu = useQueryItemMenu(data, tree, handlers)
-  const dispatch = useDispatch()
   const lakeId = useSelector(Current.getLakeId)
+  const dispatch = useDispatch()
   const itemIcon = isGroup ? <FolderIcon /> : <QueryIcon />
 
   const onGroupClick = (e) => {
@@ -50,7 +49,11 @@ const QueryItem: NodeRenderer<any> = ({
       styles={styles}
       onClick={isGroup ? onGroupClick : onItemClick}
       isFolder={isGroup}
-      onContextMenu={() => showContextMenu(ctxMenu)}
+      onContextMenu={() => {
+        showContextMenu(
+          dispatch(getQueryItemCtxMenu({data, tree, handlers, lakeId}))
+        )
+      }}
       onSubmit={handlers.submit}
     />
   )


### PR DESCRIPTION
fixes #2242 

In addition to fixing the run/copy enabling and execution, this also includes a behavior change: moving forward, when you right click on an item the context menu's actions will refer to just that one item. The delete action (and in the future, any other action which can be applied to multiple items) will act solely on the right clicked item unless that item is "selected" (highlighted in blue) along with at least one other item. In that case, all selected/highlighted items will participate in the operation.

right click on an item that is NOT part of selection
<img width="246" alt="image" src="https://user-images.githubusercontent.com/14865533/161787346-ad720ab8-b36b-41ec-bc4c-c128137ec239.png">

right click on an item that IS part of a multi selection
<img width="285" alt="image" src="https://user-images.githubusercontent.com/14865533/161787375-4734cf02-3677-43b9-a847-d874c7c001d0.png">

right click on an item that is the only item selected
<img width="243" alt="image" src="https://user-images.githubusercontent.com/14865533/161787808-2132f8f0-f09a-4c91-b122-d83720c4a7ad.png">

renaming, running, copying don't care about selection and just operate on whatever you clicked on
<img width="247" alt="image" src="https://user-images.githubusercontent.com/14865533/161787424-490cd163-6a16-401d-9bf4-bdcdd1138615.png">
 