### PR TITLE
Start using actions/setup-node@v3 due to deprecation warnings

### DIFF
--- a/.github/actions/setup-zui/action.yml
+++ b/.github/actions/setup-zui/action.yml
@@ -9,7 +9,7 @@ runs:
         go-version: "1.18"
 
     - name: Install Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         cache: yarn
         node-version-file: .node-version

--- a/.github/workflows/advance-zed.yml
+++ b/.github/workflows/advance-zed.yml
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '1.18'
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           cache: yarn
           node-version-file: .node-version


### PR DESCRIPTION
A recent Actions run produced the following warnings during a step that relied on `actions/setup-node@v2`:

```
Warning: The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

I can see that https://github.com/actions/setup-node/pull/587 appears to fix this, so if we move to `@v3` these should go away.