### PR TITLE
Fix Those Buggy Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "electron-devtools-installer": "^3.2.0",
     "electron-dl": "^3.0.1",
     "electron-localshortcut": "^3.2.1",
-    "electron-log": "^4.2.2",
+    "electron-log": "5.0.0-beta.6",
     "electron-updater": "^4.3.8",
     "event-source-polyfill": "^1.0.25",
     "filter-console": "^0.1.1",

--- a/src/js/detail.tsx
+++ b/src/js/detail.tsx
@@ -6,10 +6,10 @@ import "regenerator-runtime/runtime"
 import BrimTooltip from "./components/BrimTooltip"
 import LogDetailsWindow from "./components/LogDetailsWindow"
 import {Modals} from "./components/Modals"
-import {initDetail} from "./initializers/initDetail"
 import lib from "./lib"
+import initialize from "./initializers/initialize"
 
-initDetail()
+initialize()
   .then(({store, api, pluginManager}) => {
     window.onbeforeunload = () => {
       api.abortables.abortAll()

--- a/src/js/electron/appPathSetup.ts
+++ b/src/js/electron/appPathSetup.ts
@@ -25,7 +25,7 @@ export function appPathSetup() {
   // Logs go under userData, to make finding logs consistent across platforms.
   app.setPath("logs", path.join(app.getPath("userData"), "logs"))
 
-  log.transports.file.resolvePath = (variables) => {
+  log.transports.file.resolvePathFn = (variables) => {
     return path.join(app.getPath("logs"), variables.fileName)
   }
 }

--- a/src/js/electron/brim.ts
+++ b/src/js/electron/brim.ts
@@ -68,8 +68,6 @@ export class BrimMain {
     const visibleWindows = this.windows.where((w) => w.name !== "hidden")
     if (visibleWindows.length === 0) {
       await this.windows.init()
-    } else {
-      visibleWindows.forEach((win) => win.ref.show())
     }
   }
 

--- a/src/js/electron/brim.ts
+++ b/src/js/electron/brim.ts
@@ -68,6 +68,8 @@ export class BrimMain {
     const visibleWindows = this.windows.where((w) => w.name !== "hidden")
     if (visibleWindows.length === 0) {
       await this.windows.init()
+    } else {
+      visibleWindows.forEach((win) => win.ref.show())
     }
   }
 
@@ -84,7 +86,7 @@ export class BrimMain {
   }
 
   async saveSession() {
-    const windowState = await this.windows.serialize()
+    const windowState = this.windows.serialize()
     const mainState = getPersistedGlobalState(this.store.getState())
 
     await this.session.save(encodeSessionState(windowState, mainState))

--- a/src/js/electron/extensions.ts
+++ b/src/js/electron/extensions.ts
@@ -12,6 +12,6 @@ export function installExtensions() {
   return installExtension([REDUX_DEVTOOLS, REACT_DEVELOPER_TOOLS], {
     loadExtensionOptions: {allowFileAccess: true},
   })
-    .then(() => log.info("Devtools loaded"))
-    .catch((err) => log.error("Devtools error occurred: ", err))
+    .then(() => log.info("devtools loaded"))
+    .catch((err) => log.error("devtools error occurred: ", err))
 }

--- a/src/js/electron/ops/open-about-window-op.ts
+++ b/src/js/electron/ops/open-about-window-op.ts
@@ -1,13 +1,18 @@
+import log from "electron-log"
 import {createOperation} from "../operations"
 
 export const openAboutWindowOp = createOperation(
   "openAboutWindow",
-  ({main}) => {
+  async ({main}) => {
     const about = main.windows.all.find((w) => w.name === "about")
     if (about) {
       about.ref.focus()
     } else {
-      main.windows.create("about")
+      try {
+        await main.windows.create("about")
+      } catch (e) {
+        log.error("about window failed to open")
+      }
     }
   }
 )

--- a/src/js/electron/ops/open-detail-window-op.ts
+++ b/src/js/electron/ops/open-detail-window-op.ts
@@ -1,16 +1,11 @@
 import {zjson} from "@brimdata/zealot"
-import {createOperation, createSpecialOperation} from "../operations"
+import {createOperation} from "../operations"
 
 export const openDetailWindow = createOperation(
   "detailWindow.open",
   async ({main}, opts: {value: zjson.Object; url: string}) => {
     const win = await main.windows.create("detail")
-    // or just wait until it's loaded, then send it something
-    setupDetailWindow.return(opts).when((id) => id === win.id)
+    await win.whenInitialized()
+    win.send("detail-window-args", opts)
   }
 )
-
-export const setupDetailWindow = createSpecialOperation<
-  string,
-  {value: zjson.Object; url: string}
->("detailWindow.setup")

--- a/src/js/electron/ops/open-detail-window-op.ts
+++ b/src/js/electron/ops/open-detail-window-op.ts
@@ -1,11 +1,16 @@
 import {zjson} from "@brimdata/zealot"
 import {createOperation} from "../operations"
+import log from "electron-log"
 
 export const openDetailWindow = createOperation(
   "detailWindow.open",
   async ({main}, opts: {value: zjson.Object; url: string}) => {
-    const win = await main.windows.create("detail")
-    await win.whenInitialized()
-    win.send("detail-window-args", opts)
+    try {
+      const win = await main.windows.create("detail")
+      await win.whenInitialized()
+      win.send("detail-window-args", opts)
+    } catch (e) {
+      log.error("detail window failed to open")
+    }
   }
 )

--- a/src/js/electron/ops/open-search-window-op.ts
+++ b/src/js/electron/ops/open-search-window-op.ts
@@ -1,8 +1,13 @@
+import log from "electron-log"
 import {createOperation} from "../operations"
 
 export const openSearchWindowOp = createOperation(
   "openSearchWindow",
   async ({main}) => {
-    return main.windows.create("search")
+    try {
+      await main.windows.create("search")
+    } catch (e) {
+      log.error("search window failed to open")
+    }
   }
 )

--- a/src/js/electron/ops/run-command-op.ts
+++ b/src/js/electron/ops/run-command-op.ts
@@ -1,3 +1,4 @@
+import log from "electron-log"
 import {isString} from "lodash"
 import {Command} from "src/app/commands/command"
 import {createOperation} from "../operations"
@@ -14,8 +15,12 @@ export const runCommandOp = createOperation(
       win.ref.focus()
       sendMessage()
     } else {
-      const newWin = await main.windows.create("search")
-      newWin.ref.webContents.once("did-finish-load", sendMessage)
+      try {
+        const newWin = await main.windows.create("search")
+        newWin.ref.webContents.once("did-finish-load", sendMessage)
+      } catch (e) {
+        log.error("command failed because search window failed to open")
+      }
     }
   }
 )

--- a/src/js/electron/ops/show-preferences-op.ts
+++ b/src/js/electron/ops/show-preferences-op.ts
@@ -1,19 +1,23 @@
+import log from "electron-log"
 import {createOperation} from "../operations"
 
 export const showPreferencesOp = createOperation(
   "showPreferencesOp",
   async ({main}) => {
-    const win = main.windows.byName("search")[0]
+    try {
+      const win = main.windows.byName("search")[0]
 
-    if (win) {
-      win.ref.focus()
-      win.ref.webContents.send("showPreferences")
-    } else {
-      const newWin = await main.windows.create("search")
-
-      newWin.ref.webContents.once("did-finish-load", () => {
-        newWin.ref.webContents.send("showPreferences")
-      })
+      if (win) {
+        win.ref.focus()
+        win.ref.webContents.send("showPreferences")
+      } else {
+        const newWin = await main.windows.create("search")
+        newWin.ref.webContents.once("did-finish-load", () => {
+          newWin.ref.webContents.send("showPreferences")
+        })
+      }
+    } catch (e) {
+      log.error("preferences failed to open")
     }
   }
 )

--- a/src/js/electron/ops/show-release-notes-op.ts
+++ b/src/js/electron/ops/show-release-notes-op.ts
@@ -1,17 +1,21 @@
+import log from "electron-log"
 import {createOperation} from "../operations"
 
 export const showReleaseNotesOp = createOperation(
   "showReleaseNotes",
   async ({main}) => {
-    const win = main.windows.byName("search")[0]
-
-    if (win) {
-      win.ref.webContents.send("showReleaseNotes")
-    } else {
-      const newWin = await main.windows.create("search")
-      newWin.ref.webContents.once("did-finish-load", () => {
-        newWin.ref.webContents.send("showReleaseNotes")
-      })
+    try {
+      const win = main.windows.byName("search")[0]
+      if (win) {
+        win.ref.webContents.send("showReleaseNotes")
+      } else {
+        const newWin = await main.windows.create("search")
+        newWin.ref.webContents.once("did-finish-load", () => {
+          newWin.ref.webContents.send("showReleaseNotes")
+        })
+      }
+    } catch (e) {
+      log.error("release notes failed to open")
     }
   }
 )

--- a/src/js/electron/ops/window-initialized-op.ts
+++ b/src/js/electron/ops/window-initialized-op.ts
@@ -1,0 +1,9 @@
+import {createOperation} from "../operations"
+
+export const windowInitialized = createOperation(
+  "windowInitialized",
+  ({main}, id: string) => {
+    const win = main.windows.find(id)
+    if (win) win.didInitialize()
+  }
+)

--- a/src/js/electron/run-main/run-initializers.ts
+++ b/src/js/electron/run-main/run-initializers.ts
@@ -12,5 +12,5 @@ export async function runInitializers(main: BrimMain) {
       src.initialize(main)
     },
   })
-  log.info(`Initializers loaded`)
+  log.info(`initializers loaded`)
 }

--- a/src/js/electron/run-main/run-main.ts
+++ b/src/js/electron/run-main/run-main.ts
@@ -16,7 +16,7 @@ export async function main(args: Partial<MainArgs> = {}) {
     BOOT: Starts the app
   */
   const mainArgs = {...mainDefaults(), ...args}
-  log.info("Booting main with:", mainArgs)
+  log.info("booting main with:", mainArgs)
   const brim = await boot(mainArgs)
 
   /* 

--- a/src/js/electron/run-main/run-op-listeners.ts
+++ b/src/js/electron/run-main/run-op-listeners.ts
@@ -1,7 +1,7 @@
 import {BrimMain} from "../brim"
 import path from "path"
 import {requireDir} from "../utils/require-dir"
-import {Operation, SpecialOperation} from "../operations"
+import {Operation} from "../operations"
 
 export function runOpListeners(main: BrimMain) {
   return requireDir({
@@ -11,7 +11,6 @@ export function runOpListeners(main: BrimMain) {
       for (const key of Object.keys(exports)) {
         const op = exports[key]
         if (op instanceof Operation) op.listen(main)
-        if (op instanceof SpecialOperation) op.listen()
       }
     },
   })

--- a/src/js/electron/session.ts
+++ b/src/js/electron/session.ts
@@ -57,23 +57,23 @@ async function migrate(appState, migrator): Promise<VersionedState> {
   const state = ensureVersioned(appState)
 
   if (!canMigrate(state)) {
-    log.info("Migrations unsupported version, using fresh state")
+    log.info("migrations unsupported version, using fresh state")
     return freshState(migrator.getLatestVersion())
   }
 
   migrator.setCurrentVersion(state.version)
   const pending = migrator.getPending().length
 
-  log.info(`Migrations pending: ${pending}`)
+  log.info(`migrations pending: ${pending}`)
 
   if (pending) {
     try {
-      log.info("Migrations started")
+      log.info("migrations started")
       const nextState = migrator.runPending(state)
-      log.info(`Migrated to version: ${nextState.version}`)
+      log.info(`migrated to version: ${nextState.version}`)
       return nextState
     } catch (e) {
-      log.error("Unable to Migrate")
+      log.error("unable to migrate")
       log.error(e)
       return freshState(migrator.getLatestVersion())
     }

--- a/src/js/electron/windows/about-window.ts
+++ b/src/js/electron/windows/about-window.ts
@@ -2,6 +2,7 @@ import {WindowName} from "../windows/types"
 import {ZuiWindow} from "./zui-window"
 
 export class AboutWindow extends ZuiWindow {
+  persistable: false
   name: WindowName = "about"
   options = {
     width: 360,

--- a/src/js/electron/windows/create.ts
+++ b/src/js/electron/windows/create.ts
@@ -1,4 +1,3 @@
-import log from "electron-log"
 import {dimensFromSizePosition} from "./dimens"
 import {DetailWindow} from "./detail-window"
 import {SearchWindow} from "./search/search-window"
@@ -19,14 +18,14 @@ export function deserializeWindow(data: SerializedWindow) {
 export function createWindow(name: WindowName, props: WindowProps) {
   switch (name) {
     case "search":
-      return new SearchWindow(props)
+      return new SearchWindow(props).init()
     case "about":
-      return new AboutWindow(props)
+      return new AboutWindow(props).init()
     case "detail":
-      return new DetailWindow(props)
+      return new DetailWindow(props).init()
     case "hidden":
-      return new HiddenWindow(props)
+      return new HiddenWindow(props).init()
     default:
-      log.error("Unknown Window Type: ", name)
+      throw new Error("Unknown Window Type: ", name)
   }
 }

--- a/src/js/electron/windows/window-manager.ts
+++ b/src/js/electron/windows/window-manager.ts
@@ -76,7 +76,7 @@ export class WindowManager {
     if (win) {
       win.state = state
     } else {
-      log.error("No Window Found with id: ", id)
+      log.error("window not found: ", id)
     }
   }
 
@@ -88,16 +88,15 @@ export class WindowManager {
 
   private async register(win: ZuiWindow) {
     this.windows[win.id] = win
-    win.ref.on("closed", () => {
-      console.log("THIS WINDOW WAS CLOSED")
-      this.unregister(win)
-    })
+    win.ref.on("closed", () => this.unregister(win))
     await win.load()
+    log.debug(`window registered:`, {id: win.id, name: win.name})
     return win
   }
 
   private unregister(win: ZuiWindow) {
     delete this.windows[win.id]
+    log.debug(`window unregistered:`, {id: win.id, name: win.name})
     // whenever a window is closed in Linux or Windows check if 'hidden' window is last
     // open, and if so tell it to close so the rest of the app will shutdown
     if (

--- a/src/js/electron/windows/window-manager.ts
+++ b/src/js/electron/windows/window-manager.ts
@@ -7,7 +7,6 @@ import {State} from "src/js/state/types"
 import {ZuiWindow} from "../windows/zui-window"
 import {SerializedWindow, WindowName, WindowsState} from "../windows/types"
 import {createWindow, deserializeWindow} from "./create"
-import env from "src/app/core/env"
 
 /**
  * Listen to the close event in the zui window
@@ -15,7 +14,18 @@ import env from "src/app/core/env"
  * But if it's mac and they close the last window, just hide that last window.
  * The when the app is activated, show that last window.
  * When they click new window, check if there is a hidden search window and show it.
+ *
+ * Maybe saving the state should not be tied to the windows.
+ * Maybe you can just trigger a state save any time, not just during quit.
  */
+
+/* 
+  Keep saved state in memory 
+  Update it all the time when an interested window sends an update,
+  When a sindow closes
+  Write it out occassionally during down time
+  Write it out
+*/
 
 export class WindowManager {
   private windows: WindowsState = {}
@@ -78,16 +88,11 @@ export class WindowManager {
 
   private async register(win: ZuiWindow) {
     this.windows[win.id] = win
-    await win.load()
-    win.ref.on("close", (e) => {
-      if (win.name === "search" && this.byName("search").length === 1) {
-        if (env.isMac) {
-          e.preventDefault()
-          win.ref.hide()
-        }
-      }
+    win.ref.on("closed", () => {
+      console.log("THIS WINDOW WAS CLOSED")
+      this.unregister(win)
     })
-    win.ref.on("closed", () => this.unregister(win))
+    await win.load()
     return win
   }
 

--- a/src/js/electron/windows/window-manager.ts
+++ b/src/js/electron/windows/window-manager.ts
@@ -8,25 +8,6 @@ import {ZuiWindow} from "../windows/zui-window"
 import {SerializedWindow, WindowName, WindowsState} from "../windows/types"
 import {createWindow, deserializeWindow} from "./create"
 
-/**
- * Listen to the close event in the zui window
- * If this is the last window. Run the same thing as if they "quit" the app.
- * But if it's mac and they close the last window, just hide that last window.
- * The when the app is activated, show that last window.
- * When they click new window, check if there is a hidden search window and show it.
- *
- * Maybe saving the state should not be tied to the windows.
- * Maybe you can just trigger a state save any time, not just during quit.
- */
-
-/* 
-  Keep saved state in memory 
-  Update it all the time when an interested window sends an update,
-  When a sindow closes
-  Write it out occassionally during down time
-  Write it out
-*/
-
 export class WindowManager {
   private windows: WindowsState = {}
 

--- a/src/js/electron/windows/zui-window.ts
+++ b/src/js/electron/windows/zui-window.ts
@@ -25,6 +25,25 @@ export abstract class ZuiWindow {
     this.state = props.state
     this.dimens = props.dimens
   }
+  /**
+   * YOU MUST CALL INIT after constructing a window
+   *
+   * This is because the subclasses provide options that
+   * this base class needs access to. The order in which
+   * typescript does initialization requires this.
+   */
+  init() {
+    this.ref = new BrowserWindow({
+      ...this.options,
+      ...getWindowDimens(this.dimens, pickDimens(this.options), getDisplays()),
+    })
+    this.touch()
+    this.ref.on("focus", this.onFocus.bind(this))
+    this.ref.on("close", this.onClose.bind(this))
+    this.ref.on("focus", this.touch.bind(this))
+    enable(this.ref.webContents) // For Remote Module to Work
+    return this
+  }
 
   get destroyed() {
     return this.ref.isDestroyed()
@@ -43,15 +62,6 @@ export abstract class ZuiWindow {
   }
 
   load() {
-    this.ref = new BrowserWindow({
-      ...this.options,
-      ...getWindowDimens(this.dimens, pickDimens(this.options), getDisplays()),
-    })
-    this.touch()
-    this.ref.on("focus", this.onFocus.bind(this))
-    this.ref.on("close", this.onClose.bind(this))
-    this.ref.on("focus", this.touch.bind(this))
-    enable(this.ref.webContents) // For Remote Module to Work
     this.beforeLoad()
     return this.ref.loadFile(this.name + ".html", {
       query: {id: this.id},

--- a/src/js/electron/windows/zui-window.ts
+++ b/src/js/electron/windows/zui-window.ts
@@ -6,6 +6,7 @@ import {WindowName} from "../windows/types"
 import {Dimens, getWindowDimens, pickDimens} from "../windows/dimens"
 import {getDisplays} from "./get-displays"
 import {SerializedWindow, WindowProps} from "./types"
+import {TimedPromise} from "src/util/timed-promise"
 
 export abstract class ZuiWindow {
   abstract name: WindowName
@@ -17,11 +18,20 @@ export abstract class ZuiWindow {
   state: State | undefined
   dimens: Dimens | null = null
   persistable = true
+  initialized = new TimedPromise(60_000)
 
   constructor(props: WindowProps = {}) {
     this.id = props.id || nanoid()
     this.state = props.state
     this.dimens = props.dimens
+  }
+
+  didInitialize() {
+    this.initialized.complete()
+  }
+
+  whenInitialized() {
+    return this.initialized.waitFor()
   }
 
   beforeLoad() {

--- a/src/js/electron/windows/zui-window.ts
+++ b/src/js/electron/windows/zui-window.ts
@@ -26,6 +26,10 @@ export abstract class ZuiWindow {
     this.dimens = props.dimens
   }
 
+  get destroyed() {
+    return this.ref.isDestroyed()
+  }
+
   didInitialize() {
     this.initialized.complete()
   }

--- a/src/js/initializers/initDetail.ts
+++ b/src/js/initializers/initDetail.ts
@@ -1,5 +1,0 @@
-import initialize from "./initialize"
-
-export const initDetail = async () => {
-  return await initialize()
-}

--- a/src/js/initializers/initDetail.ts
+++ b/src/js/initializers/initDetail.ts
@@ -1,18 +1,5 @@
-import {decode, zed} from "@brimdata/zealot"
-import {setupDetailWindow} from "../electron/ops/open-detail-window-op"
-import {viewLogDetail} from "../flows/viewLogDetail"
 import initialize from "./initialize"
 
 export const initDetail = async () => {
-  const {store, api, pluginManager} = await initialize()
-  const setup = await setupDetailWindow.invoke(global.windowId)
-  if (setup) {
-    global.windowHistory.replace(setup.url)
-    const value = decode(setup.value) as zed.Record
-    if (value) {
-      store.dispatch(viewLogDetail(value))
-    }
-  }
-
-  return {store, api, pluginManager}
+  return await initialize()
 }

--- a/src/js/initializers/initIpcListeners.ts
+++ b/src/js/initializers/initIpcListeners.ts
@@ -12,6 +12,8 @@ import initNewSearchTab from "./initNewSearchTab"
 import Editor from "../state/Editor"
 import submitSearch from "src/app/query-home/flows/submit-search"
 import {commands} from "src/app/commands/command"
+import {decode, zed} from "@brimdata/zealot"
+import {viewLogDetail} from "../flows/viewLogDetail"
 
 export default (store: Store) => {
   ipcRenderer.on("focusSearchBar", () => {
@@ -85,5 +87,15 @@ export default (store: Store) => {
 
   ipcRenderer.on("runCommand", (e, id, ...args) => {
     commands.run(id, ...args)
+  })
+
+  ipcRenderer.on("detail-window-args", (e, opts) => {
+    if (opts) {
+      global.windowHistory.replace(opts.url)
+      const value = decode(opts.value) as zed.Record
+      if (value) {
+        store.dispatch(viewLogDetail(value))
+      }
+    }
   })
 }

--- a/src/js/initializers/initialize.ts
+++ b/src/js/initializers/initialize.ts
@@ -11,6 +11,7 @@ import {initAutosave} from "./initAutosave"
 import {featureFlagsOp} from "../electron/ops/feature-flags-op"
 import {commands} from "src/app/commands/command"
 import {menus} from "src/app/menus/create-menu"
+import {windowInitialized} from "../electron/ops/window-initialized-op"
 
 export default async function initialize() {
   const api = new BrimApi()
@@ -29,6 +30,7 @@ export default async function initialize() {
   initAutosave(store)
   commands.setContext(store, api)
   menus.setContext(api)
+  windowInitialized.invoke(global.windowId)
 
   return {store, api, pluginManager}
 }

--- a/src/util/timed-promise.ts
+++ b/src/util/timed-promise.ts
@@ -1,0 +1,32 @@
+export class TimedPromise {
+  private resolve: () => void = () => {}
+  private reject: (e: Error) => void = () => {}
+  private timeout?: number
+  private timeoutId: number | null = null
+  private promise: Promise<void>
+
+  constructor(timeout?: number) {
+    this.timeout = timeout
+    this.promise = new Promise<void>((resolve, reject) => {
+      this.resolve = resolve
+      this.reject = reject
+    })
+  }
+
+  complete() {
+    clearTimeout(this.timeoutId as number)
+    this.resolve()
+  }
+
+  expire() {
+    clearTimeout(this.timeoutId as number)
+    this.reject(new Error(`timeout exceeded ${this.timeout}ms`))
+  }
+
+  waitFor() {
+    if (this.timeout) {
+      this.timeoutId = setTimeout(() => this.expire(), this.timeout)
+    }
+    return this.promise
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6998,10 +6998,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-log@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "electron-log@npm:4.2.2"
-  checksum: b465daa648220508bd4bafb38f9f21b57dd8fb53ce1382fc870f3179d29fa48e494692c04784d0edf2179dceb6544f6a858640563633bf777452ee328722fcd6
+"electron-log@npm:5.0.0-beta.6":
+  version: 5.0.0-beta.6
+  resolution: "electron-log@npm:5.0.0-beta.6"
+  checksum: a54b24a42b69511ece61cd620196f0bdd91a8ea3465ece902c9a2be6d0458b3742b5b4119c139f33e4072ef8e29782d07721e0194fdc60b946b05ab9ccb0acf5
   languageName: node
   linkType: hard
 
@@ -17363,7 +17363,7 @@ __metadata:
     electron-installer-debian: ^3.0.0
     electron-installer-redhat: ^3.0.0
     electron-localshortcut: ^3.2.1
-    electron-log: ^4.2.2
+    electron-log: 5.0.0-beta.6
     electron-mock-ipc: ^0.3.10
     electron-notarize: ^0.2.1
     electron-updater: ^4.3.8


### PR DESCRIPTION
The bug:

When creating a new window, the app took these steps:
1. Load the window
2. Setup a "closed" listener to delete the reference to the window

If you closed the window quickly before it finished loading, the first step would throw an error. The second step would never happen. This lead to us keep around a reference to a destroyed window. 

Any other places in the code that tried to access anything on that window would get the "Object is Destroyed" message.

The fix is to do this:

1. Setup the "closed" listener
2. Load the window

Now, no matter what, when the window is closed, we will remove the reference to it. Just like the electron docs instruct: https://www.electronjs.org/docs/latest/api/browser-window#event-closed

If the load fails, it will throw an error. I've gone to all the places were windows are created and wrapped them in a try catch so that we get helpful error messages.

Fixes #2589