### PR TITLE
Inspector Limits

### DIFF
--- a/src/app/features/inspector/list.styled.tsx
+++ b/src/app/features/inspector/list.styled.tsx
@@ -37,4 +37,17 @@ export const List: ComponentType<PropsWithChildren<any>> = styled(
       height: 14px;
     }
   }
+
+  a.render-more {
+    background: var(--button-background);
+    color: var(--zed-key);
+    padding: 0 12px;
+    &:hover {
+      background: var(--button-background-hover);
+      color: var(--foreground-color);
+    }
+    &:active {
+      background: var(--button-background-active);
+    }
+  }
 `

--- a/src/app/features/inspector/templates/container.tsx
+++ b/src/app/features/inspector/templates/container.tsx
@@ -43,7 +43,7 @@ export function renderMoreAnchor(view: ContainerView, perPage: number) {
         view.args.ctx.props.renderMore(view.key)
       }}
     >
-      Render next {perPage}
+      Show next {perPage}
     </a>,
   ]
 }

--- a/src/app/features/inspector/templates/container.tsx
+++ b/src/app/features/inspector/templates/container.tsx
@@ -3,6 +3,7 @@ import {ContainerView} from "../views/container-view"
 import Icon from "src/app/core/icon-temp"
 import classNames from "classnames"
 import {zed} from "@brimdata/zealot"
+import {note} from "./note"
 
 export function open(view: ContainerView) {
   return (
@@ -33,11 +34,7 @@ export function expandAnchor(view: ContainerView, children: ReactNode) {
   )
 }
 
-export function renderMoreAnchor(
-  view: ContainerView,
-  perPage: number,
-  total: number
-) {
+export function renderMoreAnchor(view: ContainerView, perPage: number) {
   return [
     <a
       key="render-more-anchor"
@@ -46,7 +43,7 @@ export function renderMoreAnchor(
         view.args.ctx.props.renderMore(view.key)
       }}
     >
-      Render next {perPage} of {total}
+      Render next {perPage}
     </a>,
   ]
 }
@@ -71,4 +68,9 @@ export function icon(view: ContainerView) {
   } else {
     return <Icon name="chevron-right" key="arrow" size={16} />
   }
+}
+
+export function tail(view: ContainerView, limit: number) {
+  const n = view.count() - limit
+  return note(" …+" + n + " ")
 }

--- a/src/app/features/inspector/templates/container.tsx
+++ b/src/app/features/inspector/templates/container.tsx
@@ -1,4 +1,4 @@
-import React, {ReactElement} from "react"
+import React, {ReactNode} from "react"
 import {ContainerView} from "../views/container-view"
 import Icon from "src/app/core/icon-temp"
 import classNames from "classnames"
@@ -6,10 +6,7 @@ import {zed} from "@brimdata/zealot"
 
 export function open(view: ContainerView) {
   return (
-    <span
-      key={"open-token-" + view.args.indexPath.join(",")}
-      className="zed-syntax"
-    >
+    <span key={"open-token-" + view.key} className="zed-syntax">
       {view.openToken()}
     </span>
   )
@@ -17,29 +14,41 @@ export function open(view: ContainerView) {
 
 export function close(view: ContainerView) {
   return (
-    <span
-      key={"close-token-" + view.args.indexPath.join(",")}
-      className="zed-syntax"
-    >
+    <span key={"close-token-" + view.key} className="zed-syntax">
       {view.closeToken()}
     </span>
   )
 }
 
-export function anchor(view: ContainerView, children: ReactElement[]) {
+export function expandAnchor(view: ContainerView, children: ReactNode) {
   return (
     <a
-      key="handle"
+      key="expand-anchor"
       onClick={() => {
-        view.args.ctx.props.setExpanded(
-          view.args.indexPath.join(","),
-          !view.isExpanded()
-        )
+        view.args.ctx.props.setExpanded(view.key, !view.isExpanded())
       }}
     >
       {children}
     </a>
   )
+}
+
+export function renderMoreAnchor(
+  view: ContainerView,
+  perPage: number,
+  total: number
+) {
+  return [
+    <a
+      key="render-more-anchor"
+      className="render-more"
+      onClick={() => {
+        view.args.ctx.props.renderMore(view.key)
+      }}
+    >
+      Render next {perPage} of {total}
+    </a>,
+  ]
 }
 
 export function name(view: ContainerView) {

--- a/src/app/features/inspector/types.ts
+++ b/src/app/features/inspector/types.ts
@@ -47,4 +47,4 @@ export type RowData = {
   render: ReactNode
 }
 
-export type RenderMode = "peek" | "single"
+export type RenderMode = "single" | "peek" | "line" | "expanded"

--- a/src/app/features/inspector/types.ts
+++ b/src/app/features/inspector/types.ts
@@ -18,6 +18,8 @@ export type InspectorProps = {
   values: zed.Value[]
   isExpanded: IsExpanded
   setExpanded: SetExpanded
+  getValuePage: (key: string) => number
+  renderMore: (key: string) => void
   onContextMenu?: InspectorMouseEvent
   onClick?: InspectorMouseEvent
   loadMore?: Function

--- a/src/app/features/inspector/views/container-view.ts
+++ b/src/app/features/inspector/views/container-view.ts
@@ -70,6 +70,7 @@ export abstract class ContainerView<
     }
     nodes = nodes.concat(closing(this))
     ctx.push(container.expandAnchor(this, nodes))
+    return null
   }
 
   renderExpanded() {
@@ -85,6 +86,7 @@ export abstract class ContainerView<
     }
     ctx.unnest()
     ctx.push(closing(this))
+    return null
   }
 
   render(name?: RenderMode) {

--- a/src/app/features/inspector/views/view.ts
+++ b/src/app/features/inspector/views/view.ts
@@ -22,7 +22,7 @@ export class View<T extends zed.Any = zed.Any> {
     return this.args.ctx.props.isExpanded(this.key)
   }
 
-  render(_mode?: RenderMode): ReactNode | void {
+  render(_mode?: RenderMode): ReactNode {
     return this.args.value.toString()
   }
 

--- a/src/app/features/inspector/views/view.ts
+++ b/src/app/features/inspector/views/view.ts
@@ -22,7 +22,7 @@ export class View<T extends zed.Any = zed.Any> {
     return this.args.ctx.props.isExpanded(this.key)
   }
 
-  render(_mode?: RenderMode): ReactNode {
+  render(_mode?: RenderMode): ReactNode | void {
     return this.args.value.toString()
   }
 

--- a/src/app/features/inspector/views/view.ts
+++ b/src/app/features/inspector/views/view.ts
@@ -10,12 +10,16 @@ export class View<T extends zed.Any = zed.Any> {
     return this.args.value as T
   }
 
+  get key() {
+    return this.args.indexPath.join(",")
+  }
+
   rowCount() {
     return 1
   }
 
   isExpanded() {
-    return this.args.ctx.props.isExpanded(this.args.indexPath.join(","))
+    return this.args.ctx.props.isExpanded(this.key)
   }
 
   render(_mode?: RenderMode): ReactNode {

--- a/src/app/query-home/index.tsx
+++ b/src/app/query-home/index.tsx
@@ -87,6 +87,7 @@ const ContentWrap = styled.div`
   display: flex;
   width: 100%;
   height: 100%;
