### PR TITLE
Windows Hide Exe and Show Context Menu

### DIFF
--- a/packages/zealot/src/lake/lake.ts
+++ b/packages/zealot/src/lake/lake.ts
@@ -50,6 +50,7 @@ export class Lake {
 
     const opts = {
       stdio: ["inherit", "inherit", "inherit"],
+      windowsHide: true,
     }
     // For unix systems, pass posix pipe read file descriptor into lake process.
     // In the event of Brim getting shutdown via `SIGKILL`, this will let lake

--- a/src/app/features/sidebar/queries-section/query-item.tsx
+++ b/src/app/features/sidebar/queries-section/query-item.tsx
@@ -28,7 +28,10 @@ const QueryItem = ({
       innerStyle={style}
       isFolder={node.isInternal}
       onToggle={() => node.toggle()}
-      onContextMenu={() => queryContextMenu.build(tree, node).show()}
+      onContextMenu={(e) => {
+        e.stopPropagation()
+        queryContextMenu.build(tree, node).show()
+      }}
       onSubmit={(name) => node.submit(name)}
       onReset={() => node.reset()}
       onClick={() =>


### PR DESCRIPTION
1. Hide the zed process with windowsHide: true
2. Show the context menu by stoping propagation. There were two context menus that were both trying to show themselves. The one on top now wins and doesn't send the event it's ancestor.

Fixes #2617 
Fixes #2615