### PR TITLE
fix e2e flakiness in table.spec.ts

### DIFF
--- a/packages/e2e-tests/tests/table.spec.ts
+++ b/packages/e2e-tests/tests/table.spec.ts
@@ -18,7 +18,9 @@ test.describe("Table Testing", () => {
     await app.createPool([path])
     await app.mainWin.getByRole("button", {name: "Query Pool"}).click()
     await app.query("yield value.after") // This is a named type
-    const texts = await app.results.getByRole("columnheader").allInnerTexts()
+    const columnheader = app.results.getByRole("columnheader")
+    await columnheader.first().waitFor()
+    const texts = await columnheader.allInnerTexts()
     expect(texts).toEqual(["Id", "IsDeleted"])
   })
 })


### PR DESCRIPTION
This fixes the following e2e failure.

    $ yarn e2e table.spec.ts:16:3 --reporter=line

    Running 1 test using 1 worker
      1) table.spec.ts:16:3 › Table Testing › named type shows columns =================================

	Error: expect(received).toEqual(expected) // deep equality

	- Expected  - 4
	+ Received  + 1

	- Array [
	-   "Id",
	-   "IsDeleted",
	- ]
	+ Array []

	  20 |     await app.query("yield value.after") // This is a named type
	  21 |     const texts = await app.results.getByRole("columnheader").allInnerTexts()
	> 22 |     expect(texts).toEqual(["Id", "IsDeleted"])
	     |                   ^
	  23 |   })
	  24 | })
	  25 |

	    at /Users/noah/brimdata/brim/packages/e2e-tests/tests/table.spec.ts:22:19

      1 failed
	table.spec.ts:16:3 › Table Testing › named type shows columns ==================================