### PR TITLE
Handle before-quit-for-update

### DIFF
--- a/src/js/electron/brim.ts
+++ b/src/js/electron/brim.ts
@@ -76,6 +76,12 @@ export class BrimMain {
     this.session.saveSync(encodeSessionState(windowState, mainState))
   }
 
+  onBeforeQuit() {
+    if (this.isQuitting) return
+    this.saveSession()
+    this.isQuitting = true
+  }
+
   openUrl(uri: string) {
     const urlParts = url.parse(uri, true)
     const {code, state, error, error_description} = urlParts.query as {

--- a/src/js/electron/initializers/window-events.ts
+++ b/src/js/electron/initializers/window-events.ts
@@ -1,4 +1,4 @@
-import {app} from "electron"
+import {app, autoUpdater} from "electron"
 import log from "electron-log"
 import env from "src/app/core/env"
 import {BrimMain} from "../brim"
@@ -45,11 +45,11 @@ export function initialize(main: BrimMain) {
   })
 
   // Looks like this gets called twice on linux and windows
-  app.on("before-quit", () => {
-    if (main.isQuitting) return
-    main.saveSession()
-    main.isQuitting = true
-  })
+  app.on("before-quit", () => main.onBeforeQuit())
+
+  // https://www.electronjs.org/docs/latest/api/auto-updater#event-before-quit-for-update
+  // When autoUpdater.quitAndInstall() is called, the "before-quit" event doesn't fire
+  autoUpdater.on("before-quit-for-update", () => main.onBeforeQuit())
 
   app.on("will-quit", () => {
     main.stop()


### PR DESCRIPTION
When an update is downloaded, the app calls, autoUpdater.quitAndInstall(). This doesn't call "before-quit" but does call "before-quit-for-update".
 
See: https://www.electronjs.org/docs/latest/api/auto-updater#event-before-quit-for-update

Then it closes all windows and once all windows are closed calls app.quit().

Since we intercept the last window being closed on mac, and only "hide" the last window. The final quit wasn't being called after quitAndInstall() on mac.

We don't intercept the last window being closed if the "isQuitting" flag is true. 

We set this flag in the "before-quit" event.

This PR now does the same thing in the "before-quit-for-update" event which fixes the issue.


Fixes #2674