### PR TITLE
For Zui Insiders update notice on Linux, point to /releases/latest

### DIFF
--- a/src/js/electron/autoUpdater.ts
+++ b/src/js/electron/autoUpdater.ts
@@ -49,7 +49,7 @@ const autoUpdateLinux = async (main: BrimMain) => {
   dialog.showMessageBox(dialogOpts).then((returnValue) => {
     const navUrl =
       brimPackage.name == "zui-insiders"
-        ? brimPackage.repository + "/releases"
+        ? brimPackage.repository + "/releases/latest"
         : links.ZUI_DOWNLOAD
     if (returnValue.response === 0) open(navUrl)
   })


### PR DESCRIPTION
While writing the Release Note for the fix to #2459, I noticed something annoying with the GitHub Releases page that just started happening when we crossed over into the 100th Zui Insiders release: If you go to https://github.com/brimdata/zui-insiders/releases, the top entry shown appears to be based on an alphanumeric sort, whereas I was expecting a sort perhaps by creation date. Thankfully, the "find a release" tool still works there if someone knows the number of a newer release they were expecting to see, and the hyperlink behind **Releases > Latest** on https://github.com/brimdata/zui-insiders still goes to the most recent release. But the change I put up in #2566 to send Linux users to https://github.com/brimdata/zui-insiders/releases is no longer as helpful.

Thankfully, a URL ending in `/releases/latest` does redirect automatically to the correct place, so that seems like a solid fix. I tested the patch with a test Linux build in my "upgrade-test" repo and you can see in the attached video where it resolves the URL.

https://user-images.githubusercontent.com/5934157/199323680-340b2ad8-27dd-4adf-807b-6326a5e6fb83.mp4
