### PR TITLE
fix typo in .github/workflows/advance-zed.yml

### DIFF
--- a/.github/workflows/advance-zed.yml
+++ b/.github/workflows/advance-zed.yml
@@ -1,6 +1,6 @@
 name: Advance Zed
 
-concurrency: ${{ github.workflow }
+concurrency: ${{ github.workflow }}
 
 # This type must match the event type from Zed.
 # https://help.github.com/en/actions/reference/events-that-trigger-workflows#external-events-repository_dispatch


### PR DESCRIPTION
This fixes breakage I introduced in #2665. Sad.