### PR TITLE
Fix broken "Selectors" link

### DIFF
--- a/packages/e2e-tests/README.md
+++ b/packages/e2e-tests/README.md
@@ -42,7 +42,7 @@ await app.find(':text("New Query Session")').click()
 
 https://playwright.dev/docs/api/class-locator
 
-https://playwright.dev/docs/selectors
+https://playwright.dev/docs/other-locators (formerly "Selectors")
 
 https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques
 


### PR DESCRIPTION
https://github.com/brimdata/brim/actions/runs/3719174194/jobs/6307862383 was a recent failed link check run related to a URL pointing to Playwright docs about "Selectors". A little digging found this was an intentional change as described at https://github.com/microsoft/playwright/issues/18992 and https://github.com/microsoft/playwright/pull/19244 so here I've swapped over to the new link destination.