### PR TITLE
Add Zeek and ZJSON as export formats

### DIFF
--- a/packages/e2e-tests/tests/export.spec.ts
+++ b/packages/e2e-tests/tests/export.spec.ts
@@ -9,6 +9,8 @@ const tempDir = os.tmpdir()
 const formats = [
   {label: "zng", expectedSize: 3692},
   {label: "zson", expectedSize: 15137},
+  {label: "zjson", expectedSize: 18007},
+  {label: "zeek", expectedSize: 9697},
   {label: "json", expectedSize: 13659},
   {label: "ndjson", expectedSize: 13657},
   {label: "csv", expectedSize: 12208},
@@ -45,8 +47,8 @@ test.describe("Export tests", () => {
         .locator('#app-root button:above(:text("Export"))')
         .first()
         .click()
-      await app.mainWin.locator(`text=${label}`).first().click()
-      await app.mainWin.locator('button:has-text("Export")').click()
+      await app.mainWin.getByRole("radio", {name: `${label}`}).click()
+      await app.mainWin.getByRole("button").filter({hasText: "Export"}).click()
 
       await expect(
         await app.mainWin.locator("text=Export Complete").first()

--- a/packages/zealot/src/client/types.ts
+++ b/packages/zealot/src/client/types.ts
@@ -12,6 +12,7 @@ export type ResponseFormat =
   | "json"
   | "zjson"
   | "zson"
+  | "zeek"
 
 export type QueryOpts = {
   format: ResponseFormat

--- a/packages/zealot/src/client/utils.ts
+++ b/packages/zealot/src/client/utils.ts
@@ -33,6 +33,7 @@ export function accept(format: ResponseFormat) {
     json: "application/json",
     zjson: "application/x-zjson",
     zson: "application/x-zson",
+    zeek: "application/x-zeek",
   }
   const value = formats[format]
   if (!value) {

--- a/src/js/components/ExportModal.tsx
+++ b/src/js/components/ExportModal.tsx
@@ -106,6 +106,14 @@ const ExportModal = ({onClose}) => {
             <label htmlFor="zson">zson</label>
           </RadioItem>
           <RadioItem>
+            <input type="radio" id="zjson" value="zjson" name="format" />
+            <label htmlFor="zjson">zjson</label>
+          </RadioItem>
+          <RadioItem>
+            <input type="radio" id="zeek" value="zeek" name="format" />
+            <label htmlFor="zeek">zeek</label>
+          </RadioItem>
+          <RadioItem>
             <input type="radio" id="json" value="json" name="format" />
             <label htmlFor="json">json</label>
           </RadioItem>


### PR DESCRIPTION
Since https://github.com/brimdata/zed/pull/4246 enabled Zeek as an exportable format over the API, I've added it to the set of permitted export formats in the app.

Since ZJSON was already working in the API and #2601 has it lined up to be an explicit import format, I added that here as an export format as well for consistency.

I updated some of the locators in the e2e test to the improved syntax @jameskerr showed me, which was in one case necessary to make the updated tests pass. I'll point it out in a PR comment.