### PR TITLE
Cleanup Dev Processes

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -14,9 +14,17 @@ async function start() {
     js.waitForOutput(/Watching for file changes/),
     zealot.waitForOutput(/Watching for file changes/),
   ])
+  const livereload = sub(
+    "yarn",
+    "livereload 'dist, packages/zealot/dist'"
+  ).silence()
   log("Launching...")
-  sub("yarn", `electron . ${electronArgs}`).p.on("exit", () => process.exit(0))
-  sub("yarn", "livereload 'dist, packages/zealot/dist'").silence()
+  sub("yarn", `electron . ${electronArgs}`).p.on("exit", () => {
+    js.kill()
+    css.kill()
+    zealot.kill()
+    livereload.kill()
+  })
 }
 
 process.on("SIGINT", () => process.exit(0))

--- a/scripts/util/sub.js
+++ b/scripts/util/sub.js
@@ -39,6 +39,10 @@ class Sub {
       this.waiting = false
     })
   }
+
+  kill() {
+    process.kill(this.p.pid)
+  }
 }
 
 module.exports = (bin, args) => new Sub(bin, args)


### PR DESCRIPTION
I thought that process.exit(0) would terminate any subprocesses that were started from the main process. That is not the case with node.

So now, each process that gets started in the start script, is killed if the app is quit.