### PR TITLE
Unique appId for Zui

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -1,5 +1,5 @@
 {
-  "appId": "com.electron.brim",
+  "appId": "io.brimdata.zui",
   "asar": true,
   "asarUnpack": ["zdeps", "LICENSE.txt", "acknowledgments.txt"],
   "directories": {"output": "dist/installers"},


### PR DESCRIPTION
https://github.com/brimdata/brim/issues/2459#issuecomment-1442316859 has detailed background.

tl;dr - By changing the `appId`, now when Windows and macOS users of [Brim v0.31.0](https://github.com/brimdata/brim/releases/tag/v0.31.0) auto-update or manually install Zui v1.0, their Brim install will _not_ disappear from their list of installed Programs/Applications and hence will need to be manually uninstalled. The benefit of this is that on Windows all users will have [Application Binaries](https://zui.brimdata.io/docs/support/Filesystem-Paths#application-binaries) directories with "zui" in the path and hence tools like ones planned for [Zed lake migration](https://github.com/brimdata/zed-lake-migration) can find tine CLI tools in the expected location.

Closes #2459
