### PR TITLE
upgrade Zed to 1442bf8189f064e9bfea67e4adf71bc9a22651a8

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     "use-resize-observer": "^8.0.0",
     "valid-url": "^1.0.9",
     "web-file-polyfill": "^1.0.4",
-    "zed": "brimdata/zed#101d3589e615821d3cabc17386b7c6c7d6702128"
+    "zed": "brimdata/zed#1442bf8189f064e9bfea67e4adf71bc9a22651a8"
   },
   "peerDependencies": {
     "react": "^18.0.0",

--- a/packages/e2e-tests/tests/export.spec.ts
+++ b/packages/e2e-tests/tests/export.spec.ts
@@ -7,7 +7,7 @@ import fsExtra from "fs-extra"
 
 const tempDir = os.tmpdir()
 const formats = [
-  {label: "zng", expectedSize: 3643},
+  {label: "zng", expectedSize: 3744},
   {label: "zson", expectedSize: 15137},
   {label: "zjson", expectedSize: 18007},
   {label: "zeek", expectedSize: 9772},

--- a/yarn.lock
+++ b/yarn.lock
@@ -17333,12 +17333,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zed@brimdata/zed#101d3589e615821d3cabc17386b7c6c7d6702128":
+"zed@brimdata/zed#1442bf8189f064e9bfea67e4adf71bc9a22651a8":
   version: 0.33.0-dev
-  resolution: "zed@https://github.com/brimdata/zed.git#commit=101d3589e615821d3cabc17386b7c6c7d6702128"
+  resolution: "zed@https://github.com/brimdata/zed.git#commit=1442bf8189f064e9bfea67e4adf71bc9a22651a8"
   dependencies:
     zealot: ^0.2.0
-  checksum: 667a24765cf8b05b43725be794eebaaaa90be97eb9a255d1c7e0516a781dca2bdec3437cab80fb93d88f1bdb32e29f2734d18e5436d728902f8bd6f5d71e0a77
+  checksum: dba0630b122d1c25cfaa5814c303ce7177b7505d017ab1b5e660929f3ee92283f6a040108f88ca06f19ccc1015b14fcde16d5e0f51c794b4b42f09104f42861e
   languageName: node
   linkType: hard
 
@@ -17494,7 +17494,7 @@ __metadata:
     web-streams-polyfill: ^3.2.0
     whatwg-fetch: ^3.2.0
     win-7zip: ^0.1.0
-    zed: "brimdata/zed#101d3589e615821d3cabc17386b7c6c7d6702128"
+    zed: "brimdata/zed#1442bf8189f064e9bfea67e4adf71bc9a22651a8"
     zui-test-data: "workspace:*"
   peerDependencies:
     react: ^18.0.0


### PR DESCRIPTION
The change to packages/e2e-tests/tests/export.spec.ts reflects a change in the size of ZNG output due to the LZ4 package change in brimdata/zed#4197.