### PR TITLE
Advance Brimcap dependency to tag v1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.1.0",
     "babel-plugin-module-resolver": "^4.0.0",
-    "brimcap": "brimdata/brimcap#0bcc312e86f6e3d9cfc85033f25a4bae790b15c7",
+    "brimcap": "brimdata/brimcap#v1.3.0",
     "chalk": "^4.1.0",
     "commander": "^2.20.3",
     "cpx": "^1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4860,10 +4860,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brimcap@brimdata/brimcap#0bcc312e86f6e3d9cfc85033f25a4bae790b15c7":
+"brimcap@brimdata/brimcap#v1.3.0":
   version: 1.1.2
-  resolution: "brimcap@https://github.com/brimdata/brimcap.git#commit=0bcc312e86f6e3d9cfc85033f25a4bae790b15c7"
-  checksum: 19b11c8563df36464a083758067388d9b69ce66eee279d8baee5f8262e1a483d21e4631fe531fc5afdbdb8854db083b52a86de21b213a515be8e9e91897a932a
+  resolution: "brimcap@https://github.com/brimdata/brimcap.git#commit=218cdb58d9fcd70fc8d092f062caee6a53570181"
+  checksum: 0431fa6b6cc1082eb058154f5a0ccf1be1681733a80fd475665d49f021f5cae009da008b905895ff15d53e2082c4d5307c555fcb12c36b2ac1ebbf06cec971db
   languageName: node
   linkType: hard
 
@@ -17112,7 +17112,7 @@ __metadata:
     babel-core: ^7.0.0-bridge.0
     babel-eslint: ^10.1.0
     babel-plugin-module-resolver: ^4.0.0
-    brimcap: "brimdata/brimcap#0bcc312e86f6e3d9cfc85033f25a4bae790b15c7"
+    brimcap: "brimdata/brimcap#v1.3.0"
     chalk: ^4.1.0
     chrono-node: ^1.4.8
     classnames: ^2.2.6


### PR DESCRIPTION
Pointing at a tagged Brimcap artifact in preparation for the Zui v1.0.0 release.