### PR TITLE
Set unique appId for Zui Insiders & draft Release Note

### DIFF
--- a/electron-builder-insiders.json
+++ b/electron-builder-insiders.json
@@ -1,5 +1,6 @@
 {
   "extends": "./electron-builder.json",
+  "appId": "io.brimdata.zui-insiders",
   "mac": {
     "icon": "build/insiders/icon.icns"
   },


### PR DESCRIPTION
See https://github.com/brimdata/brim/issues/2459#issuecomment-1287473622 for the full details on this small change.

The tl;dr is that this setting of a unique `appId` for Zui Insiders is expected to resolve #2459 by allowing Zui Insiders and Brim/Zui to now be simultaneously installed on Windows. A smooth transition will require some care/steps on the part of Zui Insiders on Windows and macOS. Therefore, this PR will only be merged after communicating in advance to the existing Zui Insiders user base on Slack.

Below is a draft of the communications I'd plan to send on Slack before the change. Once this change is merged and a Zui Insiders release with the new `appId` is created, I'll put the same text as its Release Note on GitHub. Please comment in this issue with any questions or proposed changes to the draft below.

---
# Notice of Disruptive Change -- Action Advised

## Summary

Zui Insiders is intended to be installable and runnable alongside a regular Brim app release or the upcoming Zui v1.0.0 release. However, a known issue [brim/2459](https://github.com/brimdata/brim/issues/2459) has so far made this impossible on the Windows operating system.

To resolve the problem, an upcoming Zui Insiders release will contain a new unique ["application id"](https://www.electron.build/configuration/configuration.html#configuration) (appId) to differentiate it from the regular Brim/Zui releases. Unfortunately, testing has revealed that auto-update from a Zui Insiders release with the old appId to a release with the new one is not a seamless transition on Windows and macOS. The following sections describe how to complete the the one-time transition via a few manual steps.

Note that testing has confirmed that Linux users should _not_ be affected by this transition and can upgrade Zui Insiders as usual to complete this one-time transition.

## General Guidance

Windows and macOS users can have the smoothest possible transition if they avoid allowing an auto-update to the Zui Insiders release that has the updated appId. To help make this possible, an announcement will be made on the **#zui-insiders** channel on the [Brim public Slack](https://www.brimdata.io/join-slack/) the day before the release of the Zui Insiders that has the updated appId. When you've finished your work in Zui Insiders on that day, users are advised to exit and manually uninstall Zui Insiders. Saved Zed lake data and app settings will _not_ be affected by the uninstall, as these are stored separately from application binaries.

Once the new Zui Insiders with the updated appId has been released, an announcement will be made on the **#zui-insiders** channel, at which time users should manually download and install that release. This completes the transition and Zui Insiders auto-updates are expected to work seamlessly going forward, and side-by-side installation of the regular Brim app alongside Zui Insiders will then be possible on Windows.

If you should happen to have kept your Zui Insiders open on Windows or macOS such that it does attempt an auto-update to the new release, additional steps are necessary. See the following sections for guidance specific to your operating system.

## Windows Guidance

During a normal auto-update, the entry for the newer Zui Insiders in the Windows **Programs** list replaces the entry for the previous release. However, if an auto-update occurs during this one-time appId transition, repeat entries will appear in the **Programs** list, such as shown in the following screenshot. In this example, release "115" had the old appId and "116" has the new one.

![image](https://user-images.githubusercontent.com/5934157/199135720-9ec3f57a-e2e0-4651-ba68-278ed2b98717.png)

Testing has revealed that the older entry is effectively benign, such that when a release "117" is posted it would replace the entry for "116", and so on, with the "115" entry effectively being orphaned indefinitely. However, in addition to being confusing/unsightly clutter, the clashing appId values create a hazard such that clicking **Uninstall** on the old release will actually remove the binaries for the newer release. To avoid this hazard and remove the clutter, complete the following steps.

1. Click the entry for the newer release ("116" in this case) in **Programs** and select **Uninstall**.
2. Download and install the `.exe` package for the older release ("115" in this case) from the [Zui Insiders Releases](https://github.com/brimdata/zui-insiders/releases) page on GitHub.
3. Click the entry for the older release you just installed ("115" in this case") in **Programs** and select **Uninstall**. At this point the **Programs** list will be clear of all Zui Insiders entries, though your saved Zed lake data and app settings will have remained intact at their separate location.
4. Download and install the `.exe` package for the [newest Zui Insiders](https://github.com/brimdata/zui-insiders/releases/latest).
6. You can also now install the [newest Brim app](https://github.com/brimdata/brim/releases/latest) and it will no longer conflict with Zui Insiders.

## macOS Guidance

During a normal auto-update, the entry for the newer Zui Insiders in the macOS **Applications** list replaces the entry for the previous release. However, during this one-time transition, if the app pops up a notice regarding the  new release for auto-update, when you eventually exit and relaunch the app, you will be running the older release and the pop-up will appear once again. To break this cycle:

1. Exit Zui Insiders.
2. Uninstall Zui Insiders (e.g., right-click its entry in the **Applications** list and select **Move to Trash**). At this point the **Applications** list will be clear of all Zui Insiders entries, though your saved Zed lake data and app settings will have remained intact at their separate location.
3. Download and install the `.dmg` package for the [newest Zui Insiders](https://github.com/brimdata/zui-insiders/releases/latest).

There's never been a problem on macOS with Zui Insiders and the regular Brim app installing/running side-by-side, so an installed Brim app will be undisturbed by the steps above. If the regular Brim app is not already present, you can safely install it at any time.

## Linux Guidance

As stated above, testing has confirmed that this problem does not affect Linux. As auto-update is not available in Linux, your upgrade path through this one-time appId transition is the same as always, i.e., uninstall any current Zui Insiders release and then install the `.deb` or `.rpm` package for the [newest Zui Insiders](https://github.com/brimdata/zui-insiders/releases/latest). If the regular Brim app is not already present, you can safely install it at any time.

---

Fixes #2459