### PR TITLE
Fix Persist Bug

### DIFF
--- a/src/js/state/get-persistable.test.ts
+++ b/src/js/state/get-persistable.test.ts
@@ -1,0 +1,41 @@
+import initTestStore from "src/test/unit/helpers/initTestStore"
+import {getPersistedState} from "./getPersistable"
+import Lakes from "./Lakes"
+
+test("deleting access tokens for authType auth0", () => {
+  const store = initTestStore()
+  store.dispatch(
+    Lakes.add({
+      id: "1",
+      authType: "auth0",
+      host: "me.com",
+      port: "123",
+      name: "test",
+      authData: {clientId: "1", accessToken: "SECRET", domain: "me.com"},
+    })
+  )
+  const persist = getPersistedState(store.getState())
+  const persistedLake = Lakes.id("1")(persist)
+  expect(persistedLake.authData).toMatchInlineSnapshot(`
+    Object {
+      "clientId": "1",
+      "domain": "me.com",
+    }
+  `)
+})
+
+test("delete accessToken for authType none", () => {
+  const store = initTestStore()
+  store.dispatch(
+    Lakes.add({
+      id: "1",
+      authType: "none",
+      host: "me.com",
+      port: "123",
+      name: "test",
+    })
+  )
+  const persist = getPersistedState(store.getState())
+  const persistedLake = Lakes.id("1")(persist)
+  expect(persistedLake.authData).toMatchInlineSnapshot(`undefined`)
+})

--- a/src/js/state/getPersistable.ts
+++ b/src/js/state/getPersistable.ts
@@ -1,4 +1,4 @@
-import {pick} from "lodash"
+import {omit, pick} from "lodash"
 import {TabState} from "./Tab/types"
 import {State} from "./types"
 
@@ -27,10 +27,16 @@ const TAB_PERSIST: TabKey[] = [
 ]
 
 function deleteAccessTokens(state: Partial<State>) {
-  if (!state.lakes) return
-  for (const l of Object.values(state.lakes)) {
-    if (l.authType === "auth0" && l.authData) delete l.authData.accessToken
+  if (!state.lakes) return undefined
+  const newLakes = {}
+  for (const id in state.lakes) {
+    const lake = {...state.lakes[id]}
+    if (lake.authData) {
+      lake.authData = omit(lake.authData, "accessToken")
+    }
+    newLakes[id] = lake
   }
+  return newLakes
 }
 
 export function getPersistedState(original: State) {
@@ -43,7 +49,7 @@ export function getPersistedState(original: State) {
     }
     state = {...state, tabs}
   }
-
-  deleteAccessTokens(state)
+  const lakes = deleteAccessTokens(state)
+  state = {...state, lakes}
   return state
 }

--- a/src/test/shared/__mocks__/goober.ts
+++ b/src/test/shared/__mocks__/goober.ts
@@ -1,0 +1,3 @@
+export const keyframes = () => {}
+export const styled = () => () => {}
+export const setup = () => {}


### PR DESCRIPTION
Fixes #2462 

Immer makes all these objects immutable. So we need to create shallow copies of anything we want to mutate. I was able to reproduce this bug by adding a auth0 lake to zui, then quitting the app.

I also was able to reproduce it in a unit test, which I've included in this PR.
<img width="938" alt="Screen Shot 2022-07-28 at 3 59 32 PM" src="https://user-images.githubusercontent.com/3460638/181652885-e54ab573-6670-4dd5-bfc9-4b4484eaa0e3.png">

Aside: I had to mock goober which is unfortunately a dependency of react-hot-toast, which we require for the api, which we require in unit tests. I wanted to run this test without the dom, but goober needs the dom. I mocked goober to not need the dom. Now the tests can run in the node env instead of the js-dom env. They run faster in node.


