### PR TITLE
fix viewer error

### DIFF
--- a/src/js/components/ModalDialog/ModalDialog.tsx
+++ b/src/js/components/ModalDialog/ModalDialog.tsx
@@ -18,7 +18,7 @@ const Overlay = styled.div`
   display: flex;
   justify-content: center;
   align-items: flex-start;
-  z-index: 2;
+  z-index: 200;
   overflow: hidden;
 `
 

--- a/src/js/state/Results/flows.ts
+++ b/src/js/state/Results/flows.ts
@@ -49,7 +49,8 @@ function fetchResults(tabId: string): Thunk {
       )
       dispatch(actions.success(res.rows.length, tabId))
     } catch (e) {
-      dispatch(actions.error(ErrorFactory.create(e), tabId))
+      if (e instanceof DOMException && e.message.match(/user aborted/)) return
+      dispatch(actions.error(ErrorFactory.create(e).message, tabId))
     }
   }
 }

--- a/src/js/state/Results/reducer.ts
+++ b/src/js/state/Results/reducer.ts
@@ -53,6 +53,7 @@ const slice = createSlice({
         } else {
           s.status = "COMPLETE"
         }
+        s.error = null
       },
     },
     error: {


### PR DESCRIPTION
fixes #2389 

when users issue a query while there is already one in progress, we abort the first request which returns an abortion "error". We then create our own error object out of that error and set it in redux for the viewer component to use. When the second request finishes, we set the data but we don't clear the error.

Unrelated, but I also saw that our modals needed a higher z-index because of the horizontal drag anchor for resizing the editor.

Each of the 4 line changes here fixes the above 4 issues. Now we clear any results error on success, we do not treat aborted requests as errors, when we do set an error we use the error message instead of the whole object, and when we show the lake info/export-results/etc. modal with a query page open then the editor's drag anchor will remain behind it.