### PR TITLE
Add ZSON export option

### DIFF
--- a/packages/e2e-tests/tests/export.spec.ts
+++ b/packages/e2e-tests/tests/export.spec.ts
@@ -8,6 +8,7 @@ import fsExtra from "fs-extra"
 const tempDir = os.tmpdir()
 const formats = [
   {label: "zng", expectedSize: 3692},
+  {label: "zson", expectedSize: 15137},
   {label: "json", expectedSize: 13659},
   {label: "ndjson", expectedSize: 13657},
   {label: "csv", expectedSize: 12208},

--- a/src/js/components/ExportModal.tsx
+++ b/src/js/components/ExportModal.tsx
@@ -102,6 +102,10 @@ const ExportModal = ({onClose}) => {
             <label htmlFor="zng">zng</label>
           </RadioItem>
           <RadioItem>
+            <input type="radio" id="zson" value="zson" name="format" />
+            <label htmlFor="zson">zson</label>
+          </RadioItem>
+          <RadioItem>
             <input type="radio" id="json" value="json" name="format" />
             <label htmlFor="json">json</label>
           </RadioItem>


### PR DESCRIPTION
I followed the Export fix & test PRs closely enough that I could see that adding this ZSON export feature might not be too hard. Indeed, it took just a few lines of code to make it work and add a test that passes.

https://user-images.githubusercontent.com/5934157/187553865-21ad0a17-1575-438e-8475-cdb3e7857d7c.mp4

```
$ yarn e2e

Running 14 tests using 1 worker

  ✓  export.spec.ts:36:5 › Export tests › Exporting in zng format succeeds (1s)
  ✓  …rt.spec.ts:36:5 › Export tests › Exporting in zson format succeeds (901ms)
  ✓  …rt.spec.ts:36:5 › Export tests › Exporting in json format succeeds (899ms)
...
```

Closes #1486