### PR TITLE
Work around docs.github.com link checker problem

### DIFF
--- a/.github/workflows/markdown-link-check-config.json
+++ b/.github/workflows/markdown-link-check-config.json
@@ -1,3 +1,11 @@
 {
-  "retryOn429": true
+  "retryOn429": true,
+  "httpHeaders": [
+    {
+      "urls": ["https://docs.github.com/"],
+      "headers": {
+        "Accept-Encoding": "zstd, br, gzip, deflate"
+      }
+    }
+  ]
 }

--- a/docs/Supported-Platforms.md
+++ b/docs/Supported-Platforms.md
@@ -139,7 +139,7 @@ be followed.
 The most extensive testing of Brim is provided via automation that is run on
 [GitHub Actions](https://github.com/features/actions). Specific platform
 versions of
-hosted runners are referenced in the automation for Brim's
+hosted [runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners) are referenced in the automation for Brim's
 [Continuous Integration tests](https://github.com/brimdata/brim/blob/main/.github/workflows/ci.yml)
 and build workflows for
 [Windows](https://github.com/brimdata/brim/blob/main/.github/workflows/win-release-candidate.yml),


### PR DESCRIPTION
See brimdata/zed#3871 for background.

In addition to putting back a link I'd removed in a docs review, I figure having the workaround in place could be helpful for future generations since someone who innocently adds a link to docs.github.com might otherwise be left scratching their head.