### PR TITLE
Apply sass-migrator division

### DIFF
--- a/src/css/_conn-versation.scss
+++ b/src/css/_conn-versation.scss
@@ -82,11 +82,11 @@
   }
 
   .history-packet.arrow-right {
-    padding-right: $space-s/2;
+    padding-right: $space-s*0.5;
   }
 
   .history-packet.arrow-left {
-    padding-left: $space-s/2;
+    padding-left: $space-s*0.5;
     .triangle {
       order: 1;
       transform: rotate(180deg);

--- a/src/css/_mac-spinner.scss
+++ b/src/css/_mac-spinner.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 $mac-spinner-duration: 800ms;
 $mac-spinner-color: var(--aqua);
 $mac-spinner-size: 24px;
@@ -12,7 +14,7 @@ $mac-spinner-size: 24px;
     position: absolute;
     width: 100%;
     height: 100%;
-    transform: translate(50%, $mac-spinner-size / 4);
+    transform: translate(50%, $mac-spinner-size * 0.25);
   }
 
   .bar {
@@ -20,7 +22,7 @@ $mac-spinner-size: 24px;
     left: 0px;
     top: 0px;
     width: 2px;
-    height: $mac-spinner-size / 4;
+    height: $mac-spinner-size * 0.25;
     background: $mac-spinner-color;
     transform-origin: bottom center;
     border-radius: 2px;
@@ -30,8 +32,8 @@ $mac-spinner-size: 24px;
 
   @for $i from 1 through 12 {
     .bar:nth-child(#{$i}) {
-      transform: rotate(($i - 1) * 30deg) translateY(-$mac-spinner-size / 4);
-      animation-delay: ($i - 1) * ($mac-spinner-duration / 12);
+      transform: rotate(($i - 1) * 30deg) translateY(-$mac-spinner-size * 0.25);
+      animation-delay: ($i - 1) * math.div($mac-spinner-duration, 12);
     }
   }
 


### PR DESCRIPTION
A recent Zui Insiders build happened to fail and I noticed the following noise in the output:

```
[build:css       ] DEPRECATION WARNING: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.
[build:css       ] 
[build:css       ] Recommendation: math.div($space-s, 2) or calc($space-s / 2)
[build:css       ] 
[build:css       ] More info and automated migrator: https://sass-lang.com/d/slash-div
[build:css       ] 
[build:css       ]    ╷
[build:css       ] 85 │     padding-right: $space-s/2;
[build:css       ]    │                    ^^^^^^^^^^
[build:css       ]    ╵
[build:css       ]     src/css/_conn-versation.scss 85:20  @import
[build:css       ]     src/css/main.scss 27:9              root stylesheet
[build:css       ] 
[build:css       ] DEPRECATION WARNING: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.
[build:css       ] 
[build:css       ] Recommendation: math.div($space-s, 2) or calc($space-s / 2)
[build:css       ] 
[build:css       ] More info and automated migrator: https://sass-lang.com/d/slash-div
[build:css       ] 
[build:css       ]    ╷
[build:css       ] 89 │     padding-left: $space-s/2;
[build:css       ]    │                   ^^^^^^^^^^
[build:css       ]    ╵
[build:css       ]     src/css/_conn-versation.scss 89:19  @import
[build:css       ]     src/css/main.scss 27:9              root stylesheet
[build:css       ] 
[build:js        ] src/css/_about-window.scss
[build:js        ] src/css/_animations.scss
[build:js        ] src/css/_arrows.scss
[build:js        ] src/css/_brand.scss
[build:js        ] src/css/_brim-toaster.scss
[build:js        ] src/css/_button-row.scss
[build:js        ] src/css/_buttons.scss
[build:js        ] src/css/_chart-elements.scss
[build:js        ] src/css/_chart.scss
[build:js        ] src/css/_circle-chevron.scss
[build:js        ] src/css/_click-feedback.scss
[build:js        ] src/css/_column-chooser.scss
[build:js        ] src/css/_column-description.scss
[build:js        ] src/css/_columns-tree.scss
[build:js        ] src/css/_conn-versation.scss
[build:js        ] src/css/_control-bar.scss
[build:js        ] src/css/_curl-modal.scss
[build:js        ] src/css/_debug-modal.scss
[build:js        ] src/css/_download-progress.scss
[build:js        ] src/css/_empty-search-page.scss
[build:js        ] src/css/_error-boundary.scss
[build:js        ] src/css/_expand-button.scss
[build:js        ] src/css/_filter-node.scss
[build:js        ] src/css/_filter-tree.scss
[build:js        ] src/css/_global.scss
[build:js        ] src/css/_hash-correlation.scss
[build:js        ] src/css/_header-cell.scss
[build:js        ] src/css/_histogram-tooltip.scss
[build:js        ] src/css/_history-buttons.scss
[build:js        ] src/css/_history-pane.scss
[build:js        ] src/css/_html-context-menu.scss
[build:js        ] src/css/_icons.scss
[build:js        ] src/css/_info-notice.scss
[build:js        ] src/css/_ingest-warnings-modal.scss
[build:js        ] src/css/_inline-table-loading.scss
[build:js        ] src/css/_inline-table.scss
[build:js        ] src/css/_input-suggestions.scss
[build:js        ] src/css/_layout.scss
[build:js        ] src/css/_list-item.scss
[build:js        ] src/css/_loading-burst.scss
[build:js        ] src/css/_loading-message.scss
[build:js        ] src/css/_log-cell.scss
[build:js        ] src/css/_log-detail-window.scss
[build:js        ] src/css/_log-detail.scss
[build:js        ] src/css/_log-viewer.scss
[build:js        ] src/css/_mac-spinner.scss
[build:js        ] src/css/_message-box.scss
[build:js        ] src/css/_modal.scss
[build:js        ] src/css/_notice-banner.scss
[build:js        ] src/css/_packet-post-progress.scss
[build:js        ] src/css/_pane-toggle-buttons.scss
[build:js        ] src/css/_pane.scss
[build:js        ] src/css/_pins.scss
[build:js        ] src/css/_pool-modal.scss
[build:js        ] src/css/_pop-menu.scss
[build:js        ] src/css/_portal.scss
[build:js        ] src/css/_prism.scss
[build:js        ] src/css/_progress-indicator.scss
[build:js        ] src/css/_react-day-picker.scss
[build:js        ] src/css/_results-pane.scss
[build:js        ] src/css/_saved-pools-list.scss
[build:js        ] src/css/_scroll-shadow.scss
[build:js        ] src/css/_search-page.scss
[build:js        ] src/css/_search-results.scss
[build:js        ] src/css/_settings-modal.scss
[build:js        ] src/css/_sidebar.scss
[build:js        ] src/css/_span-duration.scss
[build:js        ] src/css/_tab-search-loading.scss
[build:js        ] src/css/_tab.scss
[build:js        ] src/css/_table.scss
[build:js        ] src/css/_tags.scss
[build:js        ] src/css/_text-content.scss
[build:js        ] src/css/_time-span-pickers.scss
[build:js        ] src/css/_toolbar-button.scss
[build:js        ] src/css/_tooltip.scss
[build:js        ] src/css/_whois-modal.scss
[build:js        ] src/css/_x-button.scss
[build:js        ] src/css/_zed-table.scss
[build:js        ] src/css/_zed-view.scss
[build:js        ] src/css/_zeek-plugin.scss
[build:js        ] src/css/main.scss
[build:js        ] src/ppl/README.md
[build:js        ] src/static/AppIcon.icns
[build:js        ] src/static/AppIcon.ico
[build:js        ] src/static/AppIcon.png
[build:js        ] src/static/Windows-Install.gif
[build:js        ] src/static/pool-wall-background.svg
[build:js        ] src/static/welcome-page-background.svg
[build:js        ] src/css/forms/_file-input.scss
[build:js        ] src/css/forms/_global.scss
[build:js        ] src/css/forms/_main.scss
[build:js        ] src/css/forms/_mixins.scss
[build:js        ] src/css/forms/_select-input.scss
[build:js        ] src/css/forms/_text-input.scss
[build:js        ] src/css/settings/_colors.scss
[build:js        ] src/css/settings/_fonts.scss
[build:js        ] src/css/settings/_shared-styles.scss
[build:js        ] src/css/settings/_spacing.scss
[build:js        ] src/css/shared/_effects.scss
[build:js        ] src/css/shared/_shadows.scss
[build:js        ] src/css/shared/_type-colors.scss
[build:js        ] src/css/shared/_typography.scss
[build:js        ] src/ppl/css/_load-files-input.scss
[build:js        ] src/static/fonts/recursive.woff2
[build:js        ] src/static/icons/subspace-border.svg
[build:js        ] src/static/icons/subspace.svg
[build:js        ] src/js/electron/html-dialog/dialog.html
[build:js        ] src/js/state/entity-slice/entity-slice.md
[build:js        ] src/test/shared/data/plain.txt
[build:js        ] src/test/shared/data/sample.ndjson
[build:js        ] src/test/shared/data/sample.pcap
[build:js        ] src/test/shared/data/sample.pcapng
[build:js        ] src/test/shared/data/sample.tsv
[build:js        ] src/test/shared/data/sample.zng
[build:js        ] src/test/shared/data/sample.zson
[build:js        ] src/test/unit/states/v0.12.0.json
[build:js        ] src/test/unit/states/v0.13.1.json
[build:js        ] src/test/unit/states/v0.14.0.json
[build:js        ] src/test/unit/states/v0.15.1.json
[build:js        ] src/test/unit/states/v0.17.0.json
[build:js        ] src/test/unit/states/v0.20.0.json
[build:js        ] src/test/unit/states/v0.21.1.json
[build:js        ] src/test/unit/states/v0.22.0.json
[build:js        ] src/test/unit/states/v0.23.0.json
[build:js        ] src/test/unit/states/v0.24.0.json
[build:js        ] src/test/unit/states/v0.26.0.json
[build:js        ] src/test/unit/states/v0.27.0.json
[build:js        ] src/test/unit/states/v0.30.0.json
[build:js        ] src/test/unit/states/v0.9.1.json
[build:js        ] src/js/electron/windows/search/search.html
[build:js        ] src/js/state/Queries/fixtures/test-query-lib.json
[build:css       ] DEPRECATION WARNING: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.
[build:css       ] 
[build:css       ] Recommendation: math.div($mac-spinner-size, 4) or calc($mac-spinner-size / 4)
[build:css       ] 
[build:css       ] More info and automated migrator: https://sass-lang.com/d/slash-div
[build:css       ] 
[build:css       ]    ╷
[build:css       ] 15 │     transform: translate(50%, $mac-spinner-size / 4);
[build:css       ]    │                               ^^^^^^^^^^^^^^^^^^^^^
[build:css       ]    ╵
[build:css       ]     src/css/_mac-spinner.scss 15:31  @import
[build:css       ]     src/css/main.scss 76:9           root stylesheet
[build:css       ] 
[build:css       ] DEPRECATION WARNING: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.
[build:css       ] 
[build:css       ] Recommendation: math.div($mac-spinner-size, 4) or calc($mac-spinner-size / 4)
[build:css       ] 
[build:css       ] More info and automated migrator: https://sass-lang.com/d/slash-div
[build:css       ] 
[build:css       ]    ╷
[build:css       ] 23 │     height: $mac-spinner-size / 4;
[build:css       ]    │             ^^^^^^^^^^^^^^^^^^^^^
[build:css       ]    ╵
[build:css       ]     src/css/_mac-spinner.scss 23:13  @import
[build:css       ]     src/css/main.scss 76:9           root stylesheet
[build:css       ] 
[build:css       ] DEPRECATION WARNING: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.
[build:css       ] 
[build:css       ] Recommendation: math.div(-$mac-spinner-size, 4) or calc(-$mac-spinner-size / 4)
[build:css       ] 
[build:css       ] More info and automated migrator: https://sass-lang.com/d/slash-div
[build:css       ] 
[build:css       ]    ╷
[build:css       ] 33 │       transform: rotate(($i - 1) * 30deg) translateY(-$mac-spinner-size / 4);
[build:css       ]    │                                                      ^^^^^^^^^^^^^^^^^^^^^^
[build:css       ]    ╵
[build:css       ]     src/css/_mac-spinner.scss 33:54  @import
[build:css       ]     src/css/main.scss 76:9           root stylesheet
[build:css       ] 
[build:css       ] WARNING: 1 repetitive deprecation warnings omitted.
[build:css       ] Run in verbose mode to see all warnings.
```

I followed the provided link to https://sass-lang.com/documentation/breaking-changes/slash-div that closed by saying the repairs could be done by running `sass-migrator division **/*.scss`. I've done that in this PR and the changes look mathematically sound and all the tests still pass, so putting it up for review.