### PR TITLE
Inspector Performance

### DIFF
--- a/src/app/core/utils/zed-type-class-name.ts
+++ b/src/app/core/utils/zed-type-class-name.ts
@@ -9,10 +9,6 @@ export function zedTypeClassName(data: zed.Value | zed.Type) {
     return "zed-null"
   }
 
-  if (data instanceof zed.Error) {
-    return "zed-error"
-  }
-
   if (data instanceof zed.Primitive) {
     const concrete = zed.trueType(data.type)
     const classes = []
@@ -23,4 +19,6 @@ export function zedTypeClassName(data: zed.Value | zed.Type) {
     }
     return classes.join(" ")
   }
+
+  return "zed-container"
 }

--- a/src/app/features/inspector/list.styled.tsx
+++ b/src/app/features/inspector/list.styled.tsx
@@ -16,7 +16,7 @@ export const List: ComponentType<PropsWithChildren<any>> = styled(
   }
 
   a {
-    cursor: pointer;
+    cursor: default;
     &:hover {
       background: rgba(0, 0, 0, 0.04);
     }

--- a/src/app/features/inspector/templates/closing.ts
+++ b/src/app/features/inspector/templates/closing.ts
@@ -1,0 +1,12 @@
+import {ContainerView} from "../views/container-view"
+import * as container from "./container"
+import {typename} from "./typename"
+import {zed} from "@brimdata/zealot"
+
+export function closing(view: ContainerView) {
+  let nodes = []
+  nodes.push(container.close(view))
+  if (zed.isTypeAlias(view.args.type)) nodes.push(typename(view))
+  if (!view.args.last) nodes.push(",")
+  return nodes
+}

--- a/src/app/features/inspector/templates/field.tsx
+++ b/src/app/features/inspector/templates/field.tsx
@@ -1,16 +1,17 @@
 import {zed} from "@brimdata/zealot"
+import {RenderMode} from "../types"
 import {View} from "../views/view"
 import {item} from "./item"
 import {key} from "./key"
 import {typename} from "./typename"
 
-export function field(view: View<zed.Any>) {
+export function field(view: View<zed.Any>, mode: RenderMode) {
   const nodes = []
   if (view.args.key) {
     nodes.push(key(view))
   }
 
-  nodes.push(item(view))
+  nodes.push(item(view, mode))
 
   if (zed.isTypeAlias(view.args.type)) {
     nodes.push(typename(view))

--- a/src/app/features/inspector/templates/item.tsx
+++ b/src/app/features/inspector/templates/item.tsx
@@ -1,13 +1,11 @@
 import React from "react"
 import {zedTypeClassName} from "src/app/core/utils/zed-type-class-name"
+import {RenderMode} from "../types"
 import {View} from "../views/view"
 
-export function item(view: View) {
-  const {args} = view
-  const {field, value, ctx, indexPath} = args
-  const props = {
-    key: args.indexPath.join(","),
-    className: zedTypeClassName(value),
+export function clickHandlers(view: View) {
+  const {field, value, ctx, indexPath} = view.args
+  return {
     onContextMenu: (e: React.MouseEvent) => {
       ctx.props?.onContextMenu(e, value, field, indexPath[0])
     },
@@ -15,5 +13,13 @@ export function item(view: View) {
       ctx.props?.onClick(e, value, field, indexPath[0])
     },
   }
-  return <span {...props}>{view.render()}</span>
+}
+
+export function item(view: View, mode: RenderMode) {
+  const props = {
+    key: view.args.indexPath.join(","),
+    className: zedTypeClassName(view.value),
+    ...clickHandlers(view),
+  }
+  return <span {...props}>{view.render(mode)}</span>
 }

--- a/src/app/features/inspector/templates/key.tsx
+++ b/src/app/features/inspector/templates/key.tsx
@@ -1,14 +1,18 @@
 import React from "react"
 import {createView} from "../views/create"
 import {View} from "../views/view"
-import {item} from "./item"
+import {clickHandlers, item} from "./item"
 
 export function key(view: View) {
   return (
-    <span className="zed-key" key={view.args.key.toString()}>
+    <span
+      className="zed-key"
+      key={view.args.key.toString()}
+      {...clickHandlers(view)}
+    >
       {typeof view.args.key === "string"
         ? view.args.key
-        : item(createView({...view.args, value: view.args.key}))}
+        : item(createView({...view.args, value: view.args.key}), "single")}
       :{" "}
     </span>
   )

--- a/src/app/features/inspector/templates/opening.ts
+++ b/src/app/features/inspector/templates/opening.ts
@@ -1,0 +1,16 @@
+import {ContainerView} from "../views/container-view"
+import {key} from "./key"
+import * as container from "./container"
+import {space} from "./space"
+
+export function opening(view: ContainerView) {
+  const nodes = []
+  if (view.args.key) {
+    nodes.push(key(view))
+  }
+  nodes.push(container.icon(view))
+  nodes.push(container.name(view))
+  nodes.push(space())
+  nodes.push(container.open(view))
+  return nodes
+}

--- a/src/app/features/inspector/types.ts
+++ b/src/app/features/inspector/types.ts
@@ -44,3 +44,5 @@ export type RowData = {
   indent: number
   render: ReactNode
 }
+
+export type RenderMode = "peek" | "single"

--- a/src/app/features/inspector/views/array-view.ts
+++ b/src/app/features/inspector/views/array-view.ts
@@ -1,7 +1,4 @@
 import {zed} from "@brimdata/zealot"
-import {field} from "../templates/field"
-import {note} from "../templates/note"
-import {syntax} from "../templates/syntax"
 import {createView} from "../views/create"
 import {ContainerView} from "./container-view"
 
@@ -10,24 +7,16 @@ export class ArrayView extends ContainerView<zed.Array> {
     return "Array"
   }
 
+  count() {
+    return this.value.items.length
+  }
+
   openToken() {
     return "["
   }
 
   closeToken() {
     return "]"
-  }
-
-  render() {
-    const n = 2
-    const l = this.value.items.length
-    const trail = l > n ? l - n : null
-    const nodes = []
-    nodes.push(syntax(this.openToken()))
-    nodes.push(Array.from(this.iterate(n)).map(field))
-    if (trail) nodes.push(note(" …+" + trail + " "))
-    nodes.push(syntax(this.closeToken()))
-    return nodes
   }
 
   *iterate(n?: number) {

--- a/src/app/features/inspector/views/error-view.ts
+++ b/src/app/features/inspector/views/error-view.ts
@@ -3,21 +3,37 @@ import {ContainerView} from "./container-view"
 import {createView} from "./create"
 import {field} from "../templates/field"
 import {syntax} from "../templates/syntax"
+import {RenderMode} from "../types"
+import {space} from "../templates/space"
 
 export class ErrorView extends ContainerView<zed.Error> {
-  openToken(): string {
-    return "("
-  }
-  closeToken(): string {
-    return ")"
-  }
   name(): string {
     return "Error"
   }
-  render() {
-    const {value} = this.iterate().next()
-    return ["Error", syntax("("), field(value), syntax(")")]
+
+  count() {
+    return this.iterate().next().value.count()
   }
+
+  openToken(): string {
+    return "("
+  }
+
+  closeToken(): string {
+    return ")"
+  }
+
+  render(mode: RenderMode) {
+    const {value: view} = this.iterate().next()
+    return [
+      this.name(),
+      space(),
+      syntax(this.openToken()),
+      field(view, mode),
+      syntax(this.closeToken()),
+    ]
+  }
+
   *iterate() {
     yield createView({
       ...this.args,

--- a/src/app/features/inspector/views/map-view.ts
+++ b/src/app/features/inspector/views/map-view.ts
@@ -1,7 +1,4 @@
 import {zed} from "@brimdata/zealot"
-import {field} from "../templates/field"
-import {note} from "../templates/note"
-import {syntax} from "../templates/syntax"
 import {createView} from "../views/create"
 import {ContainerView} from "./container-view"
 
@@ -10,24 +7,16 @@ export class MapView extends ContainerView<zed.Map> {
     return "Map"
   }
 
+  count(): number {
+    return this.value.value.size
+  }
+
   openToken() {
     return "|{"
   }
 
   closeToken() {
     return "}|"
-  }
-
-  render() {
-    const n = 2
-    const l = this.value.value.size
-    const trail = l > n ? l - n : null
-    const nodes = []
-    nodes.push(syntax(this.openToken()))
-    nodes.push(Array.from(this.iterate(n)).map(field))
-    if (trail) nodes.push(note(" …+" + trail + " "))
-    nodes.push(syntax(this.closeToken()))
-    return nodes
   }
 
   *iterate(n?: number) {

--- a/src/app/features/inspector/views/record-view.ts
+++ b/src/app/features/inspector/views/record-view.ts
@@ -1,7 +1,4 @@
 import {zed} from "@brimdata/zealot"
-import {field} from "../templates/field"
-import {note} from "../templates/note"
-import {syntax} from "../templates/syntax"
 import {createView} from "../views/create"
 import {ContainerView} from "./container-view"
 
@@ -10,24 +7,16 @@ export class RecordView extends ContainerView<zed.Record> {
     return "Record"
   }
 
+  count() {
+    return this.value.fields.length
+  }
+
   openToken() {
     return "{"
   }
 
   closeToken() {
     return "}"
-  }
-
-  render() {
-    const n = 2
-    const l = this.value.fields.length
-    const trail = l > n ? l - n : null
-    const nodes = []
-    nodes.push(syntax(this.openToken()))
-    nodes.push(Array.from(this.iterate(n)).map(field))
-    if (trail) nodes.push(note(" …+" + trail + " "))
-    nodes.push(syntax(this.closeToken()))
-    return nodes
   }
 
   *iterate(n?: number) {

--- a/src/app/features/inspector/views/set-view.ts
+++ b/src/app/features/inspector/views/set-view.ts
@@ -1,7 +1,4 @@
 import {zed} from "@brimdata/zealot"
-import {field} from "../templates/field"
-import {note} from "../templates/note"
-import {syntax} from "../templates/syntax"
 import {createView} from "../views/create"
 import {ContainerView} from "./container-view"
 
@@ -10,24 +7,16 @@ export class SetView extends ContainerView<zed.Set> {
     return "Set"
   }
 
+  count() {
+    return this.value.items.length
+  }
+
   openToken() {
     return "|["
   }
 
   closeToken() {
     return "]|"
-  }
-
-  render() {
-    const n = 2
-    const l = this.value.items.length
-    const trail = l > n ? l - n : null
-    const nodes = []
-    nodes.push(syntax(this.openToken()))
-    nodes.push(Array.from(this.iterate(n)).map(field))
-    if (trail) nodes.push(note(" …+" + trail + " "))
-    nodes.push(syntax(this.closeToken()))
-    return nodes
   }
 
   *iterate(n?: number) {

--- a/src/app/features/inspector/views/type-record-view.ts
+++ b/src/app/features/inspector/views/type-record-view.ts
@@ -1,7 +1,4 @@
 import {zed} from "@brimdata/zealot"
-import {field} from "../templates/field"
-import {note} from "../templates/note"
-import {syntax} from "../templates/syntax"
 import {createView} from "../views/create"
 import {ContainerView} from "./container-view"
 
@@ -10,24 +7,16 @@ export class TypeRecordView extends ContainerView<zed.TypeRecord> {
     return "Record"
   }
 
+  count() {
+    return this.value.fields.length
+  }
+
   openToken() {
     return "{"
   }
 
   closeToken() {
     return "}"
-  }
-
-  render() {
-    const n = 2
-    const l = this.value.fields.length
-    const trail = l > n ? l - n : null
-    const nodes = []
-    nodes.push(syntax(this.openToken()))
-    nodes.push(Array.from(this.iterate(n)).map(field))
-    if (trail) nodes.push(note(" …+" + trail + " "))
-    nodes.push(syntax(this.closeToken()))
-    return nodes
   }
 
   *iterate(n?: number) {

--- a/src/app/features/inspector/views/view.ts
+++ b/src/app/features/inspector/views/view.ts
@@ -1,7 +1,7 @@
 import {zed} from "@brimdata/zealot"
 import {ReactNode} from "react"
 import {field} from "../templates/field"
-import {InspectArgs} from "../types"
+import {InspectArgs, RenderMode} from "../types"
 
 export class View<T extends zed.Any = zed.Any> {
   constructor(public args: InspectArgs) {}
@@ -18,11 +18,11 @@ export class View<T extends zed.Any = zed.Any> {
     return this.args.ctx.props.isExpanded(this.args.indexPath.join(","))
   }
 
-  render(): ReactNode {
+  render(_mode?: RenderMode): ReactNode {
     return this.args.value.toString()
   }
 
   inspect() {
-    return this.args.ctx.push(field(this))
+    return this.args.ctx.push(field(this, "single"))
   }
 }

--- a/src/css/shared/_type-colors.scss
+++ b/src/css/shared/_type-colors.scss
@@ -7,10 +7,11 @@
   --interval: #544aa6;
   --bool: #3eaef4;
   --zed-string: hsl(130, 54%, 38%);
-  --zed-key: hsl(212, 17%, 55%);
+  --zed-key: hsl(212, 20%, 40%);
   --zed-number: #e65835;
   --zed-syntax: hsl(212, 17%, 55%);
   --zed-note: hsl(212, 17%, 80%);
+  --zed-container: var(--foreground-color);
 }
 
 .zed-syntax {
@@ -75,4 +76,8 @@
 .zed-note {
   color: var(--zed-note);
   font-style: italic;
+}
+
+.zed-container {
+  color: var(--zed-container);
 }


### PR DESCRIPTION
A single value can be rendered in 4 ways depending on it's level of nesting and what is expanded.

1. Render Expanded
2. Render Collapsed
3. Render Peek
4. Render Single

Here are what screenshots of each of those look like:

**Expanded**
<img width="141" alt="image" src="https://user-images.githubusercontent.com/3460638/173962997-d1a2cf86-f30e-4a8e-b559-03e0131134d1.png">

An expanded container shows all of its items on separate lines.

**Collapsed**
<img width="409" alt="image" src="https://user-images.githubusercontent.com/3460638/173963019-d7a3f1b6-09ed-4a90-944a-d82fe1d2b52a.png">

A collapsed container renders all of its items on a single line.

**Peek**
<img width="228" alt="image" src="https://user-images.githubusercontent.com/3460638/173963767-479b95f7-cb6a-437a-ae44-e02f2213947d.png">


A "peek" render means the container shows the first two items, then an ellipsis with the tail count.


**Single**
<img width="38" alt="image" src="https://user-images.githubusercontent.com/3460638/173963806-338d71c6-08c1-43dd-b469-58042710ff27.png">


A "single" render means we just show the container's syntax and the count of its items.


When any of these levels render their children, the children will be rendered and the next level down. Expanded shows children in collapsed mode, collapsed mode shows children in "peek" mode, and "peek" mode shows children in "single" mode.

The app previously didn't have a "single" mode. So if a deeply nested value was being displayed, we were "peeking" all the way down. Very dangerous.

