### PR TITLE
Add load/export support for Arrow IPC Stream

### DIFF
--- a/packages/e2e-tests/tests/export.spec.ts
+++ b/packages/e2e-tests/tests/export.spec.ts
@@ -7,13 +7,14 @@ import fsExtra from "fs-extra"
 
 const tempDir = os.tmpdir()
 const formats = [
-  {label: "ZNG", expectedSize: 3744},
-  {label: "ZSON", expectedSize: 15137},
-  {label: "ZJSON", expectedSize: 18007},
-  {label: "Zeek", expectedSize: 9772},
+  {label: "Arrow IPC Stream", expectedSize: 46512},
+  {label: "CSV", expectedSize: 12208},
   {label: "JSON", expectedSize: 13659},
   {label: "NDJSON", expectedSize: 13657},
-  {label: "CSV", expectedSize: 12208},
+  {label: "Zeek", expectedSize: 9772},
+  {label: "ZJSON", expectedSize: 18007},
+  {label: "ZNG", expectedSize: 3744},
+  {label: "ZSON", expectedSize: 15137},
 ]
 
 test.describe("Export tests", () => {

--- a/packages/zealot/src/client/types.ts
+++ b/packages/zealot/src/client/types.ts
@@ -6,13 +6,14 @@ export type ClientOpts = {
 }
 
 export type ResponseFormat =
-  | "zng"
-  | "ndjson"
+  | "arrows"
   | "csv"
   | "json"
-  | "zjson"
-  | "zson"
+  | "ndjson"
   | "zeek"
+  | "zjson"
+  | "zng"
+  | "zson"
 
 export type QueryOpts = {
   format: ResponseFormat
@@ -64,6 +65,7 @@ export type LoadOpts = {
 }
 export type LoadFormat =
   | "auto"
+  | "arrows"
   | "csv"
   | "json"
   | "line"
@@ -75,6 +77,7 @@ export type LoadFormat =
 
 export type LoadContentType =
   | "*/*"
+  | "application/vnd.apache.arrow.stream"
   | "text/csv"
   | "application/json"
   | "application/x-line"

--- a/packages/zealot/src/client/utils.ts
+++ b/packages/zealot/src/client/utils.ts
@@ -27,13 +27,14 @@ export function parseContent(resp: Response | NodeResponse) {
 
 export function accept(format: ResponseFormat) {
   const formats = {
-    zng: "application/x-zng",
-    ndjson: "application/x-ndjson",
+    arrows: "application/vnd.apache.arrow.stream",
     csv: "text/csv",
     json: "application/json",
-    zjson: "application/x-zjson",
-    zson: "application/x-zson",
+    ndjson: "application/x-ndjson",
     zeek: "application/x-zeek",
+    zjson: "application/x-zjson",
+    zng: "application/x-zng",
+    zson: "application/x-zson",
   }
   const value = formats[format]
   if (!value) {
@@ -72,6 +73,7 @@ export function getLoadContentType(
 ): LoadContentType | null {
   if (!format) return null
   if (format === "auto") return "*/*"
+  if (format === "arrows") return "application/vnd.apache.arrow.stream"
   if (format === "csv") return "text/csv"
   if (format === "json") return "application/json"
   if (format === "line") return "application/x-line"

--- a/src/components/data-format-select.tsx
+++ b/src/components/data-format-select.tsx
@@ -5,6 +5,7 @@ export function DataFormatSelect(props: JSX.IntrinsicElements["select"]) {
   return (
     <SelectInput {...props}>
       <option value="auto">Auto-detect</option>
+      <option value="arrows">Arrow IPC Stream</option>
       <option value="csv">CSV</option>
       <option value="json">JSON</option>
       <option value="line">Line</option>

--- a/src/js/components/ExportModal.tsx
+++ b/src/js/components/ExportModal.tsx
@@ -92,6 +92,10 @@ const ExportModal = ({onClose}) => {
           }}
         >
           <RadioItem>
+            <input type="radio" id="arrows" value="arrows" name="format" />
+            <label htmlFor="arrows">Arrow IPC Stream</label>
+          </RadioItem>
+          <RadioItem>
             <input type="radio" id="csv" value="csv" name="format" />
             <label htmlFor="csv">CSV</label>
           </RadioItem>

--- a/src/js/flows/exportResults.ts
+++ b/src/js/flows/exportResults.ts
@@ -25,7 +25,7 @@ function cutColumns(program, columns) {
 
 export function prepareProgram(format, program, columns) {
   let p = cutColumns(program, columns)
-  if (format === "csv") p += " | fuse"
+  if (format === "csv" || format === "arrows") p += " | fuse"
   return p
 }
 


### PR DESCRIPTION
https://github.com/brimdata/zed/pull/4252 added support for loading/querying in Arrow IPC Stream in Zed, so here we add support for it in the app as well.