### PR TITLE
Extend timeout on exports

### DIFF
--- a/packages/zealot/package.json
+++ b/packages/zealot/package.json
@@ -52,7 +52,7 @@
     "fkill": "7.2.1",
     "jest": "^27.3.1",
     "npm-run-all": "^4.1.5",
-    "prettier": "^1.19.1",
+    "prettier": "^2.6.2",
     "prettier-eslint": "^8.8.2",
     "rollup": "^2.59.0",
     "serve": "^13.0.2",

--- a/packages/zealot/src/client/client.ts
+++ b/packages/zealot/src/client/client.ts
@@ -81,6 +81,7 @@ export class Client {
       contentType: "application/json",
       format: options.format,
       signal: abortCtl.signal,
+      timeout: options.timeout,
     })
     return new ResultStream(result, abortCtl)
   }
@@ -171,7 +172,10 @@ export class Client {
     contentType?: string
   }) {
     const abortCtl = wrapAbort(opts.signal)
-    const clearTimer = this.setTimeout(() => abortCtl.abort(), opts.timeout)
+    const clearTimer = this.setTimeout(() => {
+      console.error("request timed out:", opts)
+      abortCtl.abort()
+    }, opts.timeout)
     const fetch = (opts.fetch || this.fetch) as Types.NodeFetch // Make typescript happy
     const headers = new Headers(opts.headers)
     headers.set("Accept", accept(opts.format || "zjson"))

--- a/packages/zealot/src/client/types.ts
+++ b/packages/zealot/src/client/types.ts
@@ -18,6 +18,7 @@ export type QueryOpts = {
   format: ResponseFormat
   controlMessages: boolean
   signal?: AbortSignal
+  timeout?: number
 }
 
 export type CreatePoolOpts = {

--- a/src/js/flows/exportResults.ts
+++ b/src/js/flows/exportResults.ts
@@ -42,6 +42,7 @@ export default (
     const res = await zealot.query(exportQuery, {
       format,
       controlMessages: false,
+      timeout: Infinity,
     })
     try {
       await streamPipeline(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1169,7 +1169,7 @@ __metadata:
     lodash: ^4.17.21
     node-fetch: 2
     npm-run-all: ^4.1.5
-    prettier: ^1.19.1
+    prettier: ^2.6.2
     prettier-eslint: ^8.8.2
     rollup: ^2.59.0
     serve: ^13.0.2
@@ -13494,7 +13494,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^1.19.1, prettier@npm:^1.7.0":
+"prettier@npm:^1.7.0":
   version: 1.19.1
   resolution: "prettier@npm:1.19.1"
   bin:


### PR DESCRIPTION
When exporting data, we don't get control messages. This means it could be a long time before the first byte is sent back. By default we have a 60 second timeout. A user recently hit this limit and could not export their data. This PR makes the timeout Infinity for exports.

