### PR TITLE
Pin platform versions in build/release workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   release:
     strategy:
       matrix:
-        platform: [windows-latest, macos-latest, ubuntu-latest]
+        platform: [macos-10.15, ubuntu-18.04, windows-2019]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout Zui

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
   release:
     strategy:
       matrix:
-        platform: [windows-latest, macos-latest, ubuntu-latest]
+        platform: [macos-10.15, ubuntu-18.04, windows-2019]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout Zui


### PR DESCRIPTION
I recently noticed that the platforms specified in the new build/release workflows were pointing at the `*-latest` GitHub Actions runners. However, the prior workflows that built release candidates pointed to specific versions `macos-10.15`, `ubuntu-18.04`, and `windows-2019`, and the CI workflow (which also builds the app) still pins to these versions as well.

We discussed this at team sync and there was disagreement about whether to keep pinning to specific versions or just always be testing on "latest" of all platforms. The former doesn't _necessarily_ guarantee forward compatibility with everything newer, and has the drawback of requiring manual intervention when GitHub drops support for older platforms in their Actions runners. The latter has the drawback that what's pointed to as "latest" might change without us noticing, which could cause unexpected changes.

It seemed I somewhat persuaded the team to stick with the pinned versions because I'd previously done the fairly exhaustive testing described at https://github.com/brimdata/brim/wiki/Supported-Platforms. I'm nervous that jumping ahead to building on the latest platform versions might cause some of the run-ability to disappear on the older platforms, and I'd rather not invest the cycles right now in another test cycle, nor do I love the idea of leaving a questionable support statement dangling. If/when GitHub drops support for some older platforms we'll surely notice when CI starts failing (if not before) at which point I'd be happy to do some re-testing to see if anything changes as we advance the platform version pointer, then update the support statement.