### PR TITLE
Alternate download URL for Zui Insiders

### DIFF
--- a/src/app/core/links.ts
+++ b/src/app/core/links.ts
@@ -9,4 +9,5 @@ export default {
   ZED_DOCS_FORMATS_ZNG: `https://zed.brimdata.io/docs/${zedDocsTag}/formats/zng`,
   ZED_DOCS_FORMATS_ZSON: `https://zed.brimdata.io/docs/${zedDocsTag}/formats/zson`,
   ZED_DOCS_FORMATS_ZST: `https://zed.brimdata.io/docs/${zedDocsTag}/formats/zst`,
+  ZUI_DOWNLOAD: `https://www.brimdata.io/download/`,
 }

--- a/src/js/electron/autoUpdater.ts
+++ b/src/js/electron/autoUpdater.ts
@@ -7,6 +7,8 @@ import get from "lodash/get"
 import semver from "semver/preload"
 import open from "../lib/open"
 import {BrimMain} from "./brim"
+import links from "src/app/core/links"
+import brimPackage from "../../../package.json"
 
 const getFeedURLForPlatform = (repo, platform) => {
   return `https://update.electronjs.org/${repo}/${platform}/${app.getVersion()}`
@@ -45,7 +47,10 @@ const autoUpdateLinux = async (main: BrimMain) => {
   }
 
   dialog.showMessageBox(dialogOpts).then((returnValue) => {
-    const navUrl = "https://www.brimdata.io/download/"
+    const navUrl =
+      brimPackage.name == "zui-insiders"
+        ? brimPackage.repository + "/releases"
+        : links.ZUI_DOWNLOAD
     if (returnValue.response === 0) open(navUrl)
   })
 }


### PR DESCRIPTION
Fixes #2550

To test I first created a "regular" Zui build based on this branch and installed it on Linux (artifacts [here](https://github.com/brimdata/brim/actions/runs/3155040567)). Since the `version` in `package.json` is still set to `0.30.0`, we see the pop-up that redirects to the Download page on brimdata.io when clicked, just as before.

https://user-images.githubusercontent.com/5934157/193157427-1a7ce53b-f36f-4f87-8b53-2b878cd2cdfa.mp4

Then I created a Zui Insiders dev build with a locked in version string that's older than the latest one available in GitHub (artifacts [here](https://github.com/brimdata/zui-insiders/actions/runs/3155037662)). Now when we click the link in the pop up, it goes to the GitHub Releases page where the user should see the latest available version.

https://user-images.githubusercontent.com/5934157/193160068-8efd6179-ad12-4b44-acd0-52d84f1eef4a.mp4

