### PR TITLE
zealot: don't include Content-Type header in load request

### DIFF
--- a/packages/zealot/src/client/client.ts
+++ b/packages/zealot/src/client/client.ts
@@ -172,8 +172,13 @@ export class Client {
     const clearTimer = this.setTimeout(() => abortCtl.abort(), opts.timeout)
     const fetch = (opts.fetch || this.fetch) as Types.NodeFetch // Make typescript happy
     const headers = new Headers(opts.headers)
-    if (opts.contentType) headers.set("Content-Type", opts.contentType)
     headers.set("Accept", accept(opts.format || "zjson"))
+    if (opts.contentType) {
+      headers.set("Content-Type", opts.contentType)
+    }
+    if (this.auth) {
+      headers.set("Authorization", `Bearer ${this.auth}`)
+    }
 
     const resp = await fetch(this.baseURL + opts.path, {
       method: opts.method,
@@ -187,10 +192,6 @@ export class Client {
     } else {
       return Promise.reject(createError(await parseContent(resp)))
     }
-  }
-
-  private get authHeader() {
-    return this.auth ? {Authorization: `Bearer ${this.auth}`} : undefined
   }
 
   private setTimeout(fn: () => void, ms?: number) {

--- a/packages/zealot/src/client/client.ts
+++ b/packages/zealot/src/client/client.ts
@@ -52,9 +52,8 @@ export class Client {
     if (!pool) throw new Error("Missing required option 'pool'")
     const poolId = typeof pool === "string" ? pool : pool.id
     const branch = opts.branch || "main"
-    const headers = opts.message
-      ? {"Zed-Commit": json(opts.message)}
-      : undefined
+    let headers = <any>{"Content-Type": ""}
+    if (opts.message) headers["Zed-Commit"] = json(opts.message)
     const res = await this.send({
       path: `/pool/${poolId}/branch/${encodeURIComponent(branch)}`,
       method: "POST",


### PR DESCRIPTION
Zealot's Client.load method sends a "Content-Type: application/json" request header even though we want the Zed lake service to perform format auto-detection for these requests.  Sending that header isn't a problem right now because the load endpoint ignores the Content-Type header and always does auto-detection, but brimdata/zed#4160 will change the load endpoint to respect that header and do auto-detection only if it's absent or empty.  In preparation for that, change Client.load to omit the Content-Type header so the service will continue to do auto-detection.