### PR TITLE
Various Bug Fixes

### DIFF
--- a/src/app/core/components/brim-editor.tsx
+++ b/src/app/core/components/brim-editor.tsx
@@ -113,8 +113,7 @@ const BrimEditor = ({value, isDisabled}: Props) => {
   if (isDisabled) extensions.push(EditorView.editable.of(false))
 
   useEffect(() => {
-    if (!view) return
-    if (value === currentEditorValue) return
+    if (!view || value === currentEditorValue || value === null) return
     view.dispatch(
       view.state.update({
         changes: {from: 0, to: view.state.doc.length, insert: value}
@@ -126,7 +125,7 @@ const BrimEditor = ({value, isDisabled}: Props) => {
     view.dispatch({
       effects: StateEffect.reconfigure.of(extensions)
     })
-  }, [isMultiLineMode])
+  }, [isMultiLineMode, isDisabled])
   useEffect(() => {
     if (!ref.current) return
     const state = EditorState.create({

--- a/src/app/features/sidebar/flows/remote-queries.ts
+++ b/src/app/features/sidebar/flows/remote-queries.ts
@@ -44,7 +44,7 @@ export const refreshRemoteQueries = (
         )
         | join on query_id=this
         | tombstone==false
-        | cut name, value, description, id, pins, isReadOnly`
+        | cut name, value, description, id, pins, quiet(isReadOnly)`
     )
 
     const remoteRecords = (await queryReq.js()) as Query[]

--- a/src/app/query-home/flows/initial-viewer-search.ts
+++ b/src/app/query-home/flows/initial-viewer-search.ts
@@ -14,7 +14,7 @@ const initialViewerSearch = (): Thunk<any> => (dispatch, getState) => {
   const query = Current.getQuery(getState())
   if (!query) return
   const perPage = query.hasAnalytics() ? ANALYTIC_MAX_RESULTS : PER_PAGE
-  if (query.hasHeadFilter) query.addFilterPin(`| head ${perPage}`)
+  if (!query.hasHeadFilter) query.addFilterPin(`| head ${perPage}`)
   const tabId = Tabs.getActive(getState())
   const history = global.tabHistories.get(tabId)
   const {key} = history.location

--- a/src/app/query-home/search-area/from-pin-picker.tsx
+++ b/src/app/query-home/search-area/from-pin-picker.tsx
@@ -7,6 +7,7 @@ import {useDispatch, useSelector} from "react-redux"
 import Icon from "src/app/core/icon-temp"
 import {cssVar} from "polished"
 import {updateQuery} from "../flows/update-query"
+import {MenuItemConstructorOptions} from "electron"
 
 const DropdownIcon = styled(Icon).attrs({name: "chevron-down"})``
 
@@ -52,13 +53,25 @@ const showPoolMenu = () => (dispatch, getState) => {
   const pools = Pools.getPools(lakeId)(s)
 
   const template = pools
-    ? pools.map((p) => ({
-        label: p.name,
-        click: () => {
-          query.setFromPin(p.id)
-          dispatch(updateQuery(query))
-        }
-      }))
+    ? [
+        {
+          label: "Unselect Pool",
+          click: () => {
+            query.setFromPin("")
+            dispatch(updateQuery(query))
+          }
+        },
+        {
+          type: "separator"
+        } as MenuItemConstructorOptions,
+        ...pools.map((p) => ({
+          label: p.name,
+          click: () => {
+            query.setFromPin(p.id)
+            dispatch(updateQuery(query))
+          }
+        }))
+      ]
     : [
         {
           label: "No pools in lake",

--- a/src/app/query-home/utils/brim-query.ts
+++ b/src/app/query-home/utils/brim-query.ts
@@ -49,7 +49,7 @@ export class BrimQuery {
   }
 
   get isReadOnly() {
-    return this.q.isReadOnly
+    return !!this.q.isReadOnly
   }
   toggleLock() {
     this.q.isReadOnly = !this.q.isReadOnly

--- a/src/js/components/ModalBox/useModalController.ts
+++ b/src/js/components/ModalBox/useModalController.ts
@@ -33,7 +33,6 @@ export default function useModalController(
       closeModal()
     }
     if (e.key === "Enter") {
-      console.log("hiiii")
       e.stopPropagation()
       e.preventDefault()
       const b = last(buttons)

--- a/src/js/models/TableColumns.ts
+++ b/src/js/models/TableColumns.ts
@@ -41,7 +41,7 @@ export default class TableColumns {
       const stringName = printColumnName(col.name)
       let max = estimateHeaderWidth(stringName)
       records.forEach((r) => {
-        const data = r.try(col.name)
+        const data = r?.try(col.name)
         if (!data) return
         const width = estimateCellWidth(data, stringName, this.config)
         if (width > max) max = width

--- a/src/js/state/SearchBar/flows.ts
+++ b/src/js/state/SearchBar/flows.ts
@@ -31,6 +31,8 @@ export default {
       )
       return false
     }
+
+    dispatch(SearchBar.errorSearchBarParse(""))
     return true
   },
   focus: () => () => {

--- a/src/js/state/SearchBar/reducer.ts
+++ b/src/js/state/SearchBar/reducer.ts
@@ -12,7 +12,7 @@ import {
 } from "./types"
 
 const init: SearchBarState = {
-  current: "",
+  current: null,
   pinned: [],
   error: null
 }


### PR DESCRIPTION
I spent some time clicking through the app and fixed a few issues as I encountered them, as well as some known ones:

* the head proc we append to queries had inverted logic from what it should have been
* queries' `isReadOnly` field in a zed lake needed to be quieted when it was missing otherwise we would hit an unmarshalling/`.js()` error.
* opening one query after the other would have strange behaviors where the searchbar would be empty every other tab (and be modified)
* searchbar disabling from query lock was not updating upon change of lock/isReadOnly status
* syntax errors in searchbar will be cleared upon searching once validation passes
* add a null check to `r.try()` (=> `r?.try()`) in `<TableColumn />`. It appears that elements in the records array might not always be Records?
* There was no way to unselect a pool from the from pool pin. This is a quick fix for now, though it will likely be replaced with the Pins 2.0 work