### PR TITLE
Upgrade to actions/checkout@v3 in CI

### DIFF
--- a/.github/workflows/advance-zed.yml
+++ b/.github/workflows/advance-zed.yml
@@ -28,7 +28,7 @@ jobs:
 
       # Since we intend to push, we must have a a writable token and
       # minimal git config settings to create commits.
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # ref defaults to github.sha, which is fixed at the time a run
           # is triggered. Using github.ref ensures a run that waits in

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         os: [macos-11, ubuntu-20.04, windows-2019]
     steps:
       - run: git config --global core.autocrlf false
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-zui
       - run: yarn lint
       - run: yarn test

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Upload Documentation to Wiki
         uses: brimdata/github-wiki-publish-action@v1
         with:

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -12,7 +12,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Extract branch name
       run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
       id: extract_branch


### PR DESCRIPTION
v2 is deprecated because it uses Node.js 12, which is no longer supported.

(inspired by https://github.com/brimdata/zed/pull/4185)