### PR TITLE
Add link to new Zui docs site in Help pull-down menu

### DIFF
--- a/src/app/core/links.ts
+++ b/src/app/core/links.ts
@@ -4,6 +4,7 @@ const currentZedTag = pkg.dependencies.zed.split("#")[1] || "main"
 const zedDocsTag = currentZedTag.startsWith("v") ? currentZedTag : "next"
 
 export default {
+  ZUI_DOCS_ROOT: `https://zui.brimdata.io/docs`,
   ZED_DOCS_ROOT: `https://zed.brimdata.io/docs/${zedDocsTag}/commands/zed`,
   ZED_DOCS_LANGUAGE: `https://zed.brimdata.io/docs/${zedDocsTag}/language`,
   ZED_DOCS_FORMATS_ZJSON: `https://zed.brimdata.io/docs/${zedDocsTag}/formats/zjson`,

--- a/src/app/core/links.ts
+++ b/src/app/core/links.ts
@@ -4,12 +4,12 @@ const currentZedTag = pkg.dependencies.zed.split("#")[1] || "main"
 const zedDocsTag = currentZedTag.startsWith("v") ? currentZedTag : "next"
 
 export default {
-  ZUI_DOCS_ROOT: `https://zui.brimdata.io/docs`,
   ZED_DOCS_ROOT: `https://zed.brimdata.io/docs/${zedDocsTag}/commands/zed`,
   ZED_DOCS_LANGUAGE: `https://zed.brimdata.io/docs/${zedDocsTag}/language`,
   ZED_DOCS_FORMATS_ZJSON: `https://zed.brimdata.io/docs/${zedDocsTag}/formats/zjson`,
   ZED_DOCS_FORMATS_ZNG: `https://zed.brimdata.io/docs/${zedDocsTag}/formats/zng`,
   ZED_DOCS_FORMATS_ZSON: `https://zed.brimdata.io/docs/${zedDocsTag}/formats/zson`,
   ZED_DOCS_FORMATS_VNG: `https://zed.brimdata.io/docs/${zedDocsTag}/formats/vng`,
+  ZUI_DOCS_ROOT: `https://zui.brimdata.io/docs`,
   ZUI_DOWNLOAD: `https://www.brimdata.io/download/`,
 }

--- a/src/js/electron/windows/search/app-menu.ts
+++ b/src/js/electron/windows/search/app-menu.ts
@@ -228,14 +228,20 @@ export function compileTemplate(
         },
       },
       {
-        label: "Show Welcome Page",
-        click: () => runCommandOp.run(showWelcomePage),
+        label: "Zui Docs",
+        click() {
+          shell.openExternal(links.ZUI_DOCS_ROOT)
+        },
       },
       {
         label: "Zed Syntax Docs",
         click() {
           shell.openExternal(links.ZED_DOCS_LANGUAGE)
         },
+      },
+      {
+        label: "Show Welcome Page",
+        click: () => runCommandOp.run(showWelcomePage),
       },
       {
         label: "Slack Support Channel",


### PR DESCRIPTION
I just noticed we weren't yet linking to the new site in the Help menu, so adding that here. The URL is not yet rigged up with tags since we're still on our first Zui docs release, but I can enhance this when it's needed.

I also moved the "Show Welcome Page" entry down a hair so the most helpful docs would be up top.

![image](https://user-images.githubusercontent.com/5934157/222834759-3eb08ec9-afbe-4a26-932c-16ca5b1a29b3.png)
