### PR TITLE
Named Types Bug Fix

### DIFF
--- a/packages/e2e-tests/helpers/test-app.ts
+++ b/packages/e2e-tests/helpers/test-app.ts
@@ -58,7 +58,7 @@ export default class TestApp {
     filepaths: string[],
     expectedResult = "Load Successful"
   ): Promise<void> {
-    await this.mainWin.locator('button[aria-label="create"]').click()
+    await this.mainWin.getByRole("button", {name: "create"}).click()
     await this.mainWin.locator('li:has-text("New Pool")').click()
     const [chooser] = await Promise.all([
       this.mainWin.waitForEvent("filechooser"),
@@ -132,6 +132,10 @@ export default class TestApp {
 
   sleep(ms: number) {
     return new Promise((resolve) => setTimeout(resolve, ms))
+  }
+
+  get results() {
+    return this.mainWin.getByTestId("results-pane")
   }
 }
 

--- a/packages/e2e-tests/tests/table.spec.ts
+++ b/packages/e2e-tests/tests/table.spec.ts
@@ -1,0 +1,24 @@
+import {expect, test} from "@playwright/test"
+import {getPath} from "packages/zui-test-data"
+import TestApp from "../helpers/test-app"
+
+test.describe("Table Testing", () => {
+  const app = new TestApp("Table Testing")
+
+  test.beforeAll(async () => {
+    await app.init()
+  })
+
+  test.afterAll(async () => {
+    await app.shutdown()
+  })
+
+  test("named type shows columns", async () => {
+    const path = getPath("named-type.zson")
+    await app.createPool([path])
+    await app.mainWin.getByRole("button", {name: "Query Pool"}).click()
+    await app.query("yield value.after") // This is a named type
+    const texts = await app.results.getByRole("columnheader").allInnerTexts()
+    expect(texts).toEqual(["Id", "IsDeleted"])
+  })
+})

--- a/packages/zealot/src/zed/index.ts
+++ b/packages/zealot/src/zed/index.ts
@@ -80,4 +80,5 @@ export * from "./utils/true-type"
 export * from "./utils/base-value"
 export * from "./utils/is-container"
 export * from "./utils/is-value"
+export * from "./utils/typeunder"
 export type Any = Type | Value

--- a/packages/zealot/src/zed/utils/typeunder.ts
+++ b/packages/zealot/src/zed/utils/typeunder.ts
@@ -1,0 +1,10 @@
+import {Any} from "../index"
+import {TypeAlias} from "../types/type-alias"
+
+export function typeunder(value: Any): Any {
+  if (value instanceof TypeAlias) {
+    return typeunder(value.type)
+  } else {
+    return value
+  }
+}

--- a/packages/zui-test-data/data/named-type.zson
+++ b/packages/zui-test-data/data/named-type.zson
@@ -1,0 +1,9 @@
+{
+    value: {
+        before: null (myValue={Id:int32,IsDeleted:bool}),
+        after: {
+            Id: 1,
+            IsDeleted: false
+        } (myValue)
+    }
+}

--- a/packages/zui-test-data/index.d.ts
+++ b/packages/zui-test-data/index.d.ts
@@ -1,0 +1,1 @@
+export declare function getPath(name: string): string

--- a/packages/zui-test-data/package.json
+++ b/packages/zui-test-data/package.json
@@ -1,5 +1,6 @@
 {
   "version": "1.0.0",
   "name": "zui-test-data",
-  "main": "index.js"
+  "main": "index.js",
+  "types": "index.d.ts"
 }

--- a/src/components/zed-table/header-cell.tsx
+++ b/src/components/zed-table/header-cell.tsx
@@ -15,6 +15,7 @@ export function HeaderCell({header}: {header: Header<any, any>}) {
   const width = header.getSize()
   return (
     <div
+      role="columnheader"
       className={classNames("zed-table__header-cell", {
         isPlaceholder,
         hasChildren,

--- a/src/panes/results-pane/results-pane.tsx
+++ b/src/panes/results-pane/results-pane.tsx
@@ -9,7 +9,7 @@ import {TableInspector} from "./table-inspector"
 export function ResultsPane() {
   const ref = useRef()
   return (
-    <div ref={ref} className="results-pane" data-test-locator="viewer_results">
+    <div ref={ref} className="results-pane" data-testid="results-pane">
       <AppErrorBoundary>
         <ResultsPaneProvider parentRef={ref}>
           <ResultsView />

--- a/src/panes/results-pane/table-controller.tsx
+++ b/src/panes/results-pane/table-controller.tsx
@@ -55,13 +55,16 @@ export function useTableHandlers() {
   )
 }
 
-export function useTableValues() {
-  const ctx = useResultsPaneContext()
+export function useTableValues(shape: zed.Any, values: zed.Value[]) {
   return useMemo(() => {
-    if (ctx.isSingleShape && !(ctx.firstShape instanceof zed.TypeRecord)) {
-      return ctx.values.map((value) => createRecord({this: value}))
+    if (shape instanceof zed.TypeRecord) {
+      return values
     } else {
-      return ctx.values
+      return values.map((value) => createRecord({this: value}))
     }
-  }, [ctx.values, ctx.isSingleShape, ctx.firstShape])
+  }, [shape, values])
+}
+
+export function useTableShape(shape: zed.Type) {
+  return useMemo(() => zed.typeunder(shape) as zed.Type, [shape])
 }

--- a/src/panes/results-pane/table-controller.tsx
+++ b/src/panes/results-pane/table-controller.tsx
@@ -64,7 +64,3 @@ export function useTableValues(shape: zed.Any, values: zed.Value[]) {
     }
   }, [shape, values])
 }
-
-export function useTableShape(shape: zed.Type) {
-  return useMemo(() => zed.typeunder(shape) as zed.Type, [shape])
-}

--- a/src/panes/results-pane/table.tsx
+++ b/src/panes/results-pane/table.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useMemo} from "react"
 import {useResultsContext} from "src/app/query-home"
 import {useResultsPaneContext} from "./context"
-import {useTableState, useTableValues} from "./table-controller"
+import {useTableShape, useTableState, useTableValues} from "./table-controller"
 import {useDispatch} from "src/app/core/state"
 import TableState from "src/js/state/Table"
 import {headerContextMenu} from "src/app/menus/header-context-menu"
@@ -18,7 +18,8 @@ export function Table() {
   const {table, setTable} = useResultsContext()
   const ctx = useResultsPaneContext()
   const api = useBrimApi()
-  const values = useTableValues()
+  const shape = useTableShape(ctx.firstShape)
+  const values = useTableValues(shape, ctx.values)
   const state = useTableState()
   const select = useSelect()
   const initialScrollPosition = useMemo(
@@ -26,7 +27,6 @@ export function Table() {
     []
   )
   const dispatch = useDispatch()
-  const shape = ctx.firstShape
 
   useEffect(() => {
     dispatch(TableState.setLastShape(shape))

--- a/src/panes/results-pane/table.tsx
+++ b/src/panes/results-pane/table.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useMemo} from "react"
 import {useResultsContext} from "src/app/query-home"
 import {useResultsPaneContext} from "./context"
-import {useTableShape, useTableState, useTableValues} from "./table-controller"
+import {useTableState, useTableValues} from "./table-controller"
 import {useDispatch} from "src/app/core/state"
 import TableState from "src/js/state/Table"
 import {headerContextMenu} from "src/app/menus/header-context-menu"
@@ -13,13 +13,15 @@ import {BareStringView} from "src/app/query-home/results/bare-string-view"
 import {PathView} from "src/app/query-home/results/path-view"
 import {openLogDetailsWindow} from "src/js/flows/openLogDetailsWindow"
 import {viewLogDetail} from "src/js/flows/viewLogDetail"
+import {zed} from "@brimdata/zealot"
 
 export function Table() {
   const {table, setTable} = useResultsContext()
   const ctx = useResultsPaneContext()
   const api = useBrimApi()
-  const shape = useTableShape(ctx.firstShape)
-  const values = useTableValues(shape, ctx.values)
+  const shape = ctx.firstShape
+  const recordShape = zed.typeunder(shape) as zed.TypeRecord
+  const values = useTableValues(recordShape, ctx.values)
   const state = useTableState()
   const select = useSelect()
   const initialScrollPosition = useMemo(
@@ -41,7 +43,7 @@ export function Table() {
         setTable(table)
         api.table = table
       }}
-      shape={shape}
+      shape={recordShape}
       values={values}
       width={ctx.width}
       height={ctx.height}

--- a/src/zui-kit/react/table-view.tsx
+++ b/src/zui-kit/react/table-view.tsx
@@ -31,6 +31,7 @@ export const TableView = forwardRef(function TableView(
   return (
     <Provider value={api}>
       <div
+        role="table"
         className={classNames("zed-table", {
           "zed-table--resizing": api.isResizing,
         })}


### PR DESCRIPTION
When determining if values can be rendered as a table, we look at the shapes of data returned. If there is one shape, then we render it as a table. If that shape is a record, we render the record's fields as the columns of the table. The previous code did not take into account the fact that the record might be a TypeAlias instead of a TypeRecord. So now we use a new function called `typeunder` which returns the underlying type if the parameter happens to be a TypeAlias. It's recursive so it will keep going until it doesn't reach a TypeAlias class.

Fixes #2645

## A Named Type in the Inspector
<img width="391" alt="Screenshot 2023-02-01 at 4 10 18 PM" src="https://user-images.githubusercontent.com/3460638/216199978-3ede89ec-8f4d-4a8b-8181-edf349c0eaa0.png">

## A Named Type in the Table
<img width="300" alt="CleanShot 2023-02-01 at 16 21 41@2x" src="https://user-images.githubusercontent.com/3460638/216199868-3e1e3f70-5d43-4a36-a8b5-f552ac06e080.png">


