### PR TITLE
Use replacement for deprecated set-output

### DIFF
--- a/.github/workflows/advance-zed.yml
+++ b/.github/workflows/advance-zed.yml
@@ -53,24 +53,24 @@ jobs:
         # Rewrite bare PR numbers as Zed PRs (https://github.com/brimdata/brim/issues/797)
         run: |
           sha="$(jq -r '.client_payload.merge_commit_sha' "${GITHUB_EVENT_PATH}")"
-          echo "::set-output name=sha::$sha"
+          echo "sha=$sha" >> $GITHUB_OUTPUT
           branch="$(jq -r '.client_payload.branch' "${GITHUB_EVENT_PATH}")"
-          echo "::set-output name=branch::$branch"
+          echo "branch=$branch" >> $GITHUB_OUTPUT
           number="$(jq -r '.client_payload.number' "${GITHUB_EVENT_PATH}")"
-          echo "::set-output name=number::$number"
+          echo "number=$number" >> $GITHUB_OUTPUT
           title="$(jq -r '.client_payload.title' "${GITHUB_EVENT_PATH}")"
           title="$(perl -pe 's,(\W+)(#\d+)(\W+),$1brimdata/zed$2$3,g; s,^(#\d+)(\W+),brimdata/zed$1$2,g; s,(\W+)(#\d+),$1brimdata/zed$2,g; s,^(#\d+)$,brimdata/zed$1,g;' <<< "${title}")"
-          echo "::set-output name=title::$title"
+          echo "title=$title" >> $GITHUB_OUTPUT
           body="$(jq -r '.client_payload.body' "${GITHUB_EVENT_PATH}")"
           body="$(perl -pe 's,(\W+)(#\d+)(\W+),$1brimdata/zed$2$3,g; s,^(#\d+)(\W+),brimdata/zed$1$2,g; s,(\W+)(#\d+),$1brimdata/zed$2,g; s,^(#\d+)$,brimdata/zed$1,g;' <<< "${body}")"
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
           body="${body//$'\r'/'%0D'}"
-          echo "::set-output name=body::$body"
+          echo "body=$body" >> $GITHUB_OUTPUT
           url="$(jq -r '.client_payload.url' "${GITHUB_EVENT_PATH}")"
-          echo "::set-output name=url::$url"
+          echo "url=$url" >> $GITHUB_OUTPUT
           user="$(jq -r '.client_payload.user' "${GITHUB_EVENT_PATH}")"
-          echo "::set-output name=user::$user"
+          echo "user=$user" >> $GITHUB_OUTPUT
 
       # This section runs typical CI, with an updated Zed. Most of this
       # is no different than the normal CI flow.

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Extract branch name
-      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
       id: extract_branch
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:


### PR DESCRIPTION
It was recently [announced](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) that the `set-output` syntax is being deprecated in Actions. I tested out the replacement syntax in a personal repo to get a feel for it and it works as described, so here's changes to our own Workflows to adopt the new approach.