### PR TITLE
Don't migrate lake data in Brim/Zui transition

### DIFF
--- a/src/js/electron/migrateBrimToZui.ts
+++ b/src/js/electron/migrateBrimToZui.ts
@@ -7,19 +7,16 @@ export default () => {
   if (app.name !== "Zui") return
   const zuiPath = app.getPath("userData")
   const zuiAppStatePath = path.join(zuiPath, "appState.json")
-  const zuiAppLakePath = path.join(zuiPath, "lake")
   const zuiAppDataPath = path.join(zuiPath, "data")
 
   const brimPath = zuiPath.replace("Zui", "Brim")
   if (zuiPath === brimPath) return
 
   const brimAppStatePath = path.join(brimPath, "appState.json")
-  const brimAppLakePath = path.join(brimPath, "lake")
   const brimAppDataPath = path.join(brimPath, "data")
 
   try {
     fs.statSync(brimAppStatePath)
-    fs.statSync(brimAppLakePath)
     fs.statSync(brimAppDataPath)
     log.info("brim data found")
   } catch {
@@ -29,7 +26,6 @@ export default () => {
 
   try {
     fs.statSync(zuiAppStatePath)
-    fs.statSync(zuiAppLakePath)
     fs.statSync(zuiAppDataPath)
     log.info("zui data already exists, aborting migration")
     return
@@ -40,8 +36,6 @@ export default () => {
   try {
     log.info(`migrating '${brimAppStatePath}' => '${zuiAppStatePath}'`)
     fs.copySync(brimAppStatePath, zuiAppStatePath)
-    log.info(`migrating '${brimAppLakePath} => ${zuiAppLakePath}'`)
-    fs.copySync(brimAppLakePath, zuiAppLakePath)
     log.info(`migrating '${brimAppDataPath} => ${zuiAppDataPath}'`)
     fs.copySync(brimAppDataPath, zuiAppDataPath)
   } catch (err) {


### PR DESCRIPTION
The Zed lake storage format has recently gone through a change that's not backward compatible. Meanwhile, changes back in #2428 included a recursive copy of the lake storage as part of the Brim/Zui upgrade.

The attached video was taken with [this Dev Build](https://github.com/brimdata/brim/actions/runs/4247780001) that points at the newest Zed and shows the problem created: Upon first launch in Zui, `zed serve`'s inability to read the older storage format prevents the backend from starting up at all, so the user is confronted with a failure message.

https://user-images.githubusercontent.com/5934157/221018037-2de3ef7c-731d-4997-84f6-b08e7dfe0e79.mp4

If users want to migrate their data, the current plan of record is to point them at [migration tools](https://github.com/brimdata/zed-lake-migration) that they can run manually. Therefore what this PR does is revert the parts of #2428 that auto-migrate the lake storage. Instead the user's `zed serve` will come up ok with an empty lake. Like we did back in [Brim v0.29.0](https://github.com/brimdata/brim/releases/tag/v0.29.0), we can put up a prominent "Where are my pools?" Release Note that'll show up in the app and point them to the migration tools.