### PR TITLE
remove PR creation step in .github/workflows/advance-zed.yml

### DIFF
--- a/.github/workflows/advance-zed.yml
+++ b/.github/workflows/advance-zed.yml
@@ -102,25 +102,11 @@ jobs:
             run/playwright-itest
             !run/**/SS
 
-      # This push logic is simple. If someone merges a different brim PR
-      # while this job is running, this push will fail. I anticipate
-      # this happening rarely, and it can be fixed by merging the
-      # resulting PR opened from the failure.
       - run: git commit -a -m 'upgrade Zed to ${{ github.event.client_payload.merge_commit_sha }}'
+
+      # If this push fails because a PR was merged while this job was
+      # running, you can re-run the failed job via
+      # https://github.com/brimdata/brim/actions.  Or, if you expect
+      # this workflow to be dispatched again soon, you can simply ignore
+      # the failure.
       - run: git push
-
-      - name: Create Pull Request for Manual Inspection
-        if: failure()
-        uses: peter-evans/create-pull-request@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: Zed update through "${{ steps.zed_pr.outputs.title }}" by ${{ steps.zed_pr.outputs.user }}
-          title: Zed update through "${{ steps.zed_pr.outputs.title }}" by ${{ steps.zed_pr.outputs.user }}
-          body: |
-            This is an auto-generated PR with a Zed dependency update needing manual attention. brimdata/zed#${{ steps.zed_pr.outputs.number }}, authored by @${{ steps.zed_pr.outputs.user }}, has been merged, however Zed could not be updated automatically. Please see https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} for the original failing run. If a Brim update is needed, you may use the branch on this PR to do so.
-
-            ----
-            #### ${{ steps.zed_pr.outputs.title }}
-            ${{ steps.zed_pr.outputs.body }}
-          branch: zedbot-${{ steps.zed_pr.outputs.branch }}
-          branch-suffix: short-commit-hash


### PR DESCRIPTION
The Slack notifications from .github/workflows/notify-main-failure.yaml
provide sufficient notification of failures, and the PRs aren't
particularaly useful outside of that.