### PR TITLE
Add ZNG and ZSON to file detection test

### DIFF
--- a/src/js/brim/ingest/detectFileTypes.test.ts
+++ b/src/js/brim/ingest/detectFileTypes.test.ts
@@ -10,9 +10,11 @@ const pcap = data.getWebFile("sample.pcap")
 const pcapng = data.getWebFile("sample.pcapng")
 const unknown = data.getWebFile("plain.txt")
 const zeek = data.getWebFile("sample.tsv")
+const zng = data.getWebFile("sample.zng")
+const zson = data.getWebFile("sample.zson")
 
 test("add file types", async () => {
-  const files = [pcap, pcapng, zeek, json, unknown]
+  const files = [pcap, pcapng, zeek, json, unknown, zng, zson]
 
   const types = await detectFileTypes(files)
 
@@ -22,5 +24,7 @@ test("add file types", async () => {
     {type: "log", file: zeek},
     {type: "log", file: json},
     {type: "log", file: unknown},
+    {type: "log", file: zng},
+    {type: "log", file: zson},
   ])
 })


### PR DESCRIPTION
While working on #2596 I noticed that `sample.zng` wasn't actually being used by any of our current tests. However, I've used that specific file in bug repros all the time and link to it often from issues, so I didn't want to propose removing it.

At the same time I found this "detect file types" test where I could put it to work. 😉  I threw in ZSON as well for good measure.