### PR TITLE
Unique App Ids for Zui

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   release:
     strategy:
       matrix:
-        platform: [windows-2019]
+        platform: [macos-11, ubuntu-20.04, windows-2019]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout Zui

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   release:
     strategy:
       matrix:
-        platform: [macos-11, ubuntu-20.04, windows-2019]
+        platform: [windows-2019]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout Zui

--- a/electron-builder-insiders.json
+++ b/electron-builder-insiders.json
@@ -1,5 +1,6 @@
 {
   "extends": "./electron-builder.json",
+  "appId": "io.brimdata.zui-insiders",
   "mac": {
     "icon": "build/insiders/icon.icns"
   },

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -1,5 +1,5 @@
 {
-  "appId": "com.electron.brim",
+  "appId": "io.brimdata.zui",
   "asar": true,
   "asarUnpack": ["zdeps", "LICENSE.txt", "acknowledgments.txt"],
   "directories": {"output": "dist/installers"},


### PR DESCRIPTION
It looks like windows pays attention to the appId property in the electron builder config. It was set to "com.electron.brim" for Brim v30, Zui v1, and Zui-Insiders. This looks like the reason they were overwriting the folders.

Each one now has a unique app id.

It'd be good to check the auto-update behavior again before releasing Zui Stable. I expect it would be fine, but who knows.

Actually, since I've changed the appId for zui-insiders as well,  we can see what happens when zui-insiders updates after this merges. If that works fine, then Zui will work fine as well. 

fixes #2459 