### PR TITLE
Skip Release Notes on First Launch

### DIFF
--- a/src/app/ipc/first-run.ts
+++ b/src/app/ipc/first-run.ts
@@ -1,0 +1,22 @@
+import fs from "fs-extra"
+import path from "path"
+import log from "electron-log"
+import {app} from "electron"
+
+export const getPath = () => path.join(app.getPath("userData"), "first-run")
+
+let firstRun = undefined
+
+export function isFirstRun() {
+  return new Promise<boolean>((res) => {
+    if (firstRun !== undefined) return res(firstRun)
+    fs.stat(getPath(), (err) => {
+      if (err) {
+        fs.createFile(getPath()).catch((e) => log.error(e))
+        res((firstRun = true))
+      } else {
+        res((firstRun = false))
+      }
+    })
+  })
+}

--- a/src/app/ipc/meta.ts
+++ b/src/app/ipc/meta.ts
@@ -2,7 +2,7 @@ import {readJSONSync} from "fs-extra"
 import {createClient} from "src/pkg/electron-ipc-service"
 import {app} from "electron"
 import {paths} from "./paths"
-
+import {isFirstRun} from "./first-run"
 class Meta {
   _packageJSON: object | undefined
 
@@ -19,6 +19,10 @@ class Meta {
 
   version() {
     return app.getVersion()
+  }
+
+  isFirstRun() {
+    return isFirstRun()
   }
 }
 

--- a/src/app/release-notes/maybe-show-release-notes.ts
+++ b/src/app/release-notes/maybe-show-release-notes.ts
@@ -4,12 +4,16 @@ import {releaseNotesPath} from "src/app/router/utils/paths"
 import Current from "src/js/state/Current"
 import Launches from "src/js/state/Launches"
 import Tabs from "src/js/state/Tabs"
+import {Thunk} from "src/js/state/types"
 
-export function maybeShowReleaseNotes() {
+export function maybeShowReleaseNotes(): Thunk {
   return async (dispatch, getState) => {
     const version = await metaClient.version()
+    const isFirstRunEver = await metaClient.isFirstRun()
+
     if (
       !env.isIntegrationTest &&
+      !isFirstRunEver &&
       global.mainArgs.releaseNotes &&
       Launches.firstRunOfVersion(getState(), version)
     ) {


### PR DESCRIPTION
If this is the first time ever opening the app, do not display the release notes. Otherwise, only show the release notes if it is the first time using this version.

I create a file called first-run after launching. If that file exists, it's not the first run ever.

First launch after nuking the "run" directory
<img width="1362" alt="Screen Shot 2022-06-06 at 2 14 49 PM" src="https://user-images.githubusercontent.com/3460638/172250742-8784c2ea-6998-4011-8790-76953e3492e1.png">

Launching again after changing the version in package.json to v0.30.2.

<img width="1362" alt="Screen Shot 2022-06-06 at 2 15 12 PM" src="https://user-images.githubusercontent.com/3460638/172250841-9e411098-bfbf-47c6-b062-51eea9aba1df.png">

