### PR TITLE
Construct lake URL without trailing colon if port is empty

### DIFF
--- a/src/js/components/LakeModals/ViewLakeModal.tsx
+++ b/src/js/components/LakeModals/ViewLakeModal.tsx
@@ -160,7 +160,10 @@ const ViewLake = ({onClose, onEdit}) => {
           <p>{wsStatus || "unknown"}</p>
         </Status>
         <LakeFields>
-          <Field label="Lake URL" value={[host, port].join(":")} />
+          <Field
+            label="Lake URL"
+            value={port ? [host, port].join(":") : host}
+          />
           <Field label="Zed Version" value={version} />
           <Field label="Pools" value={`${poolCount}`} />
         </LakeFields>


### PR DESCRIPTION
In my fix I mimicked this pattern:

https://github.com/brimdata/brim/blob/e17764cf31b094d2acbf4270780500ebf95a6724/src/js/components/LakeModals/LakeForm.tsx#L198

Fixes #2543