### PR TITLE
Fix Long Refresh

### DIFF
--- a/src/js/state/getPersistable.ts
+++ b/src/js/state/getPersistable.ts
@@ -1,4 +1,4 @@
-import {cloneDeep, pick} from "lodash"
+import {pick} from "lodash"
 import {TabState} from "./Tab/types"
 import {State} from "./types"
 
@@ -14,7 +14,6 @@ const WINDOW_PERSIST: StateKey[] = [
   "queries",
   "queryVersions",
   "tabHistories",
-  "tabs",
   "lakes",
 ]
 
@@ -35,15 +34,12 @@ function deleteAccessTokens(state: Partial<State>) {
 }
 
 export function getPersistedState(original: State) {
-  const clone = cloneDeep(original)
-  const state = pick(clone, WINDOW_PERSIST)
-
-  if (state.tabs) {
-    state.tabs.data = state.tabs.data.map(
-      (tab) => pick(tab, TAB_PERSIST) as TabState
-    )
+  const windowState = pick(original, WINDOW_PERSIST)
+  const tabsState = {
+    ...original.tabs,
+    data: original.tabs.data.map((tab) => pick(tab, TAB_PERSIST) as TabState),
   }
-
+  const state = {...windowState, tabs: tabsState}
   deleteAccessTokens(state)
   return state
 }

--- a/src/js/state/getPersistable.ts
+++ b/src/js/state/getPersistable.ts
@@ -34,12 +34,16 @@ function deleteAccessTokens(state: Partial<State>) {
 }
 
 export function getPersistedState(original: State) {
-  const windowState = pick(original, WINDOW_PERSIST)
-  const tabsState = {
-    ...original.tabs,
-    data: original.tabs.data.map((tab) => pick(tab, TAB_PERSIST) as TabState),
+  let state = pick(original, WINDOW_PERSIST)
+
+  if (original.tabs) {
+    const tabs = {
+      ...original.tabs,
+      data: original.tabs.data.map((tab) => pick(tab, TAB_PERSIST) as TabState),
+    }
+    state = {...state, tabs}
   }
-  const state = {...windowState, tabs: tabsState}
+
   deleteAccessTokens(state)
   return state
 }


### PR DESCRIPTION
The app was taking a long time to quit and to reload pages when the oliver.zng file was loaded. Some perf measurements revealed we were deep cloning the entire state when we did not need to.