### PR TITLE
upgrade Zed to 834a63338e3864510538f542c21000c0033b838c

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "use-resize-observer": "^8.0.0",
     "valid-url": "^1.0.9",
     "web-file-polyfill": "^1.0.4",
-    "zed": "brimdata/zed#5ee33b7afe4387f1a670eb9395d752a3a9a24fa0"
+    "zed": "brimdata/zed#834a63338e3864510538f542c21000c0033b838c"
   },
   "peerDependencies": {
     "react": "^18.0.0",

--- a/packages/zealot/src/client/client.ts
+++ b/packages/zealot/src/client/client.ts
@@ -75,7 +75,7 @@ export class Client {
     const abortCtl = wrapAbort(options.signal)
     const result = await this.send({
       method: "POST",
-      path: "/query",
+      path: `/query?ctrl=${options.controlMessages}`,
       body: json({query}),
       format: options.format,
       signal: abortCtl.signal,

--- a/yarn.lock
+++ b/yarn.lock
@@ -18016,12 +18016,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zed@brimdata/zed#5ee33b7afe4387f1a670eb9395d752a3a9a24fa0":
+"zed@brimdata/zed#834a63338e3864510538f542c21000c0033b838c":
   version: 0.33.0-dev
-  resolution: "zed@https://github.com/brimdata/zed.git#commit=5ee33b7afe4387f1a670eb9395d752a3a9a24fa0"
+  resolution: "zed@https://github.com/brimdata/zed.git#commit=834a63338e3864510538f542c21000c0033b838c"
   dependencies:
     zealot: ^0.2.0
-  checksum: fda9400b860c2a38250197c06e390f7382bb584041760513865cf169bfa631c516c21f9898b941583875f105a9b13ebcd51682edd34c0681d9ac6a699d5076c3
+  checksum: def3532e8ed08d1c92094b0fe9a78702556ef94b382de24030d8e5863b72668ff429cb18638ebdc5dbbe1db70eb56a6bfba1742bf475ea0c6c09de582618e818
   languageName: node
   linkType: hard
 
@@ -18170,7 +18170,7 @@ __metadata:
     web-streams-polyfill: ^3.2.0
     whatwg-fetch: ^3.2.0
     win-7zip: ^0.1.0
-    zed: "brimdata/zed#5ee33b7afe4387f1a670eb9395d752a3a9a24fa0"
+    zed: "brimdata/zed#834a63338e3864510538f542c21000c0033b838c"
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0


### PR DESCRIPTION
This updates Zealot for brimdata/zed#4001 by adding the ctrl URL query
parameter to POST /query requests.

Closes #2444.