### PR TITLE
Tidy the format selections for load and export

### DIFF
--- a/packages/e2e-tests/tests/export.spec.ts
+++ b/packages/e2e-tests/tests/export.spec.ts
@@ -7,13 +7,13 @@ import fsExtra from "fs-extra"
 
 const tempDir = os.tmpdir()
 const formats = [
-  {label: "zng", expectedSize: 3744},
-  {label: "zson", expectedSize: 15137},
-  {label: "zjson", expectedSize: 18007},
-  {label: "zeek", expectedSize: 9772},
-  {label: "json", expectedSize: 13659},
-  {label: "ndjson", expectedSize: 13657},
-  {label: "csv", expectedSize: 12208},
+  {label: "ZNG", expectedSize: 3744},
+  {label: "ZSON", expectedSize: 15137},
+  {label: "ZJSON", expectedSize: 18007},
+  {label: "Zeek", expectedSize: 9772},
+  {label: "JSON", expectedSize: 13659},
+  {label: "NDJSON", expectedSize: 13657},
+  {label: "CSV", expectedSize: 12208},
 ]
 
 test.describe("Export tests", () => {

--- a/src/components/data-format-select.tsx
+++ b/src/components/data-format-select.tsx
@@ -4,15 +4,15 @@ import SelectInput from "src/js/components/common/forms/SelectInput"
 export function DataFormatSelect(props: JSX.IntrinsicElements["select"]) {
   return (
     <SelectInput {...props}>
-      <option value="auto">Auto detect</option>
-      <option value="csv">csv</option>
-      <option value="json">json</option>
-      <option value="line">line</option>
-      <option value="parquet">parquet</option>
-      <option value="zeek">zeek</option>
-      <option value="zjson">zjson</option>
-      <option value="zng">zng</option>
-      <option value="zson">zson</option>
+      <option value="auto">Auto-detect</option>
+      <option value="csv">CSV</option>
+      <option value="json">JSON</option>
+      <option value="line">Line</option>
+      <option value="parquet">Parquet</option>
+      <option value="zeek">Zeek</option>
+      <option value="zjson">ZJSON</option>
+      <option value="zng">ZNG</option>
+      <option value="zson">ZSON</option>
     </SelectInput>
   )
 }

--- a/src/js/components/ExportModal.tsx
+++ b/src/js/components/ExportModal.tsx
@@ -92,6 +92,26 @@ const ExportModal = ({onClose}) => {
           }}
         >
           <RadioItem>
+            <input type="radio" id="csv" value="csv" name="format" />
+            <label htmlFor="csv">CSV</label>
+          </RadioItem>
+          <RadioItem>
+            <input type="radio" id="json" value="json" name="format" />
+            <label htmlFor="json">JSON</label>
+          </RadioItem>
+          <RadioItem>
+            <input type="radio" id="ndjson" value="ndjson" name="format" />
+            <label htmlFor="ndjson">NDJSON</label>
+          </RadioItem>
+          <RadioItem>
+            <input type="radio" id="zeek" value="zeek" name="format" />
+            <label htmlFor="zeek">Zeek</label>
+          </RadioItem>
+          <RadioItem>
+            <input type="radio" id="zjson" value="zjson" name="format" />
+            <label htmlFor="zjson">ZJSON</label>
+          </RadioItem>
+          <RadioItem>
             <input
               type="radio"
               id="zng"
@@ -99,31 +119,11 @@ const ExportModal = ({onClose}) => {
               name="format"
               defaultChecked
             />
-            <label htmlFor="zng">zng</label>
+            <label htmlFor="zng">ZNG</label>
           </RadioItem>
           <RadioItem>
             <input type="radio" id="zson" value="zson" name="format" />
-            <label htmlFor="zson">zson</label>
-          </RadioItem>
-          <RadioItem>
-            <input type="radio" id="zjson" value="zjson" name="format" />
-            <label htmlFor="zjson">zjson</label>
-          </RadioItem>
-          <RadioItem>
-            <input type="radio" id="zeek" value="zeek" name="format" />
-            <label htmlFor="zeek">zeek</label>
-          </RadioItem>
-          <RadioItem>
-            <input type="radio" id="json" value="json" name="format" />
-            <label htmlFor="json">json</label>
-          </RadioItem>
-          <RadioItem>
-            <input type="radio" id="ndjson" value="ndjson" name="format" />
-            <label htmlFor="ndjson">ndjson</label>
-          </RadioItem>
-          <RadioItem>
-            <input type="radio" id="csv" value="csv" name="format" />
-            <label htmlFor="csv">csv</label>
+            <label htmlFor="zson">ZSON</label>
           </RadioItem>
         </RadioButtons>
       </FormatContent>


### PR DESCRIPTION
As I've been working a lot lately with adding/testing formats for load & export, I've noticed how the Zed docs have been pretty tidy in how formats are typically referenced in alphabetical order and presented with capital letters where appropriate. The one exception is the CLI tooling where they're specified in lowercase, but that seems to be par for the course when it comes to CLI tools. Therefore I'm proposing we go the ordered/caps route in the app so it's consistent with what users see in the docs.