### PR TITLE
Change registered URL prefix and redirect URL from "brim" to "zui"

### DIFF
--- a/src/js/auth0/index.ts
+++ b/src/js/auth0/index.ts
@@ -7,7 +7,7 @@ interface Auth0Response {
 
 export default class Auth0Client {
   private audience = "https://lake.brimdata.io"
-  private redirectUri = "brim://auth/auth0/callback"
+  private redirectUri = "zui://auth/auth0/callback"
   // 'offline_access' ensures we receive a refresh_token
   private scope = "openid offline_access"
 

--- a/src/js/electron/initializers/custom-protocol.ts
+++ b/src/js/electron/initializers/custom-protocol.ts
@@ -2,7 +2,7 @@ import {app} from "electron"
 import {BrimMain} from "../brim"
 
 export function initialize(main: BrimMain) {
-  const brimCustomProtocol = "brim"
+  const brimCustomProtocol = "zui"
   app.setAsDefaultProtocolClient(brimCustomProtocol)
   app.on("second-instance", (e, argv) => {
     for (let arg of argv) {


### PR DESCRIPTION
I've been testing Auth0 configs to verify the changes in:

* https://github.com/brimdata/zed/pull/4354
* https://github.com/brimdata/zed/pull/4355
* https://github.com/brimdata/zed/pull/4356

...with intent to draft a doc that walks through an example/working Auth0 config that a user could follow to add user auth to their own `zed serve`. I noticed that the registered URL prefix of the app is still `brim://` and this is a bit of config that we'll need to advise users to add on the Auth0 side, so I figured it's as good a time as any to update these to their Zui equivalents.

I've made a Dev build based on this branch and confirmed a successful auth flow with with it using my own scratch Auth0 trial account.