### PR TITLE
Point at new docs site

### DIFF
--- a/src/app/core/links.ts
+++ b/src/app/core/links.ts
@@ -1,11 +1,12 @@
 import * as brimPackage from "../../../package.json"
 
 const currentZedTag = brimPackage.dependencies.zed.split("#")[1] || "main"
+const zedDocsTag = currentZedTag.startsWith("v") ? currentZedTag : "next"
 
 export default {
-  ZED_DOCS_ROOT: `https://github.com/brimdata/zed/blob/${currentZedTag}/docs/commands/zed.md`,
-  ZED_DOCS_LANGUAGE: `https://github.com/brimdata/zed/blob/${currentZedTag}/docs/language/README.md`,
-  ZED_DOCS_FORMATS_ZNG: `https://github.com/brimdata/zed/blob/${currentZedTag}/docs/formats/zng.md`,
-  ZED_DOCS_FORMATS_ZSON: `https://github.com/brimdata/zed/blob/${currentZedTag}/docs/formats/zson.md`,
-  ZED_DOCS_FORMATS_ZST: `https://github.com/brimdata/zed/blob/${currentZedTag}/docs/formats/zst.md`,
+  ZED_DOCS_ROOT: `https://zed.brimdata.io/docs/${zedDocsTag}/commands/zed`,
+  ZED_DOCS_LANGUAGE: `https://zed.brimdata.io/docs/${zedDocsTag}/language`,
+  ZED_DOCS_FORMATS_ZNG: `https://zed.brimdata.io/docs/${zedDocsTag}/formats/zng`,
+  ZED_DOCS_FORMATS_ZSON: `https://zed.brimdata.io/docs/${zedDocsTag}/formats/zson`,
+  ZED_DOCS_FORMATS_ZST: `https://zed.brimdata.io/docs/${zedDocsTag}/formats/zst`,
 }


### PR DESCRIPTION
As described in #2360, the Zed Syntax Docs link from the app has been pointing at docs URLs in the Zed GitHub repo. The new docs site makes a better destination, though.

In the past, if the app was running a random Zed commit rather than a tagged GA version like `v1.2.0` the URL would point to that specific commit hash in the Zed repo. However, the new site doesn't have docs at every hash, so this PR turns those cases into version `next`, which is effectively the docs as of the tip of Zed `main`. I expect most users running non-tagged Zed with their Brim apps would be people hacking with Zui Insiders, so this destination seems to make sense anyway.

To test, I set the Zed dependency in `package.json` to each current possible variation.

When running Brim commit 0029841 that points at Zed commit `d07901b`, we land at https://zed.brimdata.io/docs/next/language.

![image](https://user-images.githubusercontent.com/5934157/187782878-857f9df1-5122-4e0b-b0f5-4f8abd5e81d5.png)

After changing the Zed dependency to `v.1.2.0`, now we land at https://zed.brimdata.io/docs/language. Note the lack of the explicit version tag in the URL. This is due to the redirect config introduced in https://github.com/brimdata/zed-docs-site/pull/40.

![image](https://user-images.githubusercontent.com/5934157/187783310-076701ac-cc97-43b0-a68c-33162fe99f58.png)

Finally, if I change the Zed dependency to `v1.1.0`, now we land at https://zed.brimdata.io/docs/v1.1.0/language.

![image](https://user-images.githubusercontent.com/5934157/187784004-2bf5d4bf-d0c2-4071-80f5-62fffe291903.png)

Since this PR also changes the Zed format links on the import page, I tested those as well. With the Zed dependency still set to `v.1.1.0`:

![image](https://user-images.githubusercontent.com/5934157/187784544-a18ad36a-6d22-47c5-a76f-08a5e5a00143.png)

![image](https://user-images.githubusercontent.com/5934157/187784601-aa505d48-76a1-405f-b515-4d52fb495ff7.png)

![image](https://user-images.githubusercontent.com/5934157/187784638-5f29d1c5-c25f-49c5-b34b-a98638f88656.png)

import pages

Fixes #2360