### PR TITLE
Overflow hidden on the results

### DIFF
--- a/src/app/query-home/results/index.tsx
+++ b/src/app/query-home/results/index.tsx
@@ -21,6 +21,7 @@ const BG = styled.div`
 
 const Body = styled.div`
   flex: 1;
+  overflow: hidden;
 `
 
 const ResultsComponent = () => {


### PR DESCRIPTION
This must have happened in a merge conflict.

Fixes #2492 