### PR TITLE
Check pool load results and wait for pop-ups to clear

### DIFF
--- a/packages/e2e-tests/helpers/test-app.ts
+++ b/packages/e2e-tests/helpers/test-app.ts
@@ -54,7 +54,7 @@ export default class TestApp {
     this.mainWin = await this.getWindowByTitle("Zui")
   }
 
-  async createPool(filepaths: string[]): Promise<void> {
+  async createPool(filepaths: string[], expectedResult = "Load Successful"): Promise<void> {
     await this.mainWin.locator('button[aria-label="create"]').click()
     await this.mainWin.locator('li:has-text("New Pool")').click()
     const [chooser] = await Promise.all([
@@ -63,7 +63,7 @@ export default class TestApp {
     ])
 
     await chooser.setFiles(filepaths)
-    await this.mainWin.getByText("Load Successful").waitFor()
+    await this.mainWin.getByText(expectedResult).waitFor()
   }
 
   async chooseFiles(locator, paths: string[]) {

--- a/packages/e2e-tests/helpers/test-app.ts
+++ b/packages/e2e-tests/helpers/test-app.ts
@@ -54,7 +54,10 @@ export default class TestApp {
     this.mainWin = await this.getWindowByTitle("Zui")
   }
 
-  async createPool(filepaths: string[], expectedResult = "Load Successful"): Promise<void> {
+  async createPool(
+    filepaths: string[],
+    expectedResult = "Load Successful"
+  ): Promise<void> {
     await this.mainWin.locator('button[aria-label="create"]').click()
     await this.mainWin.locator('li:has-text("New Pool")').click()
     const [chooser] = await Promise.all([

--- a/packages/e2e-tests/tests/pool-loads.spec.ts
+++ b/packages/e2e-tests/tests/pool-loads.spec.ts
@@ -20,6 +20,7 @@ test.describe("Pool Loads", () => {
     await app.query("count()")
     const results = await app.getViewerResults()
     expect(results).toEqual(["count", "1"])
+    await app.mainWin.getByText("Load Successful").waitFor({state: "hidden"})
   })
 
   test("load more data into the pool", async () => {
@@ -28,19 +29,19 @@ test.describe("Pool Loads", () => {
       app.mainWin.getByRole("button", {name: "Load Data"}),
       [getPath("prs.json")]
     )
-    await app.find(":text('Load successful')").isVisible()
+    await app.mainWin.getByText("Load Successful").waitFor()
     await app.mainWin.getByRole("button", {name: "Query Pool"}).click()
     await app.query("count()")
     const results = await app.getViewerResults()
     expect(results).toEqual(["count", "2"])
+    await app.mainWin.getByText("Load Successful").waitFor({state: "hidden"})
   })
 
   test("create with bad data deletes pool", async () => {
-    await app.createPool([getPath("soccer-ball.png")])
-    await expect(app.find(":text('Format detection error')")).toBeVisible()
-    await expect(
-      app.mainWin.getByRole("treeitem", {name: "soccer-ball.png"})
-    ).toBeHidden()
+    await app.createPool([getPath("soccer-ball.png")], "Load error")
+    await app.mainWin.getByText("Format detection error").waitFor()
+    await app.mainWin.getByRole("treeitem", {name: "soccer-ball.png"}).waitFor({state: "hidden"})
+    await app.mainWin.getByText("Load error").waitFor({state: "hidden"})
   })
 
   test("load data into pool does not delete pool", async () => {
@@ -50,8 +51,7 @@ test.describe("Pool Loads", () => {
       [getPath("soccer-ball.png")]
     )
     await app.find(":text('Load error')").isVisible()
-    await expect(
-      app.mainWin.getByRole("treeitem", {name: "prs.json"})
-    ).toBeVisible()
+    app.mainWin.getByRole("treeitem", {name: "prs.json"}).waitFor()
+    await app.mainWin.getByText("Load error").waitFor({state: "hidden"})
   })
 })

--- a/packages/e2e-tests/tests/pool-loads.spec.ts
+++ b/packages/e2e-tests/tests/pool-loads.spec.ts
@@ -40,7 +40,9 @@ test.describe("Pool Loads", () => {
   test("create with bad data deletes pool", async () => {
     await app.createPool([getPath("soccer-ball.png")], "Load error")
     await app.mainWin.getByText("Format detection error").waitFor()
-    await app.mainWin.getByRole("treeitem", {name: "soccer-ball.png"}).waitFor({state: "hidden"})
+    await app.mainWin
+      .getByRole("treeitem", {name: "soccer-ball.png"})
+      .waitFor({state: "hidden"})
     await app.mainWin.getByText("Load error").waitFor({state: "hidden"})
   })
 


### PR DESCRIPTION
As observed in a failed test run at https://github.com/brimdata/brim/actions/runs/3586451129, the e2e test that was recently enhanced in #2600 could fail because the loads in quick succession may leave multiple "Load Successful" pop-ups on the screen at once. The failure looked like:

```
$ yarn e2e pool-loads

Running 4 tests using 1 worker

  ✓  1 pool-loads.spec.ts:17:3 › Pool Loads › load data into a pool (1s)
  ✓  2 …-loads.spec.ts:25:3 › Pool Loads › load more data into the pool (732ms)
  ✘  3 …s.spec.ts:38:3 › Pool Loads › create with bad data deletes pool (178ms)
  ✓  4 …ts:46:3 › Pool Loads › load data into pool does not delete pool (420ms)


  1) pool-loads.spec.ts:38:3 › Pool Loads › create with bad data deletes pool ======================

    locator.waitFor: Error: strict mode violation: "text=Load Successful" resolved to 2 elements:
        1) <div role="status" aria-live="polite" class="go141521…>Load successful</div> aka playwright.$("text=Load successful >> nth=0")
        2) <div role="status" aria-live="polite" class="go141521…>Load successful</div> aka playwright.$("text=Load successful >> nth=1")

    =========================== logs ===========================
    waiting for selector "text=Load Successful" to be visible
      strict mode violation: "text=Load Successful" resolved to 2 elements:
        1) <div role="status" aria-live="polite" class="go141521…>Load successful</div> aka playwright.$("text=Load successful >> nth=0")
        2) <div role="status" aria-live="polite" class="go141521…>Load successful</div> aka playwright.$("text=Load successful >> nth=1")

    ============================================================

       at ../helpers/test-app.ts:66

      64 |
      65 |     await chooser.setFiles(filepaths)
    > 66 |     await this.mainWin.getByText("Load Successful").waitFor()
         |                                                     ^
      67 |   }
      68 |
      69 |   async chooseFiles(locator, paths: string[]) {

        at TestApp.createPool (/Users/phil/work/brim/packages/e2e-tests/helpers/test-app.ts:66:53)
        at /Users/phil/work/brim/packages/e2e-tests/tests/pool-loads.spec.ts:39:5


  1 failed
    pool-loads.spec.ts:38:3 › Pool Loads › create with bad data deletes pool =======================
  3 passed (10s)
```

I looked at the [strictness](https://playwright.dev/docs/locators#strictness) docs and did a one-off test to confirm that changing it to `await this.mainWin.getByText("Load Successful").first().waitFor()` did indeed make the test pass again. However, that page also cautions that this approach isn't recommended, and indeed watching the tests run drove this home: The potentially stacked "Load Successful" and/or "Load error" pop-ups from tests that are running in quick succession does indeed seem to make it hazardous to rely on finding any single instance of a pop-up as evidence that a particular test succeeded or failed.

In this PR I've changed the wider test so that it waits for each pop-up to disappear before proceeding with the next test, hence no stacking. This does indeed make everything pass, though with the caveat that it slows things down:

```
$ yarn e2e pool-loads

Running 4 tests using 1 worker

  ✓  1 pool-loads.spec.ts:17:3 › Pool Loads › load data into a pool (8s)
  ✓  2 pool-loads.spec.ts:26:3 › Pool Loads › load more data into the pool (7s)
  ✓  3 …oads.spec.ts:40:3 › Pool Loads › create with bad data deletes pool (5s)
  ✓  4 …ec.ts:47:3 › Pool Loads › load data into pool does not delete pool (5s)

  Slow test file: pool-loads.spec.ts (26s)
  Consider splitting slow test files to speed up parallel execution

  4 passed (29s)
```

Maybe there's a way to speed it up again, though? One thought would be to make the pop-ups click-to-dismiss. That way `createPool()` itself could not only wait on the expected pop-up to appear but could also click to hide it before returning, which could potentially improve the reliability of all the tests that use it.

@jameskerr: Any thoughts?