### PR TITLE
Resize editor

### DIFF
--- a/src/app/query-home/results/results-error.tsx
+++ b/src/app/query-home/results/results-error.tsx
@@ -35,6 +35,7 @@ export function ResultsError(props: {error: string | object}) {
   if (isParseError(props.error)) {
     return <SyntaxError error={props.error} />
   }
+  console.error(props.error)
   return (
     <BG>
       <h2>Error</h2>

--- a/src/app/query-home/results/results.styled.tsx
+++ b/src/app/query-home/results/results.styled.tsx
@@ -66,6 +66,8 @@ export const ButtonSwitch = styled.nav`
   display: flex;
   margin: 0;
   height: 22px;
+  // z-index sits just above the drag anchor
+  z-index: 100;
   margin-top: -11px;
   margin-bottom: 10px;
 `

--- a/src/app/query-home/search-area/Input.tsx
+++ b/src/app/query-home/search-area/Input.tsx
@@ -2,11 +2,28 @@ import React from "react"
 import SubmitButton from "./submit-button"
 import styled from "styled-components"
 import QueryEditor from "./editor/query-editor"
+import {useDispatch} from "../../core/state"
+import useDrag, {DragArgs} from "../../../pkg/sectional/hooks/useDrag"
+import Editor from "../../../js/state/Editor"
+import {useSelector} from "react-redux"
+import lib from "src/js/lib"
 
-const InputBackdrop = styled.div`
+const DragAnchor = styled.div`
+  position: absolute;
+  background: transparent;
+  pointer-events: all !important;
+  z-index: 99;
+  width: 100%;
+  height: 9px;
+  bottom: -4px;
+  top: unset;
+  cursor: row-resize;
+`
+
+const InputBackdrop = styled.div<{height: number}>`
   border-bottom: 1px solid var(--border-color);
   position: relative;
-  height: 100px;
+  height: ${(p) => p.height + "px"};
 `
 
 const Submit = styled(SubmitButton)`
@@ -21,10 +38,22 @@ type Props = {
 }
 
 export default function Input({value, disabled}: Props) {
+  const dispatch = useDispatch()
+  const height = useSelector(Editor.getHeight)
+
+  const onDrag = ({dy}: DragArgs) => {
+    const minH = 100
+    const maxH = lib.win.getHeight() - 400
+    const newHeight = height + dy
+    dispatch(Editor.setHeight(Math.max(Math.min(newHeight, maxH), minH)))
+  }
+  const bindDrag = useDrag(onDrag)
+
   return (
-    <InputBackdrop>
+    <InputBackdrop height={height}>
       <QueryEditor value={value} disabled={disabled} />
       <Submit />
+      <DragAnchor onMouseDown={bindDrag} />
     </InputBackdrop>
   )
 }

--- a/src/app/query-home/search-area/Input.tsx
+++ b/src/app/query-home/search-area/Input.tsx
@@ -14,8 +14,8 @@ const DragAnchor = styled.div`
   pointer-events: all !important;
   z-index: 99;
   width: 100%;
-  height: 9px;
-  bottom: -4px;
+  height: 16px;
+  bottom: -8px;
   top: unset;
   cursor: row-resize;
 `
@@ -29,7 +29,7 @@ const InputBackdrop = styled.div<{height: number}>`
 const Submit = styled(SubmitButton)`
   position: absolute;
   right: 20px;
-  bottom: 6px;
+  bottom: 10px;
 `
 
 type Props = {

--- a/src/js/state/Editor/reducer.ts
+++ b/src/js/state/Editor/reducer.ts
@@ -9,8 +9,12 @@ const slice = createSlice({
     pins: [] as QueryPin[],
     pinEditIndex: null as null | number,
     pinHoverIndex: null as null | number,
+    height: 100,
   },
   reducers: {
+    setHeight(s, a: PayloadAction<number>) {
+      s.height = a.payload
+    },
     setValue(s, a: PayloadAction<string>) {
       s.value = a.payload
     },

--- a/src/js/state/Editor/selectors.ts
+++ b/src/js/state/Editor/selectors.ts
@@ -8,6 +8,10 @@ export const getPinEditIndex = activeTabSelect((tab) => {
   return tab.editor.pinEditIndex
 })
 
+export const getHeight = activeTabSelect((tab) => {
+  return tab.editor.height
+})
+
 export const getValue = activeTabSelect((tab) => {
   return tab.editor.value
 })

--- a/src/js/state/getPersistable.ts
+++ b/src/js/state/getPersistable.ts
@@ -12,14 +12,20 @@ const WINDOW_PERSIST: StateKey[] = [
   "launches",
   "pluginStorage",
   "queries",
-  "draftQueries",
   "queryVersions",
   "tabHistories",
   "tabs",
   "lakes",
 ]
 
-const TAB_PERSIST: TabKey[] = ["id", "search", "searchBar", "columns", "layout"]
+const TAB_PERSIST: TabKey[] = [
+  "id",
+  "search",
+  "searchBar",
+  "columns",
+  "layout",
+  "editor",
+]
 
 function deleteAccessTokens(state: Partial<State>) {
   if (!state.lakes) return


### PR DESCRIPTION
fixes #2382 

stores the height of the editor in tab state under the existing `editor` slice.

there is currently a bug where we are not properly persisting tabs which needs to be fixed before we can see the app remember that height.