### PR TITLE
Comments at the end of lines will work now

### DIFF
--- a/src/js/state/Results/paginate.test.ts
+++ b/src/js/state/Results/paginate.test.ts
@@ -1,0 +1,13 @@
+import {paginate} from "./paginate"
+
+test("works with a comment", () => {
+  const result = paginate("james // comment does not block suffix", 10, 1)
+
+  expect(result).toEqual(
+    `james // comment does not block suffix
+  | { i: count(), v: this}
+  | i > 0
+  | head 10
+  | yield v`
+  )
+})

--- a/src/js/state/Results/paginate.ts
+++ b/src/js/state/Results/paginate.ts
@@ -1,9 +1,7 @@
 export function paginate(query: string, perPage: number, page: number) {
-  return (
-    query +
-    ` | { i: count(), v: this} 
-      | i > ${(page - 1) * perPage} 
-      | head ${perPage}
-      | yield v`
-  )
+  return `${query}
+  | { i: count(), v: this}
+  | i > ${(page - 1) * perPage}
+  | head ${perPage}
+  | yield v`
 }


### PR DESCRIPTION
Fixes #2452 

Comments at the end of lines don't break queries anymore. Thanks for the rec @nwt 

<img width="1202" alt="image" src="https://user-images.githubusercontent.com/3460638/188746450-83b51c22-3e86-4a04-bf53-a11d31ed72d2.png">
