### PR TITLE
fix ingest warnings

### DIFF
--- a/src/js/components/IngestWarningsModal.tsx
+++ b/src/js/components/IngestWarningsModal.tsx
@@ -33,7 +33,7 @@ export default function IngestWarningsModal({onClose}) {
         <>
           <p>
             {
-              "The data you've attempt to import was not recognized as any supported packet capture or log format. The errors returned by each log parser:"
+              "The data you've attempted to import was not recognized as any supported packet capture or log format. The errors returned by each log parser:"
             }
           </p>
           <Scrollable>

--- a/src/js/components/IngestWarningsModal.tsx
+++ b/src/js/components/IngestWarningsModal.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import {useDispatch, useSelector} from "react-redux"
 import ToolbarButton from "src/app/query-home/toolbar/actions/button"
 import Current from "../state/Current"
-import Loads from "../state/Loads"
+import Pools from "../state/Pools"
 import useEnterKey from "./hooks/useEnterKey"
 import {
   ButtonGroup,
@@ -16,22 +16,22 @@ import {
 export default function IngestWarningsModal({onClose}) {
   const dispatch = useDispatch()
   useEnterKey(onClose)
+  const lakeId = useSelector(Current.getLakeId)
   const poolId = useSelector(Current.getPoolId)
-  const loads = useSelector((state) => Loads.wherePoolId(state, poolId))
-  if (!loads.length) return null
-  const warnings = loads.flatMap((l) => l.warnings)
-  const onClear = () => dispatch(Loads.delete(loads))
+  const warnings = useSelector(Pools.getWarnings(lakeId, poolId))
+  if (!warnings) return null
+
+  const onClear = () => {
+    dispatch(Pools.clearWarnings({lakeId, poolId}))
+    onClose()
+  }
 
   return (
     <Content width={800}>
       <Title>Ingest Warnings</Title>
       {warnings.length ? (
         <>
-          <p>
-            {
-              "The data you've attempt to import was not recognized as any supported packet capture or log format. The errors returned by each log parser:"
-            }
-          </p>
+          <p>{"Data ingest failed with these warnings."}</p>
           <Scrollable>
             <Pre>{warnings.join("\n")}</Pre>
           </Scrollable>

--- a/src/js/components/IngestWarningsModal.tsx
+++ b/src/js/components/IngestWarningsModal.tsx
@@ -31,7 +31,11 @@ export default function IngestWarningsModal({onClose}) {
       <Title>Ingest Warnings</Title>
       {warnings.length ? (
         <>
-          <p>{"Data ingest failed with these warnings."}</p>
+          <p>
+            {
+              "The data you've attempt to import was not recognized as any supported packet capture or log format. The errors returned by each log parser:"
+            }
+          </p>
           <Scrollable>
             <Pre>{warnings.join("\n")}</Pre>
           </Scrollable>

--- a/src/js/components/status-bar/ingest-progress.tsx
+++ b/src/js/components/status-bar/ingest-progress.tsx
@@ -6,15 +6,17 @@ import Warning from "src/app/core/icons/warning"
 import Current from "src/js/state/Current"
 import Loads from "src/js/state/Loads"
 import Modal from "src/js/state/Modal"
+import Pools from "src/js/state/Pools"
 import ProgressIndicator from "../ProgressIndicator"
 
 export function IngestProgress() {
   const dispatch = useDispatch()
+  const lakeId = useSelector(Current.getLakeId)
   const poolId = useSelector(Current.getPoolId)
   const progress = useSelector((s) => Loads.getPoolProgress(s, poolId))
-  const warnings = useSelector((s) => Loads.getPoolWarnings(s, poolId))
+  const warnings = useSelector(Pools.getWarnings(lakeId, poolId))
 
-  if (progress === null) return null
+  if (progress === null && !warnings) return null
 
   function onWarningsClick() {
     dispatch(Modal.show("ingest-warnings"))
@@ -24,7 +26,7 @@ export function IngestProgress() {
     <div className="packet-post-progress">
       <div className="group">
         <ProgressIndicator percent={progress} />
-        {progress === 1 && warnings.length > 0 && (
+        {progress === null && warnings && (
           <label>Ingest failed with warnings.</label>
         )}
         <div
@@ -34,7 +36,7 @@ export function IngestProgress() {
           onClick={onWarningsClick}
         >
           <Warning />
-          <label>{warnings.length}</label>
+          <label>{warnings?.length}</label>
         </div>
       </div>
     </div>

--- a/src/js/electron/ops/global-dispatch-op.ts
+++ b/src/js/electron/ops/global-dispatch-op.ts
@@ -5,9 +5,9 @@ import {ZuiWindow} from "../windows/zui-window"
 export const globalDispatchFromWindow = createOperation(
   "dispatchGlobalFromWindow",
   ({main, event}, action: AnyAction) => {
-    main.store.dispatch(action)
+    main.store.dispatch({...action, remote: true})
     main.windows.all
-      .filter((win) => win.ref.webContents === event.sender)
+      .filter((win) => win.ref.webContents !== event.sender)
       .forEach((win) => dispatchToWindow(win, action))
   }
 )

--- a/src/js/state/Loads/selectors.ts
+++ b/src/js/state/Loads/selectors.ts
@@ -15,7 +15,3 @@ export const getPoolProgress = createSelector(wherePoolId, (loads) => {
   // Not really accurate
   return sum(progresses) / progresses.length
 })
-
-export const getPoolWarnings = createSelector(wherePoolId, (loads) => {
-  return loads.flatMap((l) => l.warnings)
-})

--- a/src/js/state/Loads/types.ts
+++ b/src/js/state/Loads/types.ts
@@ -4,7 +4,6 @@ export type LoadReference = {
   id: string
   poolId: string
   progress: number
-  warnings: string[]
 }
 
 export type LoadsState = EntityState<LoadReference>

--- a/src/js/state/Pools/reducer.ts
+++ b/src/js/state/Pools/reducer.ts
@@ -7,6 +7,20 @@ const slice = createSlice({
   initialState: {} as {[lakeId: string]: {[poolId: string]: Pool}},
   name: "$POOLS_",
   reducers: {
+    appendWarning: (
+      state,
+      action: PA<{lakeId: string; poolId: string; warning: string}>
+    ) => {
+      const {lakeId, poolId, warning} = action.payload
+      const warnings = get(state, [lakeId, poolId, "warnings"], [])
+      set(state, [lakeId, poolId, "warnings"], [...warnings, warning])
+    },
+
+    clearWarnings: (state, action: PA<{lakeId: string; poolId: string}>) => {
+      const {lakeId, poolId} = action.payload
+      unset(state, [lakeId, poolId, "warnings"])
+    },
+
     setData: (state, action: PA<{lakeId: string; data: PoolConfig}>) => {
       const {lakeId, data} = action.payload
       set(state, [lakeId, data.id, "data"], data)

--- a/src/js/state/Pools/selectors.ts
+++ b/src/js/state/Pools/selectors.ts
@@ -15,6 +15,14 @@ export const get =
     return Pool.from(poolState)
   }
 
+export const getWarnings =
+  (lakeId: string, poolId: string) =>
+  (state: State): string[] | null => {
+    const poolState = getLake(state, lakeId)[poolId]
+    if (!poolState) return null
+    return poolState.warnings
+  }
+
 export const raw = (state: State): PoolsState => state.pools
 
 export const all = createSelector(

--- a/src/js/state/Pools/types.ts
+++ b/src/js/state/Pools/types.ts
@@ -3,6 +3,7 @@ import {PoolConfig, PoolStats} from "@brimdata/zealot/types"
 export type PoolState = {
   data: PoolConfig
   stats: PoolStats
+  warnings: string[]
 }
 
 export type PoolsState = {
@@ -11,79 +12,4 @@ export type PoolsState = {
     // poolId
     [key: string]: PoolState
   }
-}
-
-export type PoolsAction =
-  | POOLS_SET
-  | POOLS_DETAIL
-  | POOLS_RENAME
-  | POOLS_INGEST_PROGRESS
-  | POOLS_INGEST_WARNING_APPEND
-  | POOLS_INGEST_WARNING_CLEAR
-  | POOLS_REMOVE
-  | POOLS_LAKE_REMOVE
-export type Pool = {
-  name: string
-  id: string
-  ingest: PoolIngest
-  size: number
-  span: {
-    ts: Date
-    dur: number
-  }
-}
-
-type PoolIngest = {
-  warnings: string[]
-  progress: number | null
-}
-
-export type POOLS_SET = {
-  type: "$POOLS_SET"
-  lakeId: string
-  pools: Partial<Pool>[]
-}
-
-export type POOLS_DETAIL = {
-  type: "$POOLS_DETAIL"
-  lakeId: string
-  pool: Partial<Pool>
-}
-
-export type POOLS_RENAME = {
-  type: "$POOLS_RENAME"
-  lakeId: string
-  poolId: string
-  newName: string
-}
-
-export type POOLS_INGEST_PROGRESS = {
-  type: "$POOLS_INGEST_PROGRESS"
-  lakeId: string
-  poolId: string
-  value: number | null
-}
-
-export type POOLS_INGEST_WARNING_APPEND = {
-  type: "$POOLS_INGEST_WARNING_APPEND"
-  warning: string
-  poolId: string
-  lakeId: string
-}
-
-export type POOLS_INGEST_WARNING_CLEAR = {
-  type: "$POOLS_INGEST_WARNING_CLEAR"
-  poolId: string
-  lakeId: string
-}
-
-export type POOLS_REMOVE = {
-  type: "$POOLS_REMOVE"
-  lakeId: string
-  poolId: string
-}
-
-export type POOLS_LAKE_REMOVE = {
-  type: "$POOLS_LAKE_REMOVE"
-  lakeId: string
 }

--- a/src/plugins/log-loader/index.ts
+++ b/src/plugins/log-loader/index.ts
@@ -41,7 +41,7 @@ export const activate = (api: BrimApi) => {
         },
         signal,
       })
-      forEach(get(res, ["value", "warnings"], []), onWarning)
+      forEach(get(res, ["warnings"], []), onWarning)
     }
     await onDetailUpdate()
     onProgressUpdate(1)

--- a/src/test/unit/fixtures/index.ts
+++ b/src/test/unit/fixtures/index.ts
@@ -18,6 +18,7 @@ const pool1 = (): PoolState => ({
       dur: 1428917793 * 1000 + 7500,
     },
   },
+  warnings: null,
 })
 
 const lake1 = (): Lake => ({


### PR DESCRIPTION
Ingest warnings have been broken for a while.  Fix them.

Included are fixes to some global dispatcher bugs that were causing the Pools.appendWarning reducer to run three times per dispatch.

The video below shows what ingest warnings look like now.

https://user-images.githubusercontent.com/2574448/217313236-44ebf753-2e5c-4545-abba-5af486c24bf0.mov

Closes #2554
Closes #2606
