### PR TITLE
Use macos-11 runners and update Suported Platforms article

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   release:
     strategy:
       matrix:
-        platform: [macos-10.15, ubuntu-18.04, windows-2019]
+        platform: [macos-11, ubuntu-18.04, windows-2019]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout Zui

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-10.15, ubuntu-18.04, windows-2019]
+        os: [macos-11, ubuntu-18.04, windows-2019]
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
   release:
     strategy:
       matrix:
-        platform: [macos-10.15, ubuntu-18.04, windows-2019]
+        platform: [macos-11, ubuntu-18.04, windows-2019]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout Zui

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -278,7 +278,7 @@ We've become aware of an issue in Brim v0.22.0 where custom entries in the Query
 ## v0.21.0
 
 **NOTE** - The Brim v0.21.0 release includes initial support for the
-automatic generation of [Suricata](https://suricata-ids.org/) alerts from imported pcaps.
+automatic generation of [Suricata](https://suricata.io/) alerts from imported pcaps.
 The alert records may be isolated via a ZQL search `event_type=alert` and are
 also included automatically alongside relevant Zeek event context in the
 correlation visualization in the Log Detail view. The Suricata build that's

--- a/docs/Supported-Platforms.md
+++ b/docs/Supported-Platforms.md
@@ -23,7 +23,7 @@ recommendations on which to run Brim:
    * Windows 10 or newer
    * Windows Server 2019 or newer
 * macOS
-   * macOS Catalina 10.15.7 or newer (see [below](#hardware) for hardware considerations)
+   * macOS Big Sur 11.6.8 or newer (see [below](#hardware) for hardware considerations)
 * Linux
   * Ubuntu 18.04 or newer
   * CentOS 8.0 1905 or newer
@@ -55,9 +55,9 @@ on releases older than Windows 8.1.
 
 ### Software
 
-Brim's [test automation](#automated-testing) runs on Catalina 10.15 and
+Brim's [test automation](#automated-testing) runs on Big Sur 11 and
 therefore this is the macOS version on which we are best able to ensure quality
-and prevent regressions. Several Brim developers also run macOS Monterey 12.3
+and prevent regressions. Several Brim developers also run macOS Monterey 12.5
 and regularly perform ad hoc testing with it to reproduce reported issues.
 
 Basic [smoke testing](#smoke-testing) has also validated that Brim appears to
@@ -69,7 +69,7 @@ recommend attempting to run Brim on macOS releases older than macOS Mojave
 ### Hardware
 
 The build procedure for Brim's macOS releases creates binaries intended to
-run on the Intel-based Mac hardware that make up the majority of Macs in
+run on the Intel-based Mac hardware that make up many of the Macs in
 use today. Brim releases are not yet available that are built specifically for
 the recently-released [M1-based hardware](https://en.wikipedia.org/wiki/Apple_M1).
 However, Apple's [Rosetta 2](https://support.apple.com/en-us/HT211861) makes
@@ -105,7 +105,7 @@ Basic [smoke testing](#smoke-testing) has also validated the _oldest_
 release on which Brim appeared to work for each common distribution, as
 follows:
 
-* Ubuntu 10.04
+* Ubuntu 18.04
 * CentOS 8 1905
 * Debian 10.0.0
 * Fedora 28
@@ -128,8 +128,8 @@ strongly about trying to get Brim running on a [non-recommended platform](#non-r
 ## Development Tools
 
 There are two primary development tools on which Brim depends:
-[Electron](https://www.electronjs.org/docs/tutorial/support#supported-platforms)
-and [Go](https://golang.org/doc/install#requirements). Their support
+[Electron](https://www.electronjs.org/docs/latest/development/README)
+and [Go](https://github.com/golang/go/wiki/MinimumRequirements). Their support
 statements cite older platform releases than the Brim-specific ones cited above.
 Therefore the recommendations in the [Summary](#summary) section above should
 be followed.
@@ -155,11 +155,10 @@ confirm basic functionality. Such a smoke test consists of the following:
 * Install the Brim app using the standard package install procedure for the platform
 * Import a test pcap into Brim and confirm the bundled Zeek and Suricata both produce records from it
 
-This exercise was most recently performed in December, 2020 in preparation for
-the GA release [`v0.21.0`](https://github.com/brimdata/brim/releases/tag/v0.21.0)
-that first introduced Suricata support. For more details on the outcome of
-this exercise, review
-[brim/1263](https://github.com/brimdata/brim/issues/1263).
+This exercise was most recently performed in August, 2022 in preparation for
+the transition from Brim to GA Zui release v1.0.0. For more details on a
+particularly thorough smoke testing exercise that was performed previously,
+review [brim/1263](https://github.com/brimdata/brim/issues/1263).
 
 ## Non-Recommended Platforms
 


### PR DESCRIPTION
As noted in #2463, GitHub is deprecating the `macos-10.15` platform in their hosted Actions Runners. @mason-fish recently made some Zui test binaries that were build with `macos-11` (artifacts are [here](https://github.com/brimdata/brim/actions/runs/2827034553), made from [this branch](https://github.com/brimdata/brim/compare/build/test-zui)), so this gave me an opportunity to smoke test on an older macOS release to check if they still run ok and, if not, update our support statement. Rather than run through the exhaustive set of tests described in #1263, I opted to just test on Mojave 10.14 since that was the oldest release Brim worked on the last time I went through this exercise, and assume if that's ok then newer releases would still be ok too. Thankfully the app still installed and ran ok on that.

Since it's been a couple years since the last time we did these tests, I went ahead and also smoke tested again on Windows 8.1, CentOS 8 1905, Debian 10.0.0, and Fedora 28, as these were also "oldest working" versions in the last exercise, and I figured we might as well make sure that none of the minor changes on the Actions Runners we we use might have introduced new problems. Thankfully these tested out ok as well.

Therefore, this PR advances the macOS platform to `macos-11` and updates the [Supported Platforms](https://github.com/brimdata/brim/wiki/Supported-Platforms) wiki article to reflect this. While doing this, I recognized that the "Brim wiki" is due for an overall transition to being the "Zui wiki" (and eventually a "Zui docs site" like we did for the Zed docs). But rather than just hit this one article or change everything over now before Zui is ready for GA, I've opened #2480 as a reminder to do this later, and for now this article is still Brim-centric with just a brief reference to Zui.

FIxes #2463