### PR TITLE
Careful Detail Pane

### DIFF
--- a/src/app/core/format.test.ts
+++ b/src/app/core/format.test.ts
@@ -1,10 +1,10 @@
 import {createData} from "src/test/shared/factories/zed-factory"
 import {zed} from "@brimdata/zealot"
-import {formatPrimitive} from "./format"
+import {formatValue} from "./format"
 
 test("format a long number", () => {
   const num = createData(1394668388559068) as zed.Primitive
-  const str = formatPrimitive(num)
+  const str = formatValue(num)
 
   expect(str).toBe("1,394,668,388,559,068")
 })

--- a/src/app/core/format.ts
+++ b/src/app/core/format.ts
@@ -35,8 +35,8 @@ const getTimeZone = createSelector<State, FormatConfig, string>(
 
 export const useTimeZone = () => useSelector(getTimeZone)
 
-export function formatPrimitive(
-  data: zed.Primitive,
+export function formatValue(
+  data: zed.Value,
   config: Partial<FormatConfig> = {}
 ) {
   if (data.isUnset()) {
@@ -57,8 +57,19 @@ export function formatPrimitive(
   if (zed.isFloat64(data)) {
     return replaceDecimal(data.toString(), config.decimal)
   }
-
-  return data.toString()
+  if (zed.isPrimitive(data)) {
+    return data.toString()
+  }
+  if (data instanceof zed.Array) {
+    return `[...${data.items.length}]`
+  }
+  if (data instanceof zed.Set) {
+    return `|[...${data.items.length}]|`
+  }
+  if (data instanceof zed.Map) {
+    return `|{...${data.value.size}}|`
+  }
+  return null
 }
 
 function getNumberLocale(config) {
@@ -91,5 +102,5 @@ function formatInt(string: number, config: Partial<FormatConfig> = {}) {
 export function useZedFormatter() {
   const config = useSelector(getFormatConfig)
 
-  return useMemo(() => (value) => formatPrimitive(value, config), [config])
+  return useMemo(() => (value) => formatValue(value, config), [config])
 }

--- a/src/app/core/hooks/useStoreExport.ts
+++ b/src/app/core/hooks/useStoreExport.ts
@@ -5,7 +5,6 @@ import {useEffect} from "react"
 import {useSelector} from "react-redux"
 import LogDetails from "src/js/state/LogDetails"
 import Viewer from "src/js/state/Viewer"
-import {encode} from "@brimdata/zealot"
 import {executeCommand} from "src/js/flows/executeCommand"
 import {useDispatch} from "../state"
 
@@ -13,10 +12,8 @@ const useStoreExport = () => {
   const currentData = useSelector(LogDetails.build)
   const dispatch = useDispatch()
 
-  const zjson = currentData ? encode(currentData) : null
-
   useEffect(() => {
-    dispatch(executeCommand("data-detail:current", zjson))
+    dispatch(executeCommand("data-detail:current", currentData))
   }, [currentData])
 
   const selectedData = useSelector(Viewer.getSelectedRecords)

--- a/src/app/detail/Fields.tsx
+++ b/src/app/detail/Fields.tsx
@@ -19,18 +19,19 @@ type DTProps = {
   fields: zed.Field[]
   onRightClick: (f: zed.Field) => void
   onHover: (f: zed.Field) => void
-  format: (f: zed.Primitive) => string
+  format: (f: zed.Value) => string
 }
-
+const LIMIT = 500
 const DataPanel = React.memo<DTProps>(function DataTable({
   fields,
   onRightClick,
   onHover,
   format,
 }: DTProps) {
+  const items = fields.slice(0, LIMIT)
   return (
     <Panel>
-      {fields.map((field, index) => (
+      {items.map((field, index) => (
         <Data key={index} onMouseEnter={() => onHover(field)}>
           <Name>
             <TooltipAnchor>{printColumnName(field.path)}</TooltipAnchor>
@@ -43,6 +44,12 @@ const DataPanel = React.memo<DTProps>(function DataTable({
           </Value>
         </Data>
       ))}
+      {fields.length > LIMIT && (
+        <Data>
+          <Name>Limited to {LIMIT} fields</Name>
+          <Value>Use the Inspector view to see all values.</Value>
+        </Data>
+      )}
     </Panel>
   )
 })

--- a/src/app/viewer/measure.ts
+++ b/src/app/viewer/measure.ts
@@ -1,4 +1,4 @@
-import {FormatConfig, formatPrimitive} from "src/app/core/format"
+import {FormatConfig, formatValue} from "src/app/core/format"
 import {isEventType} from "src/ppl/suricata/suricata-plugin"
 import {isPath} from "src/ppl/zeek/zeek-plugin"
 import {zed} from "@brimdata/zealot"
@@ -27,7 +27,7 @@ export function estimateCellWidth(
   let width = MIN_WIDTH
   if (value instanceof zed.Primitive) {
     width = Math.ceil(
-      formatPrimitive(value, config).length * ONE_CHAR + CELL_PAD + 12
+      formatValue(value, config).length * ONE_CHAR + CELL_PAD + 12
     )
   } else {
     width = Math.ceil(value.toString().length * ONE_CHAR + CELL_PAD)

--- a/src/js/state/Inspector/reducer.ts
+++ b/src/js/state/Inspector/reducer.ts
@@ -1,10 +1,8 @@
 import {createSlice, PayloadAction} from "@reduxjs/toolkit"
-import {RowData} from "src/app/features/inspector/types"
 
 const slice = createSlice({
   name: "TAB_INSPECTOR",
   initialState: {
-    rows: [] as RowData[],
     expanded: new Map<string, boolean>(),
     valuePages: new Map<string, number>(),
     defaultExpanded: false,
@@ -23,7 +21,6 @@ const slice = createSlice({
     setAllExpanded: (s, a: PayloadAction<boolean>) => {
       s.expanded = new Map<any, any>()
       s.defaultExpanded = a.payload
-      s.rows = []
     },
     setScrollPosition: (s, a: PayloadAction<{top: number; left: number}>) => {
       s.scrollPosition = a.payload
@@ -31,7 +28,6 @@ const slice = createSlice({
   },
   extraReducers: (builder) => {
     builder.addCase("VIEWER_CLEAR", (s) => {
-      s.rows = []
       s.expanded = new Map<string, boolean>()
       s.valuePages = new Map<string, number>()
     })

--- a/src/js/state/LogDetails/actions.ts
+++ b/src/js/state/LogDetails/actions.ts
@@ -1,5 +1,5 @@
 import {SearchStatus} from "src/js/types/searches"
-import {encode, zed} from "@brimdata/zealot"
+import {zed} from "@brimdata/zealot"
 import {
   LOG_DETAIL_BACK,
   LOG_DETAIL_CLEAR,
@@ -11,7 +11,7 @@ import {
 export default {
   push: (record: zed.Record): LOG_DETAIL_PUSH => ({
     type: "LOG_DETAIL_PUSH",
-    record: encode(record),
+    record,
   }),
 
   back: (): LOG_DETAIL_BACK => ({
@@ -26,7 +26,7 @@ export default {
     return {
       type: "LOG_DETAIL_UPDATE",
       updates: {
-        uidLogs: encode(records),
+        uidLogs: records,
       },
     }
   },

--- a/src/js/state/LogDetails/selectors.ts
+++ b/src/js/state/LogDetails/selectors.ts
@@ -6,7 +6,7 @@ import {State} from "../types"
 import {LogDetailHistory, toHistory} from "./reducer"
 import {LogDetailsState} from "./types"
 
-import {zed, decode} from "@brimdata/zealot"
+import {zed} from "@brimdata/zealot"
 
 const getLogDetails = activeTabSelect((state: TabState) => {
   return state.logDetails
@@ -22,7 +22,7 @@ const build = createSelector<State, LogDetailHistory, zed.Record | null>(
   (history) => {
     const entry = history.current()
     if (entry && entry.log) {
-      return decode(entry.log) as zed.Record
+      return entry.log as zed.Record
     } else {
       return null
     }
@@ -33,7 +33,7 @@ const getUidLogs = createSelector<State, LogDetailHistory, zed.Record[]>(
   getHistory,
   (history) => {
     const entry = history.current()
-    return entry ? (decode(entry.uidLogs) as zed.Record[]) : []
+    return entry ? (entry.uidLogs as zed.Record[]) : []
   }
 )
 

--- a/src/js/state/LogDetails/types.ts
+++ b/src/js/state/LogDetails/types.ts
@@ -1,4 +1,4 @@
-import {zjson} from "@brimdata/zealot"
+import {zed} from "@brimdata/zealot"
 import {SearchStatus} from "../../types/searches"
 
 export type LogDetailsState = {
@@ -7,8 +7,8 @@ export type LogDetailsState = {
 }
 
 export type LogDetails = {
-  log: zjson.Object
-  uidLogs: zjson.Object[]
+  log: zed.Value
+  uidLogs: zed.Value[]
   uidStatus: SearchStatus
 }
 
@@ -21,7 +21,7 @@ export type LogDetailsAction =
 
 export type LOG_DETAIL_PUSH = {
   type: "LOG_DETAIL_PUSH"
-  record: zjson.Object
+  record: zed.Value
 }
 
 export type LOG_DETAIL_UPDATE = {

--- a/src/plugins/brimcap/brimcap-plugin.ts
+++ b/src/plugins/brimcap/brimcap-plugin.ts
@@ -1,4 +1,4 @@
-import {decode, zed} from "@brimdata/zealot"
+import {zed} from "@brimdata/zealot"
 import env from "src/app/core/env"
 import {ChildProcess, spawn} from "child_process"
 import {MenuItemConstructorOptions} from "electron"
@@ -169,7 +169,7 @@ export default class BrimcapPlugin {
       // the detail window's packets button will operate off of the 'current' record
       this.api.commands.add("data-detail:current", ([record]) => {
         if (!record) return
-        const data = decode(record) as zed.Record
+        const data = record as zed.Record
 
         updateButtonStatus(
           "detail",


### PR DESCRIPTION
- Stop decoding and encoding zed values
- Limit what gets rendered in the detail pane

We don't persist the log details state, but we were encoding the values before they went into the store. This was hurting performance when the zed value was yuge. Thankfully, it's easy to just stop encoding it since nothing depends on it being encoded.

Secondly, the detail pane was rendering the 50,000 item array to a string which also hurt performance. Now if it encounters an array, it displays the array bracks with a "..." and the number of items in the array. Same goes for sets and maps. Records are flattened in the detail view, so they don't appear in the value column.
<img width="443" alt="Screen Shot 2022-06-29 at 10 20 01 AM" src="https://user-images.githubusercontent.com/3460638/176499094-569b5a1e-6301-4193-8c4e-0c3e7e2b1338.png">

To be safe, I also limited the number of rows in the detail view to 500. If it reaches that limit, it says the user they can look in the inspector to see everything. I was testing it with a limit of 3, but it's now 500.

<img width="444" alt="Screen Shot 2022-06-29 at 10 19 15 AM" src="https://user-images.githubusercontent.com/3460638/176499122-92b2ef2c-b500-4990-9874-39ec80b655b1.png">

