### PR TITLE
Use Results.getQuery when exporting

### DIFF
--- a/src/js/flows/exportResults.ts
+++ b/src/js/flows/exportResults.ts
@@ -1,14 +1,13 @@
 import {ResponseFormat} from "@brimdata/zealot"
+import log from "electron-log"
 import fs from "fs"
 import {pipeline} from "stream"
 import util from "util"
 import brim from "../brim"
 import Columns from "../state/Columns"
-import Current from "../state/Current"
-import SearchBar from "../state/SearchBar"
+import Results from "../state/Results"
 import {Thunk} from "../state/types"
 import {getZealot} from "./getZealot"
-import {annotateQuery} from "./search/mod"
 
 const streamPipeline = util.promisify(pipeline)
 
@@ -37,11 +36,10 @@ export default (
   async (dispatch, getState): Promise<string> => {
     const zealot = await dispatch(getZealot(undefined, "node"))
     const columns = Columns.getCurrentTableColumns(getState())
-    const baseProgram = SearchBar.getSearchProgram(getState())
-    const program = prepareProgram(format, baseProgram, columns)
-    const poolId = Current.getQuery(getState()).getPoolName()
-    const query = annotateQuery(program, {poolId})
-    const res = await zealot.query(query, {
+    const originalQuery = Results.getQuery(getState())
+    const exportQuery = prepareProgram(format, originalQuery, columns)
+    log.info("Exporting", exportQuery)
+    const res = await zealot.query(exportQuery, {
       format,
       controlMessages: false,
     })

--- a/src/js/state/Results/selectors.ts
+++ b/src/js/state/Results/selectors.ts
@@ -17,6 +17,10 @@ export const getPaginatedQuery = activeTabSelect((t) => {
   }
 })
 
+export const getQuery = activeTabSelect((t) => {
+  return t.results.query
+})
+
 export const isFetching = activeTabSelect((t) => {
   return t.results.status === "FETCHING"
 })


### PR DESCRIPTION
We were generating the wrong query when exporting data. It was based on the old, pool-centric design. This PR updates it to use Results.getQuery. That returns the exact query that was used to generate the results in the table/inspector.

The annotateQuery function needs to be removed now. It is adding a time filter for a ts field to everything. That what caused this bug. The time filter removed all the results from the original query.

Fixes #2426

Note: The "Related Alerts" and "Related Conns" queries also need this treatment. They are currently broken. I did not include fixes in this PR since fixing the export is higher priority.