### PR TITLE
Fix tab state persistence

### DIFF
--- a/src/js/electron/tron/window-manager.ts
+++ b/src/js/electron/tron/window-manager.ts
@@ -178,8 +178,8 @@ export class WindowManager {
       const {size, position, query, id} = params
       const dimens = dimensFromSizePosition(size, position)
       const win = new SearchWindow(dimens, query, initialState, id)
-      await win.load()
       this.windows[id] = win
+      await win.load()
       win.ref.on("closed", () => {
         onClosed(this.windows[id])
       })


### PR DESCRIPTION
I'm still thinking of how best to test, but the fix at least was simple:

Since we now await the `window.load()` on start, each window will be created and initialize itself before that load() resolves, and we proceed to assign the window to the manager's windows state.

The problem with this is that the window's initialization process depends on the window manager already knowing about the window so that it can send it it's initial state (which we load from persisted storage). So by storing the window in the manager first and _then_ awaiting the load, the initialization is properly synchronized and can succeed. 