### PR TITLE
Increase toast loading duration to biggest number

### DIFF
--- a/src/js/components/BrimToaster.tsx
+++ b/src/js/components/BrimToaster.tsx
@@ -14,7 +14,7 @@ const BrimToaster = () => {
           duration: env.isTest ? 2 ** 31 - 1 : undefined,
         },
         loading: {
-          duration: env.isTest ? 2 ** 31 - 1 : undefined,
+          duration: 2 ** 31 - 1,
         },
         error: {
           duration: env.isTest ? 2 ** 31 - 1 : undefined,

--- a/src/js/components/BrimToaster.tsx
+++ b/src/js/components/BrimToaster.tsx
@@ -1,4 +1,3 @@
-import env from "src/app/core/env"
 import React from "react"
 import {Toaster} from "react-hot-toast"
 
@@ -9,15 +8,9 @@ const BrimToaster = () => {
       toastOptions={{
         role: "status",
         className: "brim-toast",
-        duration: env.isTest ? 2 ** 31 - 1 : undefined,
-        success: {
-          duration: env.isTest ? 2 ** 31 - 1 : undefined,
-        },
         loading: {
+          // This is so that the loading indicator does not go away.
           duration: 2 ** 31 - 1,
-        },
-        error: {
-          duration: env.isTest ? 2 ** 31 - 1 : undefined,
         },
       }}
     />

--- a/src/js/components/BrimToaster.tsx
+++ b/src/js/components/BrimToaster.tsx
@@ -12,6 +12,9 @@ const BrimToaster = () => {
           // This is so that the loading indicator does not go away.
           duration: 2 ** 31 - 1,
         },
+        success: {
+          duration: 6000,
+        },
       }}
     />
   )

--- a/src/js/components/ExportModal.tsx
+++ b/src/js/components/ExportModal.tsx
@@ -71,7 +71,7 @@ const ExportModal = ({onClose}) => {
     toast
       .promise(dispatch(exportResults(filePath, format as ResponseFormat)), {
         loading: "Exporting...",
-        success: "Export Complete",
+        success: "Export Completed: " + filePath,
         error: "Error Exporting",
       })
       .catch((e) => {

--- a/src/test/system/index.ts
+++ b/src/test/system/index.ts
@@ -1,3 +1,3 @@
 import "./real-paths"
-
+export {screen, act} from "@testing-library/react"
 export {SystemTest} from "./system-test-class"


### PR DESCRIPTION
Fixes #2497

I tested this by exporting 3.4 gigs of ndjson. The export took over a minute, did not disappear, and then displayed the "export complete" 
message.

