### PR TITLE
Use quiet() around cut() when exporting columns

### DIFF
--- a/src/js/brim/program.ts
+++ b/src/js/brim/program.ts
@@ -31,6 +31,10 @@ export default function (p = "") {
       return this
     },
 
+    quietCut(...fields: string[]) {
+      return this.cut(fields.map((fieldName) => "quiet(" + fieldName + ")"))
+    },
+
     drillDown(log: zed.Record) {
       let filter = this.filter()
 

--- a/src/js/flows/exportResults.ts
+++ b/src/js/flows/exportResults.ts
@@ -18,7 +18,7 @@ function cutColumns(program, columns) {
     const names = columns.getVisible().map((c) => c.name)
     return brim
       .program(program)
-      .cut(...names)
+      .quietCut(...names)
       .string()
   }
 }


### PR DESCRIPTION
As shown in the attached video, we can avoid the `error(missing)` values if we use `quiet()` to wrap the field references in our `cut()` of columns.

https://user-images.githubusercontent.com/5934157/188040989-5436099e-edd3-47d7-bd33-3bbc6f89f5be.mp4

As for the code change, I couldn't find other things currently using the existing `cut`, so it may have been fair game to just do the `quiet()` wrapping in there. However, in the event something else wants to invoke Zed `cut()` one day and isn't expecting the errors to be silenced, I made a new function and called that instead. I also thought about putting an optional boolean `quiet` on the existing function, but that didn't play right with the fact that there's already a "rest parameter" `...fields`. So, bottom line, no offense taken if you want to completely gut/reject this if the code doesn't meet your standards for code cleanliness and supportability. 😛 

Fixes #2190
