### PR TITLE
Locate moved Run button in e2e test

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "use-resize-observer": "^8.0.0",
     "valid-url": "^1.0.9",
     "web-file-polyfill": "^1.0.4",
-    "zed": "brimdata/zed#9c0f0973d6d52095184d11a9eb6c169be58da660"
+    "zed": "brimdata/zed#dd3b22dace0fb35bb87ee1b4b9f667ec40b3527f"
   },
   "peerDependencies": {
     "react": "^18.0.0",

--- a/packages/e2e-tests/helpers/test-app.ts
+++ b/packages/e2e-tests/helpers/test-app.ts
@@ -68,7 +68,7 @@ export default class TestApp {
 
   async query(zed: string): Promise<void> {
     await this.mainWin.locator('div[role="textbox"]').fill(zed)
-    await this.mainWin.locator('div[aria-label="editor"] + button').click()
+    await this.mainWin.locator('[aria-label="run-query"]').click()
     await this.mainWin.locator('span[aria-label="fetching"]').isHidden()
   }
 

--- a/src/app/query-home/title-bar/query-actions.tsx
+++ b/src/app/query-home/title-bar/query-actions.tsx
@@ -36,6 +36,7 @@ const RunButton = styled(Button)`
 function Run() {
   return (
     <RunButton
+      aria-label="run-query"
       onClick={() => runQuery.run()} // 🎶
       icon="run"
       iconSize={16}

--- a/yarn.lock
+++ b/yarn.lock
@@ -17348,12 +17348,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zed@brimdata/zed#9c0f0973d6d52095184d11a9eb6c169be58da660":
+"zed@brimdata/zed#dd3b22dace0fb35bb87ee1b4b9f667ec40b3527f":
   version: 0.33.0-dev
-  resolution: "zed@https://github.com/brimdata/zed.git#commit=9c0f0973d6d52095184d11a9eb6c169be58da660"
+  resolution: "zed@https://github.com/brimdata/zed.git#commit=dd3b22dace0fb35bb87ee1b4b9f667ec40b3527f"
   dependencies:
     zealot: ^0.2.0
-  checksum: 6d3b594a93ecb7c7f5d78568bd5ac41b3cfa97acc2b9f4c517a06c92b037326c705b3d8a3b9ea2f6bd76926acf0e468c1c72cb0749e67b516e2c01739258250f
+  checksum: f7200360da3e54ac07df3028fbf08cd3ac73c0cdbb68854c9a8b4e609f369e30c725f98c77fff4d2a1bae232999fec4152f9a3015f5a79e4584b3565004237a2
   languageName: node
   linkType: hard
 
@@ -17509,7 +17509,7 @@ __metadata:
     web-streams-polyfill: ^3.2.0
     whatwg-fetch: ^3.2.0
     win-7zip: ^0.1.0
-    zed: "brimdata/zed#9c0f0973d6d52095184d11a9eb6c169be58da660"
+    zed: "brimdata/zed#dd3b22dace0fb35bb87ee1b4b9f667ec40b3527f"
     zui-test-data: "workspace:*"
   peerDependencies:
     react: ^18.0.0


### PR DESCRIPTION
The button to run queries was moved in the changes in #2530 which meant the end-to-end tests could no longer locate it to click it. Since the advance of the Zed pointer requires a successful run of the e2e tests, we've been stalled on that for a few days. The fix here just gives the button a label that the e2e test can successfully find. Here's the proof of it succeeding locally:

```
$ yarn e2e

Running 16 tests using 1 worker

  ✓  …ort.spec.ts:36:5 › Export tests › Exporting in zng format succeeds (684ms)
  ✓  …rt.spec.ts:36:5 › Export tests › Exporting in zson format succeeds (875ms)
  ✓  …rt.spec.ts:36:5 › Export tests › Exporting in json format succeeds (883ms)
  ✓  ….spec.ts:36:5 › Export tests › Exporting in ndjson format succeeds (866ms)
  ✓  …ort.spec.ts:36:5 › Export tests › Exporting in csv format succeeds (870ms)
  ✓  …ogram.spec.ts:16:3 › Histogram Spec › Histogram appears for zeek data (2s)
  ✓  …:27:3 › Histogram Spec › Histogram does not appears for non-zeek data (1s)
  ✓  ingest.spec.ts:50:5 › Ingest tests › query000: "* | count()" (385ms)
  ✓  …0:5 › Ingest tests › query001: "* | count() by _path | sort _path" (254ms)
  ✓  ….spec.ts:50:5 › Ingest tests › query002: "_path=="conn" | count()" (234ms)
  ✓  …t ts, id.orig_h, id.orig_p, id.resp_h, id.resp_p, proto | sort ts" (303ms)
  ✓  …est tests › query004: "_path=="x509" or _path=="ssl" | sort _path" (261ms)
  ✓  …sts › session queries are the default and ordered properly in history (2s)
  ✓  …' creation, modification, update/save, proper outdated status display (2s)
  ✓  …ec.ts:72:3 › Query tests › named query, save as => new named query (397ms)
  ✓  …ts:14:3 › Handle Zed server events › pool-new/update/delete/commit (199ms)

  16 passed (33s)
```

Fixes #2534