### PR TITLE
Quit the App in a Sane Way

### DIFF
--- a/src/js/electron/brim-start.test.ts
+++ b/src/js/electron/brim-start.test.ts
@@ -45,7 +45,7 @@ test("activates shows the window", async () => {
   app.emit("activate")
   expect(brim.windows.visible).toHaveLength(1)
   brim.windows.visible.forEach((win) => {
-    expect(win.ref.show).toHaveBeenCalled()
+    expect(win.ref.isVisible()).toBe(true)
   })
 })
 
@@ -81,7 +81,7 @@ test("last window closed hides on mac", async () => {
   brim.windows.emit("window-will-close", {preventDefault})
 
   expect(preventDefault).toHaveBeenCalled()
-  expect(brim.windows.visible[0].ref.hide).toHaveBeenCalled()
+  expect(brim.windows.visible[0].ref.isVisible()).toBe(false)
   expect(app.quit).not.toHaveBeenCalled()
 })
 
@@ -97,6 +97,6 @@ test("last window quits on not mac", async () => {
   brim.windows.emit("window-will-close", {preventDefault})
 
   expect(preventDefault).toHaveBeenCalled()
-  expect(brim.windows.visible[0].ref.hide).not.toHaveBeenCalled()
+  expect(brim.windows.visible[0].ref.isVisible()).toBe(true)
   expect(app.quit).toHaveBeenCalled()
 })

--- a/src/js/electron/brim-start.test.ts
+++ b/src/js/electron/brim-start.test.ts
@@ -1,6 +1,9 @@
 import "src/test/system/real-paths"
+import {app} from "electron"
 import {BrimMain} from "./brim"
 import {installExtensions} from "./extensions"
