### PR TITLE
Brim->Zui in window title

### DIFF
--- a/search.html
+++ b/search.html
@@ -2,7 +2,7 @@
 <html lang="en" dir="ltr">
   <head>
     <meta charset="utf-8" />
-    <title>Brim</title>
+    <title>Zui</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" type="text/css" href="dist/css/main.css" />
     <meta


### PR DESCRIPTION
I admittedly found this fix via grep-n-hack, but I made some test artifacts and it did make the symptom go away on macOS, Linux, and Windows, so it hits the spot for my immediate needs.

FWIW I did find some other lingering "Brim" references still out there, but I didn't fiddle with any of them because I wasn't sure if there could be undesirable side effects. Happy to bring them into the PR if they're deemed safe/desirable changes.

https://github.com/brimdata/brim/blob/8ac2379dd254ec6dcd265c2c770ebbca07e2aeb5/src/app/router/routes.ts#L12

https://github.com/brimdata/brim/blob/8ac2379dd254ec6dcd265c2c770ebbca07e2aeb5/src/js/brim/brimTab.ts#L26

https://github.com/brimdata/brim/blob/8ac2379dd254ec6dcd265c2c770ebbca07e2aeb5/src/js/electron/windows/search/app-menu.ts#L75

Fixes #2523