### PR TITLE
Fix broken links in Brim docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,12 +87,12 @@ As you can see below, there've been many changes since the last Brim GA release!
   introduction of Zed lakes causes no immediate change to your favorite Brim
   workflows, they unlock powerful new functionality that will be revealed in
   Brim going forward, including Git-like branching. See the
-  [Zed lake README](https://github.com/brimdata/zed/blob/main/docs/zed/README.md)
+  [Zed lake README](https://github.com/brimdata/zed/blob/v0.30.0/docs/lake/README.md)
   for details.
 * Enhancements have been made to the Zed language to unify search and
   expression syntax, introduce new operators and functions for data
   exploration and shaping, and more! Review the
-  [Zed language docs](https://github.com/brimdata/zed/blob/main/docs/zq/language.md)
+  [Zed language docs](https://github.com/brimdata/zed/blob/v0.30.0/docs/language/README.md)
   for details.
 * pcap processing is now handled by a separate, new component
   called Brimcap. Your favorite pcap workflows in Brim have not changed, but
@@ -134,7 +134,7 @@ particular we'd like to bring to your attention first.
   saved custom entries to the Query Library, you'll need to change these
   yourself. Some key changes include `:=` now being used for assignment, `==`
   for equality comparisons, and string values
-  must now be quoted in [field/value](https://github.com/brimdata/zed/blob/main/docs/zq/language.md#search-expressions) matches.
+  must now be quoted in [field/value](https://github.com/brimdata/zed/blob/v0.30.0/docs/language/search-syntax/README.md) matches.
 
 The exhaustive set of changes is listed below. Come talk to us on
 [Slack](https://www.brimdata.io/join-slack/) if you have additional
@@ -157,7 +157,7 @@ questions.
 * Adjust the guidance on the **Import Files** page and add a [wiki article](https://github.com/brimdata/brim/wiki/Importing-CSV%2C-Parquet%2C-and-ZST) with more detail (#1548, #1625, #1626, #1635)
 * Brim is now packaged using [electron-builder](https://www.electron.build/), which streamlines installation and auto-update (#1508)
 * Fix an issue where importing an NDJSON record containing an empty object caused a "Cannot read property 'map' of null" pop-up error (#1581)
-* Remove the legacy approach for applying Zed types to NDJSON input, as this is now done via Zed shapers ([docs](https://github.com/brimdata/zed/blob/main/zeek/Shaping-Zeek-NDJSON.md)) (#1580, #1582)
+* Remove the legacy approach for applying Zed types to NDJSON input, as this is now done via Zed shapers ([docs](https://github.com/brimdata/zed/blob/v0.30.0/zeek/Shaping-Zeek-NDJSON.md)) (#1580, #1582)
 * Brim now invokes [Brimcap](https://github.com/brimdata/brimcap) to generate logs from imported pcaps and to extract flows when **Packets** is clicked, rather than relying on `zqd` (#1584, #1573, #1591, #1590, #1598, #1614, #1617, #1637, #1651, #1664, #1668, #1705, #1731, #1735, #1748, #1747, #1781, #1789, #1810, #1816, #1829, #1833)
 * Use pools in Zed lakes for backend storage rather than Spaces (#1589, #1601, #1633, #1676, #1696, #1710, #1712, #1772, #1822)
 * Implement the full Zed type system in JavaScript, which allows for improved presentation of array and set types, and also fixes an issue where named types were rejected at import (#1603, #1623, #1663, #1732)
@@ -365,7 +365,7 @@ as usual.
 * Fix an issue where opening/closing a Log Detail window during pcap import canceled the import (#1015)
 * Sort field names in the column chooser alphabetically (#1012)
 * Add a search tool in the column chooser to find field names (#1012)
-* Fix an issue where clicking a link to [ZQL docs](https://github.com/brimdata/zed/blob/main/docs/zq/language.md) opened an unusable window (#1030)
+* Fix an issue where clicking a link to [ZQL docs](https://github.com/brimdata/zed/blob/v0.20.0/zql/docs/README.md) opened an unusable window (#1030)
 * Expand the [wiki docs](https://github.com/brimdata/brim/wiki/Troubleshooting#ive-clicked-to-open-a-packet-capture-in-brim-but-it-failed-to-open) for troubleshooting pcap extraction issues (#1020)
 * Fix an issue where the Packets button was not activating after scrolling down in the main events view (#1027)
 * Add the ability to connect Brim to a remote `zqd` (#1007)

--- a/docs/Filesystem-Paths.md
+++ b/docs/Filesystem-Paths.md
@@ -81,9 +81,9 @@ Brim and the bundled Zed/Brimcap tools often make use of temporary storage.
 Some examples:
 
 * The **Zed** backend may use temporary storage to "spill to disk" when
-performing [`sort`](https://github.com/brimdata/zed/blob/main/docs/zq/operators/sort.md),
-[`fuse`](https://github.com/brimdata/zed/tree/main/docs/zq/operators/fuse.md),
-or [aggregations](https://github.com/brimdata/zed/blob/main/docs/zq/reference.md#aggregate-functions) on data sets that cannot fit into allocated system
+performing [`sort`](https://zed.brimdata.io/docs/language/operators/sort/),
+[`fuse`](https://zed.brimdata.io/docs/language/operators/fuse/),
+or [aggregations](https://zed.brimdata.io/docs/language/aggregates/) on data sets that cannot fit into allocated system
 memory. For this, Zed uses a directory with a name that starts with
 `zed-spill-`. The directory is automatically deleted when the operation
 finishes.

--- a/docs/Joining-Data.md
+++ b/docs/Joining-Data.md
@@ -35,9 +35,9 @@ shy!
 # Example Usage
 
 By its nature, a join operation requires two inputs that will
-ultimately be combined. The Zed [`join` docs](https://github.com/brimdata/zed/tree/main/docs/zq/operators/join.md)
+ultimately be combined. The Zed [`join` docs](https://zed.brimdata.io/docs/language/operators/join/)
 show examples with the [Zed CLI tools](https://github.com/brimdata/zed#quick-start)
-that specify these inputs as named files or pools in a [Zed Lake](https://github.com/brimdata/zed/blob/main/docs/zed/README.md).
+that specify these inputs as named files or pools in a [Zed Lake](https://zed.brimdata.io/docs/commands/zed/#1-the-lake-model).
 
 The `join` operator is still experimental and has somewhat hard-to-use syntax,
 though this should be improved soon in a subsequent release.
@@ -61,7 +61,7 @@ you can execute all the other examples shown while accessing data from multiple
 pools. The joined results can be sent into yet another pool for further query
 from within Brim, if desired.
 
-To illustrate this, we'll walk through the [example that shows inputs from pools](https://github.com/brimdata/zed/blob/main/docs/zq/operators/from.md).
+To illustrate this, we'll walk through the [example that shows inputs from pools](https://zed.brimdata.io/docs/language/operators/from/).
 To ensure API-compatibility with the Zed backend, we'll use the `zed` binary
 found in the `zdeps` directory under the Brim [application binaries](https://github.com/brimdata/brim/wiki/Filesystem-Paths#application-binaries-v0250)
 path, specifically on macOS in this case.
@@ -109,13 +109,13 @@ the split, the multiple branches are _merged_ back into a single stream before
 `join` operates on them.
 
 The first argument to `join` is a Zed
-[expression](https://github.com/brimdata/zed/blob/main/docs/zq/language.md#6-expressions)
+[expression](https://zed.brimdata.io/docs/language/#6-expressions)
 that references fields in the respective left/right data sources to determine
 if a pair of records from each should be joined. In this case, since the field
 we're joining on is named `uid` in both data sources, the simple expression
 `uid=uid` suffices. The next argument is a comma-separated list of field names
 or assignments, similar to how the
-[`cut`](https://github.com/brimdata/zed/tree/main/docs/zq/operators/cut.md)
+[`cut`](https://zed.brimdata.io/docs/language/operators/cut/)
 operator is used.
 
 To apply this using `zq`, we employ its `-P` option that allows us to specify
@@ -175,7 +175,7 @@ laid out in columns with headers. However, this did not occur with our joined
 ZNG data.
 
 To understand why, it helps to look at our two example `conn` records in
-[ZSON](https://github.com/brimdata/zed/blob/main/docs/formats/zson.md) format.
+[ZSON](https://zed.brimdata.io/docs/formats/zson/) format.
 
 ```
 $ zq -f zson 'id.orig_p=49885 or id.orig_p=54470' conn-plus-spl.zng
@@ -254,7 +254,7 @@ $ zq -f zson 'id.orig_p=49885 or id.orig_p=54470' conn-plus-spl.zng
 ```
 
 The presence of the separate
-[Type Definitions](https://github.com/brimdata/zed/blob/main/docs/formats/zson.md#25-types)
+[Type Definitions](https://zed.brimdata.io/docs/formats/zson/#25-types)
 `(=2)` and `(=5)` shows us how separate schemas were generated for the two
 record variations produced by the `join`: The ones that matched on `uid` (and
 hence contained the additional SPL-SPT fields) and the ones that didn't.
@@ -263,7 +263,7 @@ predicated on query results all falling under a single schema, since the
 headers need to reflect all fields expected in the output.
 
 Now that we're recognized this, we can make a small change to our Zed to address
-it. By adding the [`fuse`](https://github.com/brimdata/zed/tree/main/docs/zq/operators/fuse.md)
+it. By adding the [`fuse`](https://zed.brimdata.io/docs/language/operators/fuse/)
 operator, we can ensure all the data is captured under a single, unified
 schema.
 

--- a/docs/Remote-Lakes.md
+++ b/docs/Remote-Lakes.md
@@ -12,7 +12,7 @@
 # Summary
 
 By default, the Brim application connects to a Lake on the system on which
-it is launched. This Lake includes [Zed Lake](https://github.com/brimdata/zed/blob/main/docs/zed/README.md)
+it is launched. This Lake includes [Zed Lake](https://zed.brimdata.io/docs/commands/zed/#1-the-lake-model)
 storage on the local filesystem for holding imported data. However, Brim is
 capable of accessing data stored in a Zed Lake in a remote Lake as well.
 This cookbook describes the available options and current limitations.
@@ -59,7 +59,7 @@ However, the overall app experience is powered by a distributed "backend"
 architecture that includes multiple components.
 
 One essential component is the Zed Lake which is accessed via a
-[`zed serve`](https://github.com/brimdata/zed/blob/main/docs/zed/README.md)
+[`zed serve`](https://zed.brimdata.io/docs/commands/zed/#213-serve)
 process that manages the storage and querying of imported data. Operations on
 the Zed Lake are invoked via a [REST API](https://en.wikipedia.org/wiki/Representational_state_transfer)
 that's utilized by a "client", such as the Brim app. The

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -88,7 +88,7 @@ and details to [brim/1490](https://github.com/brimdata/brim/issues/1490).
 In all other cases, please [open a new issue](#opening-an-issue).
 
 To begin troubleshooting this, it helps to understand the "backend" of Brim.
-One essential component is a [Zed Lake](https://github.com/brimdata/zed/blob/main/docs/zed/README.md),
+One essential component is a [Zed Lake](https://zed.brimdata.io/docs/commands/zed/#1-the-lake-model),
 a server-style process that manages the storage and querying of imported data.
 Operations in the pools of a Zed Lake are invoked via a [REST
 API](https://en.wikipedia.org/wiki/Representational_state_transfer) that's


### PR DESCRIPTION
As pre-sold to @mason-fish and @nwt, this is the first of what I expect to be a few passes through the Brim docs. I'd initially envisioned doing it all in one big PR, but @mason-fish made a good argument to fix the broken links first so the link checker would stop freaking out.

In subsequent PRs, I expect to:

1.  Purge some docs coverage that are specific to older releases, similar in spirit to what @nwt did with #2321.
2.  Correct some of the Zed CLI invocations in the wiki articles to be in sync with newer command syntax.