### PR TITLE
fix e2e flakiness in pool-loads.spec.ts

### DIFF
--- a/packages/e2e-tests/helpers/test-app.ts
+++ b/packages/e2e-tests/helpers/test-app.ts
@@ -94,6 +94,7 @@ export default class TestApp {
   // TODO: this method is a wip, it still needs to wait for cells to populate first
   async getViewerResults(includeHeaders = true): Promise<string[]> {
     const fields = await this.mainWin.locator(".zed-table__cell")
+    await fields.waitFor()
     let results = await fields.evaluateAll<string[], HTMLElement>((nodes) =>
       nodes.map((n) => n.innerText.trim())
     )


### PR DESCRIPTION
This fixes the following two e2e failures, which I often see.

    $ yarn e2e pool-loads:17 pool-loads:26 --reporter=line

    Running 2 tests using 1 worker
      1) pool-loads.spec.ts:17:3 › Pool Loads › load data into a pool ==================================

	Error: expect(received).toEqual(expected) // deep equality

	- Expected  - 4
	+ Received  + 1

	- Array [
	-   "count",
	-   "1",
	- ]
	+ Array []

	  20 |     await app.query("count()")
	  21 |     const results = await app.getViewerResults()
	> 22 |     expect(results).toEqual(["count", "1"])
	     |                     ^
	  23 |     await app.mainWin.getByText("Load Successful").waitFor({state: "hidden"})
	  24 |   })
	  25 |

	    at /Users/noah/brimdata/brim/packages/e2e-tests/tests/pool-loads.spec.ts:22:21

      2) pool-loads.spec.ts:26:3 › Pool Loads › load more data into the pool ===========================

	Error: expect(received).toEqual(expected) // deep equality

	- Expected  - 4
	+ Received  + 1

	- Array [
	-   "count",
	-   "2",
	- ]
	+ Array []

	  34 |     await app.query("count()")
	  35 |     const results = await app.getViewerResults()
	> 36 |     expect(results).toEqual(["count", "2"])
	     |                     ^
	  37 |     await app.mainWin.getByText("Load Successful").waitFor({state: "hidden"})
	  38 |   })
	  39 |

	    at /Users/noah/brimdata/brim/packages/e2e-tests/tests/pool-loads.spec.ts:36:21

      2 failed
	pool-loads.spec.ts:17:3 › Pool Loads › load data into a pool ===================================
	pool-loads.spec.ts:26:3 › Pool Loads › load more data into the pool ============================