### PR TITLE
upgrade to Go 1.18 in .github/workflows/

### DIFF
--- a/.github/workflows/advance-zed.yml
+++ b/.github/workflows/advance-zed.yml
@@ -76,7 +76,7 @@ jobs:
       # is no different than the normal CI flow.
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.16"
+          go-version: '1.18'
       - uses: actions/setup-node@v2
         with:
           cache: yarn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.16"
+          go-version: '1.18'
       - uses: actions/setup-node@v2
         with:
           cache: yarn

--- a/.github/workflows/linux-release-candidate.yml
+++ b/.github/workflows/linux-release-candidate.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.16"
+          go-version: '1.18'
 
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/macos-release-candidate.yml
+++ b/.github/workflows/macos-release-candidate.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.16"
+          go-version: '1.18'
 
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/win-release-candidate.yml
+++ b/.github/workflows/win-release-candidate.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.16"
+          go-version: '1.18'
 
       - uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
This anticipates brimdata/zed#3833, which upgrades Zed to Go 1.18.