### PR TITLE
Export e2e test

### DIFF
--- a/packages/e2e-tests/tests/export.spec.ts
+++ b/packages/e2e-tests/tests/export.spec.ts
@@ -1,0 +1,57 @@
+import {test, expect} from "@playwright/test"
+import path from "path"
+import {testDataDir} from "../helpers/env"
+import TestApp from "../helpers/test-app"
+import os from "os"
+import fsExtra from "fs-extra"
+
+const tempDir = os.tmpdir()
+const formats = [
+  {label: "zng", expectedSize: 3692},
+  {label: "json", expectedSize: 13659},
+  {label: "ndjson", expectedSize: 13657},
+  {label: "csv", expectedSize: 12208},
+]
+
+test.describe("Export tests", () => {
+  const app = new TestApp("Export tests")
+
+  test.beforeAll(async () => {
+    await app.init()
+    await app.createPool([
+      path.normalize(path.join(testDataDir(), "sample.tsv")),
+    ])
+    await app.mainWin
+      .locator('#app-root button:above(:text("Query Pool"))')
+      .first()
+      .click()
+  })
+
+  test.afterAll(async () => {
+    await app.shutdown()
+  })
+
+  formats.forEach(({label, expectedSize}) => {
+    test(`Exporting in ${label} format succeeds`, async () => {
+      const file = path.join(tempDir, `results.${label}`)
+
+      app.brim.evaluate(async ({dialog}, filePath) => {
+        dialog.showSaveDialog = () =>
+          Promise.resolve({canceled: false, filePath})
+      }, file)
+
+      await app.mainWin
+        .locator('#app-root button:above(:text("Export"))')
+        .first()
+        .click()
+      await app.mainWin.locator(`text=${label}`).first().click()
+      await app.mainWin.locator('button:has-text("Export")').click()
+
+      await expect(
+        await app.mainWin.locator("text=Export Complete").first()
+      ).toBeVisible()
+
+      expect(fsExtra.statSync(file).size).toBe(expectedSize)
+    })
+  })
+})


### PR DESCRIPTION
fixed #2432 

I was flirting with the idea of switching our export flow to use an html file input so that we can use the same pattern for testing save dialogs as we do for the ingest flow (where Playwright has visibility and control of the "filechooser" event), but I ended up finding a very simple way to mock it within playwright instead. It's worth taking note of this particular pattern because it can be used for other electron features that aren't supported by playwright yet:

```js
      app.brim.evaluate(async ({dialog}, filePath) => {
        dialog.showSaveDialog = () =>
          Promise.resolve({canceled: false, filePath})
      }, file)
```

The tests go through all 4 currently supported export formats and verifies success by checking that the size of the output file is correct, which seemed good enough for me.