### PR TITLE
Remove comment since getViewerResults waits for cells now

### DIFF
--- a/packages/e2e-tests/helpers/test-app.ts
+++ b/packages/e2e-tests/helpers/test-app.ts
@@ -91,7 +91,6 @@ export default class TestApp {
     await this.mainWin.locator('span[aria-label="fetching"]').isHidden()
   }
 
-  // TODO: this method is a wip, it still needs to wait for cells to populate first
   async getViewerResults(includeHeaders = true): Promise<string[]> {
     const fields = await this.mainWin.locator(".zed-table__cell")
     await fields.waitFor()


### PR DESCRIPTION
As noted in https://github.com/brimdata/brim/pull/2687#pullrequestreview-1320699701, now that we've added `await fields.waitFor()` in `getViewerResults()`, it seems we can remove this comment.