### PR TITLE
Use server-supplied audience in Auth0Client

### DIFF
--- a/src/js/auth0/index.ts
+++ b/src/js/auth0/index.ts
@@ -6,12 +6,15 @@ interface Auth0Response {
 }
 
 export default class Auth0Client {
-  private audience = "https://lake.brimdata.io"
   private redirectUri = "brim://auth/auth0/callback"
   // 'offline_access' ensures we receive a refresh_token
   private scope = "openid offline_access"
 
-  constructor(private clientId: string, private auth0Domain: string) {}
+  constructor(
+    private audience: string,
+    private clientId: string,
+    private auth0Domain: string
+  ) {}
 
   openLoginUrl(state: string): Promise<void> {
     const loginUrl = new URL("authorize", this.auth0Domain)

--- a/src/js/components/Login.test.tsx
+++ b/src/js/components/Login.test.tsx
@@ -64,7 +64,12 @@ function getLake() {
   return brim.lake({
     ...defaultLake(),
     authType: "auth0",
-    authData: {domain: "http://test.com", accessToken: "test", clientId: "hi"},
+    authData: {
+      audience: "test",
+      domain: "http://test.com",
+      accessToken: "test",
+      clientId: "hi",
+    },
   })
 }
 

--- a/src/js/flows/lake/buildLake.ts
+++ b/src/js/flows/lake/buildLake.ts
@@ -21,9 +21,10 @@ export const buildLake =
     if (isEmpty(lake.authType)) {
       const resp = await zealot.authMethod()
       if (resp.kind === "auth0") {
-        const {client_id: clientId, domain} = resp.auth0
+        const {audience, client_id: clientId, domain} = resp.auth0
         lake.authType = "auth0"
         lake.authData = {
+          audience,
           clientId,
           domain,
         }

--- a/src/js/flows/lake/getAuth0.ts
+++ b/src/js/flows/lake/getAuth0.ts
@@ -10,7 +10,7 @@ export const getAuth0 =
     if (!l.authType || l.authType !== "auth0") return null
     if (!l.authData) throw new Error("authData missing from lake")
 
-    const {clientId, domain} = l.authData
+    const {audience, clientId, domain} = l.authData
 
-    return new Auth0Client(clientId, domain)
+    return new Auth0Client(audience, clientId, domain)
   }

--- a/src/js/state/Lakes/types.ts
+++ b/src/js/state/Lakes/types.ts
@@ -13,6 +13,7 @@ export type AuthType = "none" | "auth0"
 export type AuthData = Auth0Data
 
 export interface Auth0Data {
+  audience: string
   clientId: string
   domain: string
   accessToken?: string

--- a/src/js/state/stores/get-persistable.test.ts
+++ b/src/js/state/stores/get-persistable.test.ts
@@ -18,13 +18,19 @@ test("deleting access tokens for authType auth0", () => {
       host: "me.com",
       port: "123",
       name: "test",
-      authData: {clientId: "1", accessToken: "SECRET", domain: "me.com"},
+      authData: {
+        audience: "a",
+        clientId: "1",
+        accessToken: "SECRET",
+        domain: "me.com",
+      },
     })
   )
   const persist = getPersistedWindowState(store.getState())
   const persistedLake = Lakes.id("1")(persist)
   expect(persistedLake.authData).toMatchInlineSnapshot(`
     Object {
+      "audience": "a",
       "clientId": "1",
       "domain": "me.com",
     }
@@ -67,13 +73,19 @@ test("global persist", () => {
       host: "me.com",
       port: "123",
       name: "test",
-      authData: {clientId: "1", accessToken: "SECRET", domain: "me.com"},
+      authData: {
+        audience: "a",
+        clientId: "1",
+        accessToken: "SECRET",
+        domain: "me.com",
+      },
     })
   )
   const persist = getPersistedGlobalState(store.getState())
   const persistedLake = Lakes.id("1")(persist)
   expect(persistedLake.authData).toMatchInlineSnapshot(`
     Object {
+      "audience": "a",
       "clientId": "1",
       "domain": "me.com",
     }


### PR DESCRIPTION
Auth0Client uses a fixed audience value (https://lake.brimdata.io) in the authorization request it sends to Auth0, limiting Auth0Client to use with Auth0 APIs created with that value as their API identifier.  Change Auth0Client to use the audience supplied by the lake service in the GET /auth/methods response instead.  (The lake service's audience is configured with the -auth.audience flag to "zed serve", added in brimdata/zed#4356).