### PR TITLE
Enable assisted installer so per-machine can be selected

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -12,6 +12,7 @@
   "linux": {"target": ["deb", "rpm"]},
   "rpm": {"depends": ["openssl"]},
   "deb": {"depends": ["openssl"]},
+  "nsis": {"oneClick": false, "perMachine": false},
   "forceCodeSigning": true,
   "afterSign": "electron-builder-notarize",
   "publish": {


### PR DESCRIPTION
https://www.electron.build/configuration/nsis describes the options being used here. Up until now we've always gone with the [electron-builder](https://www.electron.build/) default of a one-click, per-user install. With the combination I'm using in this PR, the user will be prompted as shown in the following video (made with a Dev build from [this Actions run](https://github.com/brimdata/brim/actions/runs/4298560382)), such that they can choose the per-machine install. After selecting that install option I logged out and logged in as a different user and confirmed I saw the Zui icon on its desktop and could launch the app ok. The app binaries in that case end up in `%ProgramFiles%\Zui` (i.e., `C:\Program Files\Zui`) rather than the `%USERPROFILE%\AppData\Local\Programs\Zui` that we're accustomed to seeing with the per-user install.

https://user-images.githubusercontent.com/5934157/222031766-a5646a5d-5aec-4025-9cdb-9d0eb54c541c.mp4

Since Zui Insiders derives its electron-builder config from Zui, I also made a Dev build in [this Actions run](https://github.com/brimdata/zui-insiders/actions/runs/4299006773) and confirmed that also worked fine with per-machine install.

If this merges, I'll update the docs in #2531 to mention this as an alternate install option and filesystem path.

For #2685