+import {main} from "./run-main/run-main"
+import env from "src/app/core/env"
 
 jest.mock("./extensions", () => ({
   installExtensions: jest.fn(),
@@ -9,72 +12,91 @@ jest.mock("./extensions", () => ({
 jest.mock("@brimdata/zealot")
 
 test("start is called in zed lake", async () => {
-  const brim = await BrimMain.boot({devtools: false, autoUpdater: false})
-  await brim.start()
+  const brim = (await main({devtools: false, autoUpdater: false})) as BrimMain
   expect(brim.lake.start).toHaveBeenCalledTimes(1)
 })
 
-test("activate when zero windows open", async () => {
-  const brim = await BrimMain.boot({
+test("app opens a window on startup", async () => {
+  const brim = (await main({
     devtools: false,
     autoUpdater: false,
     lake: false,
-  })
-  expect(brim.windows.count).toBe(0)
-  await brim.activate()
-  // default "search" window + "hidden" window (background renderer) === 2
-  expect(brim.windows.count).toBe(2)
+  })) as BrimMain
+  expect(brim.windows.visible).toHaveLength(1)
+})
+test("activate creates window if there are none", async () => {
+  const brim = (await main({
+    devtools: false,
+    autoUpdater: false,
+    lake: false,
+  })) as BrimMain
+  // @ts-ignore clear the windows for the test
+  brim.windows.windows = {}
+  app.emit("activate")
+  expect(brim.windows.visible).toHaveLength(1)
 })
 
-test("activate when one or more windows open", async () => {
-  const brim = await BrimMain.boot({
+test("activates shows the window", async () => {
+  const brim = (await main({
     devtools: false,
     autoUpdater: false,
     lake: false,
+  })) as BrimMain
+  app.emit("activate")
+  expect(brim.windows.visible).toHaveLength(1)
+  brim.windows.visible.forEach((win) => {
+    expect(win.ref.show).toHaveBeenCalled()
   })
-  await brim.activate()
-  expect(brim.windows.count).toBe(2)
-  await brim.activate()
-  expect(brim.windows.count).toBe(2)
-})
-
-test("start opens default windows and in correct focus order", async () => {
-  const brim = await BrimMain.boot({
-    devtools: false,
-    autoUpdater: false,
-    lake: false,
-  })
-  await brim.start()
-  expect(brim.windows.count).toBe(2)
-  const windows = brim.windows.all
-  try {
-    expect(windows[0].name).toBe("search")
-    expect(windows[1].name).toBe("hidden")
-  } catch (e) {
-    // this try block has been proven to be indeterminate, log windows too if it fails so we can see why
-    console.error("windows are: ", windows)
-    throw e
-  }
 })
 
 test("start installs dev extensions if is dev", async () => {
-  const brim = await BrimMain.boot({
-    lake: false,
+  await main({
     devtools: true,
     autoUpdater: false,
+    lake: false,
   })
-  await brim.start()
   expect(installExtensions).toHaveBeenCalled()
   // @ts-ignore
   installExtensions.mockReset()
 })
 
 test("start does not install dev extensions if not dev", async () => {
-  const brim = await BrimMain.boot({
-    lake: false,
+  await main({
     devtools: false,
     autoUpdater: false,
+    lake: false,
   })
-  await brim.start()
   expect(installExtensions).not.toHaveBeenCalled()
+})
+
+test("last window closed hides on mac", async () => {
+  jest.spyOn(env, "isMac", "get").mockReturnValue(true)
+
+  const brim = (await main({
+    devtools: false,
+    autoUpdater: false,
+    lake: false,
+  })) as BrimMain
+  const preventDefault = jest.fn()
+  brim.windows.emit("window-will-close", {preventDefault})
+
+  expect(preventDefault).toHaveBeenCalled()
+  expect(brim.windows.visible[0].ref.hide).toHaveBeenCalled()
+  expect(app.quit).not.toHaveBeenCalled()
+})
+
+test("last window quits on not mac", async () => {
+  jest.spyOn(env, "isMac", "get").mockReturnValue(false)
+
+  const brim = (await main({
+    devtools: false,
+    autoUpdater: false,
+    lake: false,
+  })) as BrimMain
+  const preventDefault = jest.fn()
+  brim.windows.emit("window-will-close", {preventDefault})
+
+  expect(preventDefault).toHaveBeenCalled()
+  expect(brim.windows.visible[0].ref.hide).not.toHaveBeenCalled()
+  expect(app.quit).toHaveBeenCalled()
 })

--- a/src/js/electron/initializers/window-events.ts
+++ b/src/js/electron/initializers/window-events.ts
@@ -44,7 +44,9 @@ export function initialize(main: BrimMain) {
     }
   })
 
+  // Looks like this gets called twice on linux and windows
   app.on("before-quit", () => {
+    if (main.isQuitting) return
     main.saveSession()
     main.isQuitting = true
   })

--- a/src/js/electron/initializers/window-events.ts
+++ b/src/js/electron/initializers/window-events.ts
@@ -26,10 +26,10 @@ export function initialize(main: BrimMain) {
   })
 
   app.on("activate", () => {
-    if (main.windows.visible.length === 0) {
-      main.windows.init()
-    } else {
-      main.windows.visible.forEach((win) => win.ref.show())
+    if (main.windows.singleHidden) {
+      main.windows.unhideAll()
+    } else if (main.windows.visible.length === 0) {
+      main.windows.create("search")
     }
   })
 

--- a/src/js/electron/initializers/window-events.ts
+++ b/src/js/electron/initializers/window-events.ts
@@ -50,11 +50,6 @@ export function initialize(main: BrimMain) {
   })
 
   app.on("will-quit", () => {
-    console.log("will quit")
     main.stop()
-  })
-
-  app.on("quit", () => {
-    console.log("quit")
   })
 }

--- a/src/js/electron/ops/autosave-op.ts
+++ b/src/js/electron/ops/autosave-op.ts
@@ -1,9 +1,10 @@
 import log from "electron-log"
 import {throttle} from "lodash"
 import {State} from "src/js/state/types"
+import {BrimMain} from "../brim"
 import {createOperation} from "../operations"
 
-const saveSession = throttle((main) => {
+const saveSession = throttle((main: BrimMain) => {
   main.saveSession()
   log.debug("Session Autosaved")
 }, 500)
@@ -11,6 +12,7 @@ const saveSession = throttle((main) => {
 export const autosaveOp = createOperation(
   "windows.autosave",
   async ({main}, windowId: string, windowState: State) => {
+    if (main.isQuitting) return
     main.windows.update(windowId, windowState)
     saveSession(main)
   }

--- a/src/js/electron/ops/open-search-window-op.ts
+++ b/src/js/electron/ops/open-search-window-op.ts
@@ -5,7 +5,11 @@ export const openSearchWindowOp = createOperation(
   "openSearchWindow",
   async ({main}) => {
     try {
-      await main.windows.create("search")
+      if (main.windows.singleHidden) {
+        main.windows.unhideAll()
+      } else {
+        await main.windows.create("search")
+      }
     } catch (e) {
       log.error("search window failed to open")
     }

--- a/src/js/electron/session.ts
+++ b/src/js/electron/session.ts
@@ -20,6 +20,10 @@ export default function session(path: string) {
       return lib.file(p).write(JSON.stringify({version, data}))
     },
 
+    saveSync(data: SessionState, p: string = path) {
+      return lib.file(p).writeSync(JSON.stringify({version, data}))
+    },
+
     load: async function (): Promise<SessionState | null | undefined> {
       const migrator = await Migrations.init()
       const file = lib.file(path)

--- a/src/js/electron/windows/window-manager.ts
+++ b/src/js/electron/windows/window-manager.ts
@@ -74,6 +74,14 @@ export class WindowManager extends EventEmitter {
     )
   }
 
+  get singleHidden() {
+    return this.visible.length === 1 && !this.visible[0].ref.isVisible()
+  }
+
+  unhideAll() {
+    this.visible.forEach((win) => win.ref.show())
+  }
+
   private async register(win: ZuiWindow) {
     this.windows[win.id] = win
     win.ref.on("close", (e) => this.emit("window-will-close", e))

--- a/src/js/lib/file.ts
+++ b/src/js/lib/file.ts
@@ -80,6 +80,10 @@ export default function file(p: string) {
       })
     },
 
+    writeSync(data: string) {
+      fs.writeFileSync(p, data)
+    },
+
     remove() {
       return new Promise<void>((good, bad) => {
         fs.unlink(p, (err) => {

--- a/src/test/shared/__mocks__/electron.ts
+++ b/src/test/shared/__mocks__/electron.ts
@@ -27,6 +27,7 @@ export class BrowserWindow {
   webContents = new WebContents()
   isDestroyed = jest.fn(() => false)
   focus = jest.fn()
+  visible = true
   center() {}
   setMenu() {}
   on() {
@@ -52,8 +53,15 @@ export class BrowserWindow {
     return [0, 0]
   }
   destroy() {}
-  hide = jest.fn()
-  show = jest.fn()
+  hide() {
+    this.visible = false
+  }
+  show() {
+    this.visible = true
+  }
+  isVisible() {
+    return this.visible
+  }
 }
 
 class MockApp extends EventEmitter {

--- a/src/test/shared/__mocks__/electron.ts
+++ b/src/test/shared/__mocks__/electron.ts
@@ -52,16 +52,17 @@ export class BrowserWindow {
     return [0, 0]
   }
   destroy() {}
+  hide = jest.fn()
+  show = jest.fn()
 }
 
-class MockApp {
+class MockApp extends EventEmitter {
   isPackaged = true
   quit = jest.fn()
   relaunch = jest.fn()
   disableHardwareAcceleration = jest.fn()
   requestSingleInstanceLock = jest.fn()
   setAsDefaultProtocolClient = jest.fn()
-  on = jest.fn()
   whenReady = jest.fn(() => Promise.resolve())
 
   commandLine = {


### PR DESCRIPTION
The logic for closing the last window of zui is now as follows:

1. If mac, hide the last window, don't close it. Upon activation, just shows that window again.

2. If not mac, abort the normal close window event and initiate an app quit event.

The app quit event saves the session, then closes all the windows and shuts down the main process.

This will fix much of the confusion people have had with their tab state being removed.

Closes #1817 
