### PR TITLE
Zui v1.0.0 upgraded from Brim v0.31.0 is not "first run"

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Zed User Interface",
   "repository": "https://github.com/brimdata/brim",
   "license": "BSD-3-Clause",
-  "version": "0.30.0",
+  "version": "1.0.0",
   "main": "dist/js/electron/main.js",
   "author": "Brim Data <support@brimdata.io> (http://www.brimdata.io)",
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Zed User Interface",
   "repository": "https://github.com/brimdata/brim",
   "license": "BSD-3-Clause",
-  "version": "1.0.0",
+  "version": "0.30.0",
   "main": "dist/js/electron/main.js",
   "author": "Brim Data <support@brimdata.io> (http://www.brimdata.io)",
   "workspaces": [

--- a/src/js/electron/first-run.ts
+++ b/src/js/electron/first-run.ts
@@ -1,19 +1,34 @@
 import fs from "fs-extra"
 import path from "path"
-import log from "electron-log"
 import {app} from "electron"
 
-export const getPath = () => path.join(app.getPath("userData"), "first-run")
+let result: undefined | boolean = undefined
+
+export function setFirstRun(value: boolean) {
+  result = value
+}
 
 export function isFirstRun() {
-  return new Promise<boolean>((res) => {
-    fs.stat(getPath(), (err) => {
-      if (err) {
-        fs.createFile(getPath()).catch((e) => log.error(e))
-        res(true)
-      } else {
-        res(false)
-      }
-    })
-  })
+  if (result === undefined) {
+    if (markerExists()) {
+      setFirstRun(false)
+    } else {
+      setFirstRun(true)
+      markFirstRun()
+    }
+  }
+
+  return result
+}
+
+function markFirstRun() {
+  fs.createFileSync(getPath())
+}
+
+function markerExists() {
+  return fs.existsSync(getPath())
+}
+
+function getPath() {
+  return path.join(app.getPath("userData"), "first-run")
 }

--- a/src/js/electron/first-run.ts
+++ b/src/js/electron/first-run.ts
@@ -5,17 +5,14 @@ import {app} from "electron"
 
 export const getPath = () => path.join(app.getPath("userData"), "first-run")
 
-let firstRun = undefined
-
 export function isFirstRun() {
   return new Promise<boolean>((res) => {
-    if (firstRun !== undefined) return res(firstRun)
     fs.stat(getPath(), (err) => {
       if (err) {
         fs.createFile(getPath()).catch((e) => log.error(e))
-        res((firstRun = true))
+        res(true)
       } else {
-        res((firstRun = false))
+        res(false)
       }
     })
   })

--- a/src/js/electron/migrateBrimToZui.ts
+++ b/src/js/electron/migrateBrimToZui.ts
@@ -2,6 +2,7 @@ import {app} from "electron"
 import path from "path"
 import fs from "fs-extra"
 import log from "electron-log"
+import {getPath} from "./first-run"
 
 export default () => {
   if (app.name !== "Zui") return
@@ -47,6 +48,13 @@ export default () => {
   } catch (err) {
     log.error("migration failed: ", err)
     return
+  }
+
+  try {
+    log.info(`marking that the app has been previously run`)
+    fs.createFile(getPath()).catch((e) => log.error(e))
+  } catch (err) {
+    log.error("failed to leave first-run marker: ", err)
   }
 
   log.info("migration completed")

--- a/src/js/electron/migrateBrimToZui.ts
+++ b/src/js/electron/migrateBrimToZui.ts
@@ -2,7 +2,6 @@ import {app} from "electron"
 import path from "path"
 import fs from "fs-extra"
 import log from "electron-log"
-import {getPath} from "./first-run"
 
 export default () => {
   if (app.name !== "Zui") return
@@ -46,7 +45,9 @@ export default () => {
 
   try {
     log.info(`marking that the app has been previously run`)
-    fs.createFile(getPath()).catch((e) => log.error(e))
+    fs.createFile(path.join(app.getPath("userData"), "phil-first-run")).catch(
+      (e) => log.error(e)
+    )
   } catch (err) {
     log.error("failed to leave first-run marker: ", err)
   }

--- a/src/js/electron/migrateBrimToZui.ts
+++ b/src/js/electron/migrateBrimToZui.ts
@@ -2,7 +2,7 @@ import {app} from "electron"
 import path from "path"
 import fs from "fs-extra"
 import log from "electron-log"
-import {getPath} from "./first-run"
+import {setFirstRun} from "./first-run"
 
 export default () => {
   if (app.name !== "Zui") return
@@ -44,12 +44,8 @@ export default () => {
     return
   }
 
-  try {
-    log.info(`marking that the app has been previously run`)
-    fs.createFile(getPath()).catch((e) => log.error(e))
-  } catch (err) {
-    log.error("failed to leave first-run marker: ", err)
-  }
+  log.info(`marking that the app has been previously run`)
+  setFirstRun(false)
 
   log.info("migration completed")
 }

--- a/src/js/electron/migrateBrimToZui.ts
+++ b/src/js/electron/migrateBrimToZui.ts
@@ -2,6 +2,7 @@ import {app} from "electron"
 import path from "path"
 import fs from "fs-extra"
 import log from "electron-log"
+import {getPath} from "./first-run"
 
 export default () => {
   if (app.name !== "Zui") return
@@ -45,9 +46,7 @@ export default () => {
 
   try {
     log.info(`marking that the app has been previously run`)
-    fs.createFile(path.join(app.getPath("userData"), "phil-first-run")).catch(
-      (e) => log.error(e)
-    )
+    fs.createFile(getPath()).catch((e) => log.error(e))
   } catch (err) {
     log.error("failed to leave first-run marker: ", err)
   }


### PR DESCRIPTION
The changes in #2380 caused the launch of an upgraded Zui `v1.0.0` to meet the definition of a "first run" such that Release Notes were not being shown. This PR adds override logic in the Brim-to-Zui migration code so the Release Notes will still be shown in this case.

The following test results show it working in a [Dev build](https://github.com/brimdata/brim/actions/runs/4264930903) based on this branch with the one additional change of the `version` string in `package.json` being set to `1.0.0`.

In the first video we start from a GA install of Brim `v0.31.0` and upgrade to this Zui `v1.0.0` artifact. As we'd hope, the app _does_ attempt to fetch the `v1.0.0` release notes.

https://user-images.githubusercontent.com/5934157/221262767-5cd5a9e1-aeb0-46ed-af60-510aa8abdcad.mp4

The second video confirms that the "first run" logic still does what we want for true "first runs". In this case we start from a fresh system that has never had old Brim installed on it and install the ZUi `v1.0.0` artifact for the first time. No Release Notes are shown.

https://user-images.githubusercontent.com/5934157/221262947-adfd4ce8-6808-4ea8-9bb6-ad82aa62ba5f.mp4

Fixes #2682