### PR TITLE
Alt-key will toggle recursively

### DIFF
--- a/src/app/features/inspector/templates/container.tsx
+++ b/src/app/features/inspector/templates/container.tsx
@@ -25,8 +25,8 @@ export function expandAnchor(view: ContainerView, children: ReactNode) {
   return (
     <a
       key="expand-anchor"
-      onClick={() => {
-        view.args.ctx.props.setExpanded(view.key, !view.isExpanded())
+      onClick={(e) => {
+        e.altKey ? view.toggleRecursive() : view.toggle()
       }}
     >
       {children}

--- a/src/app/features/inspector/views/container-view.ts
+++ b/src/app/features/inspector/views/container-view.ts
@@ -113,4 +113,34 @@ export abstract class ContainerView<
   isRowLimited() {
     return this.rowLimit() < this.count()
   }
+
+  toggle() {
+    this.isExpanded() ? this.collapse() : this.expand()
+  }
+
+  expand() {
+    this.args.ctx.props.setExpanded(this.key, true)
+  }
+
+  collapse() {
+    this.args.ctx.props.setExpanded(this.key, false)
+  }
+
+  toggleRecursive() {
+    this.isExpanded() ? this.collapseRecursive() : this.expandRecursive()
+  }
+
+  expandRecursive() {
+    this.expand()
+    for (const view of this.iterate()) {
+      if (view instanceof ContainerView) view.expandRecursive()
+    }
+  }
+
+  collapseRecursive() {
+    this.collapse()
+    for (const view of this.iterate()) {
+      if (view instanceof ContainerView) view.collapseRecursive()
+    }
+  }
 }


### PR DESCRIPTION
Fixes #2464

If you hold down alt (or option on mac) then click on the expand/collapse button, it will expand or collapse that value and all its children.

I chose alt because that is what Google Chrome devtools chose when expanding/collapsing all nodes in the html inspector. https://umaar.com/dev-tips/181-expand-nodes/