### PR TITLE
Advance Zed pointer to c770649

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "tree-model": "^1.0.7",
     "use-resize-observer": "^8.0.0",
     "web-file-polyfill": "^1.0.4",
-    "zed": "brimdata/zed#82ddbf2ca86ebeb1eb8bb6d4c7915d2d6b9e4091"
+    "zed": "brimdata/zed#c770649413677a618b36acee7ff1a9350cfe4830"
   },
   "peerDependencies": {
     "react": "^18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17040,12 +17040,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zed@brimdata/zed#82ddbf2ca86ebeb1eb8bb6d4c7915d2d6b9e4091":
+"zed@brimdata/zed#c770649413677a618b36acee7ff1a9350cfe4830":
   version: 0.33.0-dev
-  resolution: "zed@https://github.com/brimdata/zed.git#commit=82ddbf2ca86ebeb1eb8bb6d4c7915d2d6b9e4091"
+  resolution: "zed@https://github.com/brimdata/zed.git#commit=c770649413677a618b36acee7ff1a9350cfe4830"
   dependencies:
     zealot: ^0.2.0
-  checksum: 4980680d9a6051cdb560c04034afc2a47398ea72c64dd54beca2f85ad626ac7838f874b4c2fb916bd9d1304f431612f7272b18298f29da8600d643ed72cbfbe4
+  checksum: 6eaac205de2e9dc90199b8d5606f1cd6ecf15e8fb62f0e7d31e41024db315ee456c3a214584ae233078957967b3e9382984c184ebb4e50a23f38f75236424338
   languageName: node
   linkType: hard
 
@@ -17196,7 +17196,7 @@ __metadata:
     web-streams-polyfill: ^3.2.0
     whatwg-fetch: ^3.2.0
     win-7zip: ^0.1.0
-    zed: "brimdata/zed#82ddbf2ca86ebeb1eb8bb6d4c7915d2d6b9e4091"
+    zed: "brimdata/zed#c770649413677a618b36acee7ff1a9350cfe4830"
     zui-test-data: "workspace:*"
   peerDependencies:
     react: ^18.0.0


### PR DESCRIPTION
Since the e2e tests have been fussy lately, I went ahead and confirmed they're all passing locally with a recent Zed commit and am manually advancing the pointer.