### PR TITLE
upgrade chrono-node to 2.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "acorn": "^7.4.1",
     "ajv": "^6.9.1",
     "animejs": "^3.2.0",
-    "chrono-node": "^1.4.8",
+    "chrono-node": "^2.5.0",
     "classnames": "^2.2.6",
     "cross-fetch": "^3.1.4",
     "d3": "^5.16.0",

--- a/src/js/lib/date.ts
+++ b/src/js/lib/date.ts
@@ -1,4 +1,4 @@
-import chrono from "chrono-node"
+import * as chrono from "chrono-node"
 import moment from "moment-timezone"
 import relTime from "../models/relTime"
 import time from "../models/time"
@@ -45,9 +45,9 @@ date.parseInZone = (string, zone, ref?) => {
     return string
   } else {
     if (/^\s*now.*/i.test(string)) return null
-    const d = chrono.casual.parseDate(string, ref)
-    if (d) {
-      return time(d).toTs()
+    const d = chrono.casual.parse(string, ref)
+    if (d && d[0].text == string) {
+      return time(d[0].date()).toTs()
     } else {
       return null
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5409,12 +5409,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chrono-node@npm:^1.4.8":
-  version: 1.4.8
-  resolution: "chrono-node@npm:1.4.8"
+"chrono-node@npm:^2.5.0":
+  version: 2.5.0
+  resolution: "chrono-node@npm:2.5.0"
   dependencies:
-    dayjs: ^1.8.19
-  checksum: 964b392813284c99df5b16757882e7164f4a11839020028eaa0e9960dc048f30887ad792ce308e20d531abf20a025b3a4d85812e55ccc8a70db0feef783ec84b
+    dayjs: ^1.10.0
+  checksum: 810681d3f14ce790a6f22afc269f407d8b0708239c4a255eb1a0a065c0234524d771d2dd01c438c1bd73843989bc8ac95b788d53d7a6a1116d2f891ce2e51238
   languageName: node
   linkType: hard
 
@@ -6357,10 +6357,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dayjs@npm:^1.8.19":
-  version: 1.8.30
-  resolution: "dayjs@npm:1.8.30"
-  checksum: 8ba83a8e7ab3085b5863afa2a6e25f052c5fdb2f923271f10c2b0ba7c73fd35e5d67f431ed47bb61f2ea9eb5188d1bf6fc1de19b98d177bf5446ced2ebf15c6b
+"dayjs@npm:^1.10.0":
+  version: 1.11.7
+  resolution: "dayjs@npm:1.11.7"
+  checksum: 5003a7c1dd9ed51385beb658231c3548700b82d3548c0cfbe549d85f2d08e90e972510282b7506941452c58d32136d6362f009c77ca55381a09c704e9f177ebb
   languageName: node
   linkType: hard
 
@@ -11886,9 +11886,9 @@ __metadata:
   linkType: hard
 
 "minimist@npm:^1.1.0, minimist@npm:^1.2.0, minimist@npm:^1.2.3, minimist@npm:^1.2.5":
-  version: 1.2.5
-  resolution: "minimist@npm:1.2.5"
-  checksum: 86706ce5b36c16bfc35c5fe3dbb01d5acdc9a22f2b6cc810b6680656a1d2c0e44a0159c9a3ba51fb072bb5c203e49e10b51dcd0eec39c481f4c42086719bae52
+  version: 1.2.8
+  resolution: "minimist@npm:1.2.8"
+  checksum: 75a6d645fb122dad29c06a7597bddea977258957ed88d7a6df59b5cd3fe4a527e253e9bbf2e783e4b73657f9098b96a5fe96ab8a113655d4109108577ecf85b0
   languageName: node
   linkType: hard
 
@@ -17114,7 +17114,7 @@ __metadata:
     babel-plugin-module-resolver: ^4.0.0
     brimcap: "brimdata/brimcap#v1.4.0"
     chalk: ^4.1.0
-    chrono-node: ^1.4.8
+    chrono-node: ^2.5.0
     classnames: ^2.2.6
     commander: ^2.20.3
     cpx: ^1.5.0


### PR DESCRIPTION
This version fixes CVE-2021-23371.