### PR TITLE
More query-flow fixes

### DIFF
--- a/src/app/features/sidebar/plus-button.tsx
+++ b/src/app/features/sidebar/plus-button.tsx
@@ -54,10 +54,6 @@ export default function PlusButton() {
         },
       },
       {
-        label: "New Remote Query",
-        click: () => dispatch(Modal.show("new-query", {isRemote: true})),
-      },
-      {
         label: "New Pool",
         click: () => dispatch(Tabs.create(lakeImportPath(lakeId))),
         enabled: !!lakeId,

--- a/src/app/query-home/results/results-error.tsx
+++ b/src/app/query-home/results/results-error.tsx
@@ -33,16 +33,15 @@ function isParseError(obj: unknown): obj is PegSyntaxError {
 }
 
 export function ResultsError(props: {error: string | object}) {
-  if (isString(props.error))
-    return (
-      <BG>
-        <h4>Error</h4>
-        <p>{props.error}</p>
-      </BG>
-    )
   if (isParseError(props.error)) {
     return <SyntaxError error={props.error} />
   }
+  return (
+    <BG>
+      <h4>Error</h4>
+      <p>{props.error.toString()}</p>
+    </BG>
+  )
 }
 
 export function SyntaxError(props: {error: PegSyntaxError}) {

--- a/src/app/query-home/utils/brim-query.ts
+++ b/src/app/query-home/utils/brim-query.ts
@@ -1,5 +1,5 @@
 import {Query} from "src/js/state/Queries/types"
-import {last} from "lodash"
+import {isEmpty, last} from "lodash"
 import {QueryPin, QueryPinInterface} from "../../../js/state/Editor/types"
 import {isNumber} from "lodash"
 import brim from "src/js/brim"
@@ -99,16 +99,19 @@ export class BrimQuery implements Query {
   }
 
   toString(): string {
-    let s = (this.current?.pins || [])
-      .filter((p) => !p.disabled)
-      .map<QueryPinInterface>(buildPin)
-      .map((p) => p.toZed())
+    let pinS = []
+    if (!isEmpty(this.current?.pins))
+      pinS = this.current.pins
+        .filter((p) => !p.disabled)
+        .map<QueryPinInterface>(buildPin)
+        .map((p) => p.toZed())
+    let s = pinS
       .concat(this.current?.value ?? "")
       .filter((s) => s.trim() !== "")
       .join(" | ")
       .trim()
 
-    if (s === "") s = "*"
+    if (isEmpty(s)) s = "*"
     if (isNumber(this.head)) s += ` | head ${this.head}`
 
     return s


### PR DESCRIPTION
* Remove the "add remote query" from plus menu since it was still using the old modal flow which would cause a breakage.
* Fixed BrimQuery .toString() typeErrors that occured in special situations
* Display errors in results

The error we get when there is no `from <pool> |` from the backend was not getting displayed. Now it does (though we should make this more helpful!)
<img width="1365" alt="image" src="https://user-images.githubusercontent.com/14865533/170572868-77ec3772-7cdb-4942-9002-205cb09d701a.png">
