### PR TITLE
Rename ZST to VNG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,7 +170,7 @@ questions.
 - Fix an issue where deleting a Space that was shown in the active tab would cause a crash (#1527)
 - Fix an issue where navigating to a workspace that does not exist would cause a crash (#1533)
 - Commas are now stripped when a numeric value is copied into the paste buffer via right-click **Copy** (#1535)
-- Adjust the guidance on the **Import Files** page and add a [wiki article](https://github.com/brimdata/brim/wiki/Importing-CSV%2C-Parquet%2C-and-ZST) with more detail (#1548, #1625, #1626, #1635)
+- Adjust the guidance on the **Import Files** page and add a [wiki article](https://github.com/brimdata/brim/wiki/Importing-CSV%2C-Parquet%2C-and-VNG) with more detail (#1548, #1625, #1626, #1635)
 - Brim is now packaged using [electron-builder](https://www.electron.build/), which streamlines installation and auto-update (#1508)
 - Fix an issue where importing an NDJSON record containing an empty object caused a "Cannot read property 'map' of null" pop-up error (#1581)
 - Remove the legacy approach for applying Zed types to NDJSON input, as this is now done via Zed shapers ([docs](https://github.com/brimdata/zed/blob/v0.30.0/zeek/Shaping-Zeek-NDJSON.md)) (#1580, #1582)

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -20,7 +20,7 @@ effective use of the Brim desktop application and related tools.
 ## User Documentation
 
 - [[Migration for Version 0.29]]
-- [[Importing Parquet and ZST]]
+- [[Importing Parquet and VNG]]
 
 ## Cookbooks
 

--- a/docs/Importing-Parquet-and-VNG.md
+++ b/docs/Importing-Parquet-and-VNG.md
@@ -1,4 +1,4 @@
-# Importing Parquet and ZST
+# Importing Parquet and VNG
 
 - [Summary](#summary)
 - [Example](#example)
@@ -11,7 +11,7 @@ depends on the backend [Zed](https://github.com/brimdata/zed) platform's
 ability to "auto-detect" these formats. While several formats are covered by
 the current auto-detection implementation,
 [Parquet](https://parquet.apache.org/) and
-[ZST](https://zed.brimdata.io/docs/formats/zst/) are not
+[VNG](https://zed.brimdata.io/docs/formats/vng/) are not
 yet (see [zed/2517](https://github.com/brimdata/zed/issues/2517)).
 
 This article shows how the Zed CLI tools can be used to preprocess data of
@@ -37,7 +37,7 @@ USAGE
 
 OPTIONS
 ...
-    -i format of input data [auto,zng,zst,json,zeek,zjson,csv,parquet] (default "auto")
+    -i format of input data [auto,zng,vng,json,zeek,zjson,csv,parquet,line] (default "auto")
 ...
 ```
 

--- a/docs/Importing-Parquet-and-VNG.md
+++ b/docs/Importing-Parquet-and-VNG.md
@@ -11,7 +11,7 @@ depends on the backend [Zed](https://github.com/brimdata/zed) platform's
 ability to "auto-detect" these formats. While several formats are covered by
 the current auto-detection implementation,
 [Parquet](https://parquet.apache.org/) and
-[VNG](https://zed.brimdata.io/docs/formats/vng/) are not
+[VNG](https://zed.brimdata.io/docs/next/formats/vng) are not
 yet (see [zed/2517](https://github.com/brimdata/zed/issues/2517)).
 
 This article shows how the Zed CLI tools can be used to preprocess data of

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -8,7 +8,7 @@
 **User Documentation**
 
 - [[Migration for Version 0.29]]
-- [[Importing Parquet and ZST]]
+- [[Importing Parquet and VNG]]
 
 **Cookbooks**
 

--- a/src/app/core/links.ts
+++ b/src/app/core/links.ts
@@ -9,6 +9,6 @@ export default {
   ZED_DOCS_FORMATS_ZJSON: `https://zed.brimdata.io/docs/${zedDocsTag}/formats/zjson`,
   ZED_DOCS_FORMATS_ZNG: `https://zed.brimdata.io/docs/${zedDocsTag}/formats/zng`,
   ZED_DOCS_FORMATS_ZSON: `https://zed.brimdata.io/docs/${zedDocsTag}/formats/zson`,
-  ZED_DOCS_FORMATS_ZST: `https://zed.brimdata.io/docs/${zedDocsTag}/formats/vng`,
+  ZED_DOCS_FORMATS_VNG: `https://zed.brimdata.io/docs/${zedDocsTag}/formats/vng`,
   ZUI_DOWNLOAD: `https://www.brimdata.io/download/`,
 }

--- a/src/app/core/links.ts
+++ b/src/app/core/links.ts
@@ -9,6 +9,6 @@ export default {
   ZED_DOCS_FORMATS_ZJSON: `https://zed.brimdata.io/docs/${zedDocsTag}/formats/zjson`,
   ZED_DOCS_FORMATS_ZNG: `https://zed.brimdata.io/docs/${zedDocsTag}/formats/zng`,
   ZED_DOCS_FORMATS_ZSON: `https://zed.brimdata.io/docs/${zedDocsTag}/formats/zson`,
-  ZED_DOCS_FORMATS_ZST: `https://zed.brimdata.io/docs/${zedDocsTag}/formats/zst`,
+  ZED_DOCS_FORMATS_ZST: `https://zed.brimdata.io/docs/${zedDocsTag}/formats/vng`,
   ZUI_DOWNLOAD: `https://www.brimdata.io/download/`,
 }


### PR DESCRIPTION
https://github.com/brimdata/zed/pull/4256 handled the bulk of the format rename, so now we need to hit other repos. Right now a changed doc link causes a CI failure here in the app, so that's addressed here.