### PR TITLE
Fix pivot to logs

### DIFF
--- a/src/js/brim/program.test.ts
+++ b/src/js/brim/program.test.ts
@@ -68,6 +68,15 @@ describe("drill down", () => {
     expect(program).toBe('this["i d"]["orig h"]==192.168.0.54')
   })
 
+  test("when there is a sort on there", () => {
+    const program = brim
+      .program('name=="james" | count() by proto | sort -r count')
+      .drillDown(result)
+      .string()
+
+    expect(program).toBe('name=="james" proto=="udp"')
+  })
+
   test("combines keys in the group by proc", () => {
     const program = brim
       .program('_path=="dns" | count() by id.orig_h, proto, query | sort -r')
@@ -351,10 +360,8 @@ describe("extracting the first filter", () => {
   })
 
   test('_path=="conn" | filter a', () => {
-    // This is questionable. We'd need another way to extract the filter if we
-    // want the result of this to be _path==\"conn\" | filter a
     expect(brim.program('_path=="conn" | filter a').filter()).toEqual(
-      '_path=="conn"'
+      '_path=="conn" | filter a'
     )
   })
 

--- a/src/js/brim/program.ts
+++ b/src/js/brim/program.ts
@@ -39,6 +39,7 @@ export default function (p = "", pins: string[] = []) {
 
     drillDown(log: zed.Record) {
       let filter = this.filter()
+
       const newFilters = this.ast()
         .groupByKeys()
         .map((name) => log.tryField(name))
@@ -86,11 +87,14 @@ export default function (p = "", pins: string[] = []) {
     },
 
     filter() {
-      const [head, ...tail] = p.split("|")
+      const [head, ...tail] = p.split(
+        /\|?\s*(summarize|count|countdistinct|sum)/i
+      )
 
       if (isEmpty(tail) && this.hasAnalytics()) {
         return "*"
       } else {
+        if (isEmpty(trim(head))) return "*"
         return trim(head)
       }
     },


### PR DESCRIPTION
There is a bug where the “pivot to logs” right click option does not create the correct query. The correct query must retain all the filters before the first aggregate clause, then add a new filter based on what the user clicked.

The AST used to have a dedicated section for “filters”. That’s gone now that the language has matured. So, there is not a reliable way to know when the filters start and stop.

Yesterday, I started to go down rabbit hole of building the AST manager that we’ve always dreamed of. Here is my draft PR that get’s started on that effort.  However, to build this correctly would take weeks and then more weeks to iron out all the bugs. Then we would need to maintain it in lock step with any language changes. There are some open questions on that draft PR that welcome discussion.

So to fix this bug today, before we release, I use a regex to look at the query string, find the first occurrence of summarize|count|countdistinct|sum , then keep the first part as the “filters”.


fixes #2282 
The Draft Zed Ast Manager PR #2345 