### PR TITLE
Fix pivot to logs when it has a star

### DIFF
--- a/src/js/brim/program.test.ts
+++ b/src/js/brim/program.test.ts
@@ -77,6 +77,15 @@ describe("drill down", () => {
     expect(program).toBe('name=="james" proto=="udp"')
   })
 
+  test("when there is a grep with a star", () => {
+    const program = brim
+      .program(`grep(/(\*|Elm)/) Category=="Furnishings" | count() by proto`)
+      .drillDown(result)
+      .string()
+
+    expect(program).toBe('grep(/(*|Elm)/) Category=="Furnishings" proto=="udp"')
+  })
+
   test("combines keys in the group by proc", () => {
     const program = brim
       .program('_path=="dns" | count() by id.orig_h, proto, query | sort -r')

--- a/src/js/brim/program.test.ts
+++ b/src/js/brim/program.test.ts
@@ -79,7 +79,7 @@ describe("drill down", () => {
 
   test("when there is a grep with a star", () => {
     const program = brim
-      .program(`grep(/(\*|Elm)/) Category=="Furnishings" | count() by proto`)
+      .program('grep(/(*|Elm)/) Category=="Furnishings" | count() by proto')
       .drillDown(result)
       .string()
 

--- a/src/js/brim/program.ts
+++ b/src/js/brim/program.ts
@@ -47,7 +47,7 @@ export default function (p = "", pins: string[] = []) {
         .map(brim.syntax.include)
         .join(" ")
 
-      if (/\s*\*\s*/.test(filter)) filter = ""
+      if (/^\s*\*\s*$/.test(filter)) filter = ""
       if (newFilters.includes(filter)) filter = ""
 
       p = stdlib.string(filter).append(" ").append(newFilters).trim().self()


### PR DESCRIPTION
This fixes the problem Steve encountered today with pivot to logs.

The problem was the "*" in the filter. There was a regex that looks for a star that clears the filter. But it should only look for a "lone" star, not a star that's within other stuff.

