### PR TITLE
Watch for "Load Successful" pop-up after pool creation

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -63,3 +63,5 @@ rules:
     - off
   jest/no-done-callback:
     - off
+  jest/no-standalone-expect:
+    - off

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -63,5 +63,3 @@ rules:
     - off
   jest/no-done-callback:
     - off
-  jest/no-standalone-expect:
-    - off

--- a/packages/e2e-tests/helpers/test-app.ts
+++ b/packages/e2e-tests/helpers/test-app.ts
@@ -8,7 +8,6 @@ import {
   Page,
   _electron as electron,
 } from "playwright-chromium"
-import {expect} from "@playwright/test"
 import env from "../../../src/app/core/env"
 import {itestDir} from "./env"
 
@@ -64,7 +63,7 @@ export default class TestApp {
     ])
 
     await chooser.setFiles(filepaths)
-    await expect(this.mainWin.getByText("Load Successful")).toBeVisible()
+    await this.mainWin.getByText("Load Successful").waitFor()
   }
 
   async chooseFiles(locator, paths: string[]) {

--- a/packages/e2e-tests/helpers/test-app.ts
+++ b/packages/e2e-tests/helpers/test-app.ts
@@ -8,6 +8,7 @@ import {
   Page,
   _electron as electron,
 } from "playwright-chromium"
+import {expect} from "@playwright/test"
 import env from "../../../src/app/core/env"
 import {itestDir} from "./env"
 
@@ -63,7 +64,7 @@ export default class TestApp {
     ])
 
     await chooser.setFiles(filepaths)
-    await this.mainWin.locator("text=Import Complete.").isVisible()
+    await expect(this.mainWin.getByText("Load Successful")).toBeVisible()
   }
 
   async chooseFiles(locator, paths: string[]) {


### PR DESCRIPTION
I was trying my hand at creating an e2e test by going off some existing tests and I was getting unexpected results. It turns out the example I was following may have had problems, as I found that if I replaced the `Import Complete.` in this diff with garbage text, the test still passed without complaint. I looked for other examples and found that changing to `expect(...).toBeVisible()` did what I think was intended, as now it chokes on garbage text but runs successfully when it sees the `Load Successful` pop-up. However, one snag remained in that the linter complained `error:  Expect must be inside of a test block`. I figured out how to adjust the linter rules to allow this, but if there's a better way to go about this, I'm all ears.