### PR TITLE
fix zdeps -version output with dummy @yarnpkg/plugin-github

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           go-version: '1.18'
       - uses: actions/setup-node@v2
         with:
+          cache: yarn
           node-version-file: .node-version
       - run: yarn --inline-builds
       - run: yarn lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
           go-version: '1.18'
       - uses: actions/setup-node@v2
         with:
-          cache: yarn
           node-version-file: .node-version
       - run: yarn --inline-builds
       - run: yarn lint

--- a/.yarn/plugins/@yarnpkg/plugin-github.cjs
+++ b/.yarn/plugins/@yarnpkg/plugin-github.cjs
@@ -1,0 +1,11 @@
+module.exports = {
+  name: "@yarnpkg/plugin-github",
+  factory: function (require) {
+    // This dummy implementation overrides the builtin plugin, which
+    // fetches a tarball from GitHub instead of cloning the repository.
+    // Brimcap and Zed must be built in a cloned repository so the
+    // resulting executables will produce meaningful output for the
+    // -version flag.
+    return {}
+  }
+};

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -9,6 +9,8 @@ plugins:
     spec: "@yarnpkg/plugin-version"
   - path: .yarn/plugins/@yarnpkg/plugin-interactive-tools.cjs
     spec: "@yarnpkg/plugin-interactive-tools"
+  - path: .yarn/plugins/@yarnpkg/plugin-github.cjs
+    spec: '@yarnpkg/plugin-github'
 
 yarnPath: .yarn/releases/yarn-3.1.1.cjs
 


### PR DESCRIPTION
Both Brimcap and Zed must be built in a cloned Git repository to ensure
that "brimcap -version", "zed -version", and "zq -version" produce
meaningful output, but Yarn's @yarnpkg/plugin-github plugin fetches
tarballs for GitHub repositories instead of cloning them.  Add a dummy
plugin so Yarn will clone repositories instead.

Closes #2311.