### PR TITLE
Fix broken links in wiki

### DIFF
--- a/docs/Supported-Platforms.md
+++ b/docs/Supported-Platforms.md
@@ -141,10 +141,7 @@ The most extensive testing of Brim is provided via automation that is run on
 versions of
 hosted [runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners) are referenced in the automation for Brim's
 [Continuous Integration tests](https://github.com/brimdata/brim/blob/main/.github/workflows/ci.yml)
-and build workflows for
-[Windows](https://github.com/brimdata/brim/blob/main/.github/workflows/win-release-candidate.yml),
-[macOS](https://github.com/brimdata/brim/blob/main/.github/workflows/macos-release-candidate.yml), and
-[Linux](https://github.com/brimdata/brim/blob/main/.github/workflows/linux-release-candidate.yml).
+and [release workflow](https://github.com/brimdata/brim/blob/main/.github/workflows/release.yml).
 
 ## Smoke Testing
 

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -279,7 +279,7 @@ its origin.
   into [Brimcap releases](https://github.com/brimdata/brimcap/releases).
 
 * Each Brim release points at a [Brimcap release](https://github.com/brimdata/brim/blob/b288fae1654bd6b848a0714583f6570d22e91d97/package.json#L68)
-  that's bundled by Brim's own [release automation](https://github.com/brimdata/brim/blob/v0.25.0/.github/workflows/win-release-candidate.yml).
+  that's bundled by Brim's own [release automation](https://github.com/brimdata/brim/blob/main/.github/workflows/release.yml).
 
 To summarize, the executable consists of a minimally-enhanced Suricata-Update that's been
 turned into an executable by other open source tools. If your conclusion


### PR DESCRIPTION
The markdown link checker had failures last night because these wiki articles were pointing at the old release YAML workflows that no longer exist. Here I point a the newer YAML.