### PR TITLE
Increase timeout when closing

### DIFF
--- a/src/js/electron/window/SearchWindow.ts
+++ b/src/js/electron/window/SearchWindow.ts
@@ -90,7 +90,7 @@ export class SearchWindow implements BrimWindow {
   getStateFromWebContents() {
     const replyChannel = randomHash()
     return new Promise((resolve, reject) => {
-      const safety = setTimeout(() => reject(new Error("Timeout")), 1000)
+      const safety = setTimeout(() => reject(new Error("Timeout")), 60_000)
       this.ref.webContents.send("getState", replyChannel)
       ipcMain.once(replyChannel, (event, state) => {
         clearTimeout(safety)


### PR DESCRIPTION
We must be doing something that is taking longer than a second to clean up that the large JSON value is revealing.