+  min-height: 0;
 `
 
 const QueryHome = () => {

--- a/src/app/query-home/results/main-inspector.tsx
+++ b/src/app/query-home/results/main-inspector.tsx
@@ -8,7 +8,7 @@ import {useDispatch} from "src/app/core/state"
 import {viewLogDetail} from "src/js/flows/viewLogDetail"
 import Slice from "src/js/state/Inspector"
 import {useRowSelection} from "./results-table/hooks/use-row-selection"
-import {debounce, values} from "lodash"
+import {debounce, isNumber, values} from "lodash"
 import Results from "src/js/state/Results"
 
 export function MainInspector(props: {
@@ -19,6 +19,7 @@ export function MainInspector(props: {
   const select = useSelect()
   const dispatch = useDispatch()
   const expanded = useSelector(Slice.getExpanded)
+  const valuePages = useSelector(Slice.getValuePages)
   const defaultExpanded = useSelector(Slice.getDefaultExpanded)
   const {parentRef, clicked} = useRowSelection({
     count: values.length,
@@ -34,6 +35,15 @@ export function MainInspector(props: {
     } else {
       return defaultExpanded
     }
+  }
+
+  function getValuePage(key: string) {
+    const page = valuePages.get(key)
+    return isNumber(page) ? page : 1
+  }
+
+  function renderMore(key: string) {
+    dispatch(Slice.renderMore({key}))
   }
 
   function loadMore() {
@@ -84,6 +94,8 @@ export function MainInspector(props: {
       innerRef={parentRef}
       isExpanded={useCallback(isExpanded, [expanded, defaultExpanded])}
       setExpanded={useCallback(setExpanded, [])}
+      getValuePage={useCallback(getValuePage, [valuePages])}
+      renderMore={useCallback(renderMore, [])}
       loadMore={useCallback(loadMore, [])}
       onContextMenu={useCallback(onContextMenu, [])}
       onClick={useCallback(onClick, [])}

--- a/src/js/state/Inspector/index.ts
+++ b/src/js/state/Inspector/index.ts
@@ -5,5 +5,6 @@ export default {
   getExpanded: activeTabSelect((t) => t.inspector.expanded),
   getDefaultExpanded: activeTabSelect((t) => t.inspector.defaultExpanded),
   getScrollPosition: activeTabSelect((t) => t.inspector.scrollPosition),
+  getValuePages: activeTabSelect((t) => t.inspector.valuePages),
   ...actions,
 }

--- a/src/js/state/Inspector/reducer.ts
+++ b/src/js/state/Inspector/reducer.ts
@@ -6,10 +6,16 @@ const slice = createSlice({
   initialState: {
     rows: [] as RowData[],
     expanded: new Map<string, boolean>(),
+    valuePages: new Map<string, number>(),
     defaultExpanded: false,
     scrollPosition: {top: 0, left: 0},
   },
   reducers: {
+    renderMore: (s, a: PayloadAction<{key: string}>) => {
+      const {key} = a.payload
+      const page = s.valuePages.get(key) || 1
+      s.valuePages.set(key, page + 1)
+    },
     setExpanded(s, a: PayloadAction<{key: string; isExpanded: boolean}>) {
       const {key, isExpanded} = a.payload
       s.expanded.set(key, isExpanded)
@@ -27,6 +33,7 @@ const slice = createSlice({
     builder.addCase("VIEWER_CLEAR", (s) => {
       s.rows = []
       s.expanded = new Map<string, boolean>()
+      s.valuePages = new Map<string, number>()
     })
   },
 })


### PR DESCRIPTION
The inspector was slow when a nested container value had a large number of children. For example, a record with an array field that had 10,000 items.

When the record was expanded, it would display the whole array on one line. All 10,000 items. Now this is limited to 15.

<img width="728" alt="image" src="https://user-images.githubusercontent.com/3460638/174675481-5fae9009-e336-4482-a3ef-3a1b2fcc42c5.png">


<img width="413" alt="image" src="https://user-images.githubusercontent.com/3460638/174678784-c4c58c27-0c8f-488e-877c-2e5f238e2ae6.png">

Now when you click that array to expand it, it was creating rows for all 10,000 items. This was also slow. Now it only will show the first 100 items, with a button to load the next 100.

<img width="323" alt="image" src="https://user-images.githubusercontent.com/3460638/174678918-95e0a6fa-7f08-4ebe-9bd6-5c778943eaba.png">
 To do this, we keep track of the "page" that the user has loaded in the inspector state. We store it in a map with the value index path as the key, and the page number as the value. Each time the button is clicked, the page number gets incremented and the next page is rendered.

This applies to all container values.

Here it is with a record with a ton of fields: 
<img width="413" alt="image" src="https://user-images.githubusercontent.com/3460638/174676306-b7966bea-844f-4eb3-91a3-1c94d0f97d5a.png">

<img width="199" alt="image" src="https://user-images.githubusercontent.com/3460638/174678942-eb1d4ed2-4c2b-4bd0-9e37-51e35ab76a82.png">