### PR TITLE
Fix Null Pool Key

### DIFF
--- a/src/app/core/pools/pool.test.ts
+++ b/src/app/core/pools/pool.test.ts
@@ -1,0 +1,21 @@
+import {Pool} from "./pool"
+
+test("keys when null", () => {
+  const p = new Pool({
+    id: "1",
+    ts: new Date(),
+    name: "no keys",
+    layout: {keys: null, order: "desc"},
+  })
+  expect(p.keys).toEqual([])
+})
+
+test("keys when array", () => {
+  const p = new Pool({
+    id: "1",
+    ts: new Date(),
+    name: "no keys",
+    layout: {keys: [["nested", "here"]], order: "desc"},
+  })
+  expect(p.keys).toEqual([["nested", "here"]])
+})

--- a/src/app/core/pools/pool.ts
+++ b/src/app/core/pools/pool.ts
@@ -22,6 +22,10 @@ export class Pool {
     else throw new Error("No stats for this pool")
   }
 
+  get keys() {
+    return this.data.layout.keys || []
+  }
+
   defaultSpanArgs() {
     return this.everythingSpan()
   }
@@ -35,7 +39,7 @@ export class Pool {
   }
 
   hasTsKey() {
-    return isEqual(this.data.layout.keys, [["ts"]])
+    return isEqual(this.keys, [["ts"]])
   }
 
   empty() {

--- a/src/app/features/sidebar/index.tsx
+++ b/src/app/features/sidebar/index.tsx
@@ -10,6 +10,7 @@ import QueriesSection from "./queries-section"
 import Header from "./header"
 import {Menu} from "./menu"
 import SidebarToggleButton from "./sidebar-toggle-button"
+import AppErrorBoundary from "src/js/components/AppErrorBoundary"
 
 const EmptyText = styled.div`
   ${(p) => p.theme.typography.labelNormal}
@@ -76,7 +77,9 @@ export function Sidebar() {
         <>
           <Header />
           <Menu />
-          <SectionContentSwitch sectionName={currentSectionName} />
+          <AppErrorBoundary>
+            <SectionContentSwitch sectionName={currentSectionName} />
+          </AppErrorBoundary>
         </>
       )}
     </Pane>

--- a/src/app/pools/home.tsx
+++ b/src/app/pools/home.tsx
@@ -51,7 +51,7 @@ const PoolHome = () => {
       value: "",
     })
   }
-  const keys = pool.data.layout.keys.map((k) => k.join("."))
+  const keys = pool.keys.map((k) => k.join("."))
 
   return (
     <div>
@@ -79,7 +79,7 @@ const PoolHome = () => {
         </dl>
         <dl>
           <dt>Layout Key{keys.length > 1 ? "s" : null} </dt>
-          <dd>{keys.join(", ")}</dd>
+          <dd>{keys.join(", ") || "null"}</dd>
         </dl>
         <dl>
           <dt>Layout Order </dt>

--- a/src/app/query-home/results/index.tsx
+++ b/src/app/query-home/results/index.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef} from "react"
+import React from "react"
 import {useSelector} from "react-redux"
 import {useResizeObserver} from "src/js/components/hooks/useResizeObserver"
 import {useResultsData} from "./data-hook"
@@ -10,7 +10,6 @@ import Results from "src/js/state/Results"
 import styled from "styled-components"
 import {MAIN_RESULTS} from "src/js/state/Results/types"
 import AppErrorBoundary from "src/js/components/AppErrorBoundary"
-import {useLocation} from "react-router"
 
 const BG = styled.div`
   display: flex;
@@ -29,16 +28,10 @@ const ResultsComponent = () => {
   const view = useResultsView()
   const {ref, rect} = useResizeObserver()
   const error = useSelector(Results.getError(MAIN_RESULTS))
-  const location = useLocation()
-  const boundary = useRef<AppErrorBoundary>()
-
-  useEffect(() => {
-    boundary.current.clear()
-  }, [location.key])
 
   return (
     <BG>
-      <AppErrorBoundary ref={boundary}>
+      <AppErrorBoundary>
         <Body ref={ref} data-test-locator="viewer_results">
           {error && <ResultsError error={error} />}
           {!error && view.isTable && (

--- a/src/app/routes/app-wrapper/main-area.tsx
+++ b/src/app/routes/app-wrapper/main-area.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import {useDispatch} from "src/app/core/state"
+import AppErrorBoundary from "src/js/components/AppErrorBoundary"
 import Tabs from "src/js/state/Tabs"
 import styled from "styled-components"
 
@@ -29,7 +30,7 @@ export function MainArea({children}) {
   return (
     <BG onMouseDown={touched} onKeyDown={touched}>
       <div id="modal-dialog-root" />
-      {children}
+      <AppErrorBoundary>{children}</AppErrorBoundary>
     </BG>
   )
 }

--- a/src/js/components/AppErrorBoundary.tsx
+++ b/src/js/components/AppErrorBoundary.tsx
@@ -1,10 +1,10 @@
-import React from "react"
+import React, {useRef} from "react"
 import Link from "./common/Link"
 
 type Props = {children: any}
 type State = {error: Error | null | undefined}
 
-export default class AppErrorBoundary extends React.Component<Props, State> {
+class ErrorCatcher extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props)
     this.state = {error: null}
@@ -32,4 +32,11 @@ export default class AppErrorBoundary extends React.Component<Props, State> {
       </div>
     )
   }
+}
+
+export default function AppErrorBoundary({children}) {
+  const boundary = useRef<ErrorCatcher>()
+  boundary?.current?.clear()
+
+  return <ErrorCatcher ref={boundary}>{children}</ErrorCatcher>
 }


### PR DESCRIPTION
fixes #2490 

Be able to render a pool with a null keys value:

<img width="420" alt="CleanShot 2022-08-16 at 12 17 17@2x" src="https://user-images.githubusercontent.com/3460638/184963653-7d7aaa75-cd2b-472e-9cf8-96decc2f6eb3.png">

I also added an error boundary that clears itself if it's parent re-renders. It now looks like this:

https://user-images.githubusercontent.com/3460638/184963748-1d6f7f6d-e9c8-4fc1-acec-bf5e96b88a6a.mp4

