### PR TITLE
Fix Double Scroll Bar

### DIFF
--- a/src/app/features/sidebar/common.tsx
+++ b/src/app/features/sidebar/common.tsx
@@ -13,9 +13,9 @@ export const StyledSection = styled.section`
 
 export const SectionContents = styled.div`
   flex: 1;
-  overflow-y: auto;
   position: relative;
   padding-top: 6px;
+  min-height: 0;
 
   &::before,
   &::after {

--- a/src/app/features/sidebar/item.tsx
+++ b/src/app/features/sidebar/item.tsx
@@ -205,7 +205,12 @@ type ItemProps = {
 
 export function Item(props: ItemProps) {
   return (
-    <Container tabIndex={0} style={props.styles.row} ref={props.innerRef}>
+    <Container
+      tabIndex={0}
+      style={props.styles.row}
+      ref={props.innerRef}
+      title={props.text}
+    >
       <BG
         aria-selected={props.state.isSelected}
         className={getClassNames(props)}

--- a/src/js/components/DragAnchor.tsx
+++ b/src/js/components/DragAnchor.tsx
@@ -13,15 +13,16 @@ const Area = styled.div`
   bottom: 0;
   background: transparent;
   pointer-events: all !important;
-  cursor: col-resize;
   z-index: 99;
 
   &.align-left {
-    left: -4px;
+    left: -5px;
+    cursor: col-resize;
   }
 
   &.align-right {
-    right: -4px;
+    right: -5px;
+    cursor: col-resize;
   }
 `
 


### PR DESCRIPTION
Fixes: #2457

Now there will be no flashing horizontal scrollbar, and no double vertical scroll bar as you resize or scale.

I made the choice for the sidebar not to be horizontally scrollable. That was a design choice that follows the pattern of other apps with sidebars. For example, here's a screenshot from slack with a long channel name. It also doesn't scroll horizontally.

<img width="470" alt="Screen Shot 2022-07-22 at 10 38 04 AM" src="https://user-images.githubusercontent.com/3460638/180497140-447966a3-66b7-41cc-9034-d23937dc27bb.png"> 

I also tweeked the size of the drag anchors for the panes. And gave the section contents a min-width of 0 so that they will shrink as the window gets smaller.

I'd upload a video but I don't have good internet.