### PR TITLE
Remove link to offline wrccdc site

### DIFF
--- a/docs/Remote-Lakes.md
+++ b/docs/Remote-Lakes.md
@@ -212,8 +212,7 @@ Because only your local pcap index was populated, another user remotely
 accessing the same pool would be able to query the logs, but in order to
 successfully extract flows from it, they would need to obtain and locally index
 the same pcap file. The following commands could be executed by such a user on
-their Mac workstation to index the same
-[sample pcap](https://archive.wrccdc.org/pcaps/2018/wrccdc.2018-03-23.010014000000000.pcap.gz)
+their Mac workstation to index the same sample pcap
 shown above. See [brimcap/105](https://github.com/brimdata/brimcap/issues/105) for more details.
 
 ```


### PR DESCRIPTION
This wrccdc link has been breaking in our automated link checker for a couple days. I happen to have a contact for someone that looks after the wrccdc site who said it was due to come back online shortly, but today they updated me to say it won't happen until early August. Therefore I'm just removing the link. In fact, since the URL for the pcap also appears in the `wget` command line in the fixed text right below here in the article, I don't even think it'll be necessary to put the hyperlink back when they're online again. 😛